### PR TITLE
Fix Dockerfiles and npm package READMEs

### DIFF
--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -104,6 +104,8 @@ jobs:
 
       - name: Publish npm package
         run: |
+          # copy README.md to project root
+          cp servers/lib/README.md .
           cd servers/lib
           yarn install
           yarn build

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -81,6 +81,8 @@ jobs:
 
       - name: Publish npm package
         run: |
+          # copy README.md to project root
+          cp servers/execution/runner/README.md .
           cd servers/execution/runner
           yarn install
           yarn build

--- a/docker/README.md
+++ b/docker/README.md
@@ -64,9 +64,6 @@ The configuration files to be updated are:
 1. client/config/local.js
    please see [client config](../docs/admin/client/config.md) for help
    with updating this config file)
-1. servers/lib/config/.env.default
-   please see [lib config](../docs/admin/servers/lib/docker.md) for help
-   with updating this config file)
 
 ## Development Environment
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,7 +13,12 @@ There are two dockerfiles for building the containers:
 
 - **client.dockerfile**: Dockerfile for building
   the client application container.
-- **libms.dockerfile**: Dockerfile for building the library microservice container.
+- **libms.dockerfile**: Dockerfile for building the library
+  microservice container from source code.
+- **libms.npm.dockerfile**: Dockerfile for building the library
+  microservice container from published npm package at npmjs.com.
+  This Dockerfile is only used during publishing. It is used neither
+  in the development builds nor in Github actions.
 - **compose.dev.yml:** Docker Compose configuration for
   development environment.
 - **.env**: environment variables for docker compose file
@@ -107,21 +112,53 @@ the publication of images to Docker Hub.
 :stop_sign: This publishing step is managed
 only by project maintainers. Regular developers can skip this step.
 
+### React Website
+
+```sh
+docker build -t intocps/dtaas-web:latest -f ./docker/client.dockerfile .
+docker tag intocps/dtaas-web:latest intocps/dtaas-web:<version>
+docker push intocps/dtaas-web:latest
+docker push intocps/dtaas-web:<version>
+```
+
+To tag version **0.3.1** for example, use
+
+```sh
+docker tag intocps/dtaas-web:latest intocps/dtaas-web:0.3.1
+```
+
+To test the react website container on localhost, please use
+
+```bash
+docker run -d \
+  -v ${PWD}/client/config/local.js:/dtaas/client/build/env.js \
+  -p 4000:4000 intocps/dtaas-web:latest
+```
+
+### Library Microservice
+
+The Dockerfile of library microservice has `VERSION` argument.
+This argument helps pick the right package version from <http://npmjs.com>.
+
 ```sh
 docker login -u <username> -p <password>
-docker build -t intocps/libms:latest -f ./docker/libms.dockerfile .
-docker tag intocps/libms:latest intocps/libms:version
+docker build -t intocps/libms:latest -f ./docker/libms.npm.dockerfile .
 docker push intocps/libms:latest
-docker push intocps/libms:version
-
-docker build -t intocps/dtaas-web:latest -f ./docker/client.dockerfile .
-docker tag intocps/dtaas-web:latest intocps/dtaas-web:version
-docker push intocps/dtaas-web:latest
-docker push intocps/dtaas-web:version
+docker build --build-arg="VERSION=<version>" \
+  -t intocps/libms:<version> -f ./docker/libms.npm.dockerfile .
+docker push intocps/libms:<version>
 ```
 
 To tag version 0.3.1 for example, use
 
 ```sh
-docker tag intocps/dtaas-web:latest intocps/dtaas-web:0.3.1
+docker build --build-arg="VERSION=0.3.1" \
+  -t intocps/libms:0.3.1 -f ./docker/libms.npm.dockerfile .
+```
+
+To test the library microservice on localhost, please use
+
+```bash
+docker run -d -v ${PWD}/files:/dtaas/libms/files \
+  -p 4001:4001 intocps/libms:latest
 ```

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -39,7 +39,6 @@ services:
       dockerfile: ${DTAAS_DIR}/docker/libms.dockerfile
     restart: unless-stopped
     volumes:
-      - ${DTAAS_DIR}/servers/lib/config/.env.default:/dtaas/libms/.env
       - ${DTAAS_DIR}/files:/dtaas/libms/files
     labels:
       - "traefik.enable=true"

--- a/docker/libms.dockerfile
+++ b/docker/libms.dockerfile
@@ -5,28 +5,23 @@ FROM node:20.10.0-slim as build
 # Set the working directory inside the container
 WORKDIR /dtaas/libms
 
-# Copy package.json and yarn.lock to the working directory
-COPY ./servers/lib/package.json ./
-COPY ./servers/lib/yarn.lock ./
+# Copy the the application code to the working directory
+COPY ./servers/lib/ .
 
 # Install dependencies
 RUN yarn install --immutable --immutable-cache --check-cache
 
-# Copy the rest of the application code to the working directory
-COPY ./servers/lib/ ./
-
 # Build the app
 RUN yarn build
 
+
 FROM node:20.10.0-slim
 COPY --from=build /dtaas/libms/dist /dtaas/libms/dist
-COPY --from=build /dtaas/libms/package.json /dtaas/libms/package.json
 COPY --from=build /dtaas/libms/node_modules /dtaas/libms/node_modules
+COPY --from=build /dtaas/libms/package.json /dtaas/libms/package.json
+COPY --from=build /dtaas/libms/config /dtaas/libms/config
 
 WORKDIR /dtaas/libms
 
-COPY ./servers/lib/config/.env.default .env
-COPY ./servers/lib/config/http.json .
-
 # Define the command to run your app
-CMD ["yarn", "start", "-H", "http.json"]
+CMD ["yarn", "start", "--config", "config/.env.default", "-H", "config/http.json"]

--- a/docker/libms.dockerfile
+++ b/docker/libms.dockerfile
@@ -8,7 +8,7 @@ WORKDIR /dtaas/libms
 # pull the libms package from npm registry
 RUN npm i -g @into-cps-association/libms@0.4.4
 
-COPY ./deploy/config/lib .
+COPY ./deploy/config/lib.docker .
 COPY ./servers/lib/config/http.json .
 
 # Define the command to run your app

--- a/docker/libms.dockerfile
+++ b/docker/libms.dockerfile
@@ -1,15 +1,32 @@
-FROM node:20.10.0-slim
+FROM node:20.10.0-slim as build
 
 #! docker should be run from the root directory of the project
 
 # Set the working directory inside the container
 WORKDIR /dtaas/libms
 
-# pull the libms package from npm registry
-RUN npm i -g @into-cps-association/libms@0.4.4
+# Copy package.json and yarn.lock to the working directory
+COPY ./servers/lib/package.json ./
+COPY ./servers/lib/yarn.lock ./
 
-COPY ./deploy/config/lib.docker .
+# Install dependencies
+RUN yarn install --immutable --immutable-cache --check-cache
+
+# Copy the rest of the application code to the working directory
+COPY ./servers/lib/ ./
+
+# Build the app
+RUN yarn build
+
+FROM node:20.10.0-slim
+COPY --from=build /dtaas/libms/dist /dtaas/libms/dist
+COPY --from=build /dtaas/libms/package.json /dtaas/libms/package.json
+COPY --from=build /dtaas/libms/node_modules /dtaas/libms/node_modules
+
+WORKDIR /dtaas/libms
+
+COPY ./servers/lib/config/.env.default .env
 COPY ./servers/lib/config/http.json .
 
 # Define the command to run your app
-CMD ["libms", "-H", "http.json"]
+CMD ["yarn", "start", "-H", "http.json"]

--- a/docker/libms.npm.dockerfile
+++ b/docker/libms.npm.dockerfile
@@ -1,0 +1,16 @@
+FROM node:20.10.0-slim
+
+#! docker should be run from the root directory of the project
+
+# Set the working directory inside the container
+WORKDIR /dtaas/libms
+
+# pull the libms package from npm registry
+ARG VERSION="latest"
+RUN npm i -g @into-cps-association/libms@${VERSION}
+
+COPY ./deploy/config/lib.docker .env
+COPY ./servers/lib/config/http.json .
+
+# Define the command to run your app
+CMD ["libms", "-H", "http.json"]

--- a/servers/execution/runner/package.json
+++ b/servers/execution/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@into-cps-association/runner",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "DT Runner",
   "main": "dist/src/runner.js",
   "repository": "https://github.com/into-cps-association/DTaaS.git",

--- a/servers/lib/package.json
+++ b/servers/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@into-cps-association/libms",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "microservices that handles request by fetching and returning the file-names and folders of given directory",
   "author": "phillip.boe.jensen@gmail.com",
   "contributors": [


### PR DESCRIPTION
* Fixes mistakes in Dockerfile of libms. There are separate dockerfiles for publishing libms inside and outside of github actions.
* Updates the docker README for the developers
* The existing github actions publishes top-level README for all packages. This PR fixes the incorrect README problem by copying the correct README in the github actions file.
* Bumps up the bug fix versions of lib microservice and client website packages

Fixes issues #783 and #787 