### PR TITLE
Publish docker images to DockerHub

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -101,4 +101,5 @@ jobs:
       image-name: dtaas-web
       version: ${{ needs.get_version.outputs.version }}
       dockerfile: client.dockerfile
+      readme-file: client/README.md
     secrets: inherit

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -118,4 +118,6 @@ jobs:
       version: ${{ needs.get_version.outputs.version }}
       dockerfile: client.dockerfile
       readme-file: client/DOCKER.md
-    secrets: inherit
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -101,5 +101,5 @@ jobs:
       image-name: dtaas-web
       version: ${{ needs.get_version.outputs.version }}
       dockerfile: client.dockerfile
-      readme-file: client/README.md
+      readme-file: client/DOCKER.md
     secrets: inherit

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -100,7 +100,7 @@ jobs:
     needs: [client, get_version]
     uses: ./.github/workflows/docker-ghcr.yml
     with: 
-      image-name: dtaas-web
+      image-name: into-cps-association/dtaas-web
       version: ${{ needs.get_version.outputs.version }}
       dockerfile: client.dockerfile
     secrets: inherit
@@ -114,7 +114,7 @@ jobs:
     needs: [client, get_version]
     uses: ./.github/workflows/docker-dockerhub.yml
     with: 
-      image-name: dtaas-web
+      image-name: into-cps-association/dtaas-web
       version: ${{ needs.get_version.outputs.version }}
       dockerfile: client.dockerfile
       readme-file: client/DOCKER.md

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -114,7 +114,7 @@ jobs:
     needs: [client, get_version]
     uses: ./.github/workflows/docker-dockerhub.yml
     with: 
-      image-name: into-cps-association/dtaas-web
+      image-name: dtaas-web
       version: ${{ needs.get_version.outputs.version }}
       dockerfile: client.dockerfile
       readme-file: client/DOCKER.md

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -98,7 +98,7 @@ jobs:
     needs: [client, get_version]
     uses: ./.github/workflows/docker.yml
     with: 
-      registry: ghcr.io
-      image-name: into-cps-association/dtaas-web
+      image-name: dtaas-web
       version: ${{ needs.get_version.outputs.version }}
       dockerfile: client.dockerfile
+    secrets: inherit

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -114,7 +114,7 @@ jobs:
     needs: [client, get_version]
     uses: ./.github/workflows/docker-dockerhub.yml
     with: 
-      image-name: dtaas-web
+      image-name: intocps/dtaas-web
       version: ${{ needs.get_version.outputs.version }}
       dockerfile: client.dockerfile
       readme-file: client/DOCKER.md

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -89,14 +89,28 @@ jobs:
     outputs:
       version: ${{ steps.get_version.outputs.version }}
 
-  publish-docker-image:
+  publish-docker-image-ghcr:
     if: | 
       github.event_name == 'push' &&
       (startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/release-v'))
       
-    name: Publish Docker image
+    name: Publish Docker image (GHCR)
     needs: [client, get_version]
-    uses: ./.github/workflows/docker.yml
+    uses: ./.github/workflows/docker-ghcr.yml
+    with: 
+      image-name: dtaas-web
+      version: ${{ needs.get_version.outputs.version }}
+      dockerfile: client.dockerfile
+    secrets: inherit
+
+  publish-docker-image-dockerhub:
+    if: | 
+      github.event_name == 'push' &&
+      (startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/release-v'))
+      
+    name: Publish Docker image (DockerHub)
+    needs: [client, get_version]
+    uses: ./.github/workflows/docker-dockerhub.yml
     with: 
       image-name: dtaas-web
       version: ${{ needs.get_version.outputs.version }}

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -47,6 +47,8 @@ jobs:
         run: |
           yarn test:int
           yarn test:unit
+          yarn test:preview:unit
+          yarn test:preview:int
 
       - name: Upload unit and integration test coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/docker-dockerhub.yml
+++ b/.github/workflows/docker-dockerhub.yml
@@ -1,12 +1,13 @@
-name: Build and Push Docker Image
+# Reusable workflow for building and pushing a Docker Image to DockerHub.
+# 
+# Username is taken from the repository variable, "DOCKERHUB_USERNAME"
+# Password is taken from the repository secret, "DOCKERHUB_TOKEN"
+
+name: Build and Push Docker Image (DockerHub)
 
 on:
   workflow_call:
     inputs:
-      # registry:
-      #   required: false
-      #   type: string
-      #   default: "ghcr.io"
       image-name:
         required: true
         type: string
@@ -21,10 +22,13 @@ on:
         required: true
         type: string
     secrets:
-      DOCKERHUB_USERNAME:
-        required: true
       DOCKERHUB_TOKEN:
         required: true
+
+env:
+  registry: docker.io
+  username: ${{ vars.DOCKERHUB_USERNAME }}
+  password: ${{ secrets.DOCKERHUB_TOKEN }}
 
 jobs:
   build-and-push-image:
@@ -38,29 +42,23 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      # - name: Log in to the Container registry
-      #   uses: docker/login-action@v3
-      #   with:
-      #     registry: ${{ inputs.registry }}
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.registry }}
+          username: ${{ env.username }}
+          password: ${{ env.password }}
 
       - name: Check if version exists
         id: check_version
         run: |
-          if docker manifest inspect ${{ inputs.image-name }}:${{ inputs.version }} > /dev/null 2>&1; then
+          if docker manifest inspect ${{ env.registry }}/${{ env.username }}/${{ inputs.image-name }}:${{ inputs.version }} > /dev/null 2>&1; then
             echo "Version ${{ inputs.version }} already exists."
             echo "exists=true" >> $GITHUB_ENV
           else
             echo "Version ${{ inputs.version }} does not exist."
             echo "exists=false" >> $GITHUB_ENV
           fi
-
-      - name: Log in to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
         if: env.exists == 'false'
@@ -69,12 +67,12 @@ jobs:
           context: .
           file: ./docker/${{ inputs.dockerfile }}
           push: true
-          tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ inputs.image-name }}:${{ inputs.version }}, ${{ vars.DOCKERHUB_USERNAME }}/${{ inputs.image-name }}:latest
+          tags: ${{ env.registry }}/${{ env.username }}/${{ inputs.image-name }}:${{ inputs.version }}, ${{ env.registry }}/${{ env.username }}/${{ inputs.image-name }}:latest
 
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v4
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ vars.DOCKERHUB_USERNAME }}/${{ inputs.image-name }}
+          username: ${{ env.username }}
+          password: ${{ env.password }}
+          repository: ${{ env.username }}/${{ inputs.image-name }}
           readme-filepath: ${{ inputs.readme-file }}

--- a/.github/workflows/docker-dockerhub.yml
+++ b/.github/workflows/docker-dockerhub.yml
@@ -1,6 +1,6 @@
 # Reusable workflow for building and pushing a Docker Image to DockerHub.
 # 
-# Username is taken from the repository variable, "DOCKERHUB_USERNAME"
+# Username is taken from the repository secret, "DOCKERHUB_USERNAME"
 # Password is taken from the repository secret, "DOCKERHUB_TOKEN"
 
 name: Build and Push Docker Image (DockerHub)
@@ -22,12 +22,14 @@ on:
         required: true
         type: string
     secrets:
+      DOCKERHUB_USERNAME:
+        required: true
       DOCKERHUB_TOKEN:
         required: true
 
 env:
   registry: docker.io
-  username: ${{ vars.DOCKERHUB_USERNAME }}
+  username: ${{ secrets.DOCKERHUB_USERNAME }}
   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
 jobs:

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,0 +1,64 @@
+# Reusable workflow for building and pushing a Docker Image to GHCR.
+# 
+# Username is taken from the user who scheduled the workflow
+# Password is taken from the auto-generated GitHub token
+
+name: Build and Push Docker Image (GHCR)
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+        default: "latest"
+      dockerfile:
+        required: true
+        type: string
+
+env:
+  registry: ghcr.io
+  username: ${{ github.actor }}
+  password: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.registry }}
+          username: ${{ env.username }}
+          password: ${{ env.password }}
+
+      - name: Check if version exists
+        id: check_version
+        run: |
+          if docker manifest inspect ${{ env.registry }}/${{ env.username }}/${{ inputs.image-name }}:${{ inputs.version }} > /dev/null 2>&1; then
+            echo "Version ${{ inputs.version }} already exists."
+            echo "exists=true" >> $GITHUB_ENV
+          else
+            echo "Version ${{ inputs.version }} does not exist."
+            echo "exists=false" >> $GITHUB_ENV
+          fi
+
+      - name: Build and push Docker image
+        if: env.exists == 'false'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/${{ inputs.dockerfile }}
+          push: true
+          tags: ${{ env.registry }}/${{ env.username }}/${{ inputs.image-name }}:${{ inputs.version }}, ${{ env.registry }}/${{ env.username }}/${{ inputs.image-name }}:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,21 +45,21 @@ jobs:
       #     username: ${{ github.actor }}
       #     password: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Check if version exists
-      #   id: check_version
-      #   run: |
-      #     if docker manifest inspect ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.version }} > /dev/null 2>&1; then
-      #       echo "Version ${{ inputs.version }} already exists."
-      #       echo "exists=true" >> $GITHUB_ENV
-      #     else
-      #       echo "Version ${{ inputs.version }} does not exist."
-      #       echo "exists=false" >> $GITHUB_ENV
-      #     fi
+      - name: Check if version exists
+        id: check_version
+        run: |
+          if docker manifest inspect ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.version }} > /dev/null 2>&1; then
+            echo "Version ${{ inputs.version }} already exists."
+            echo "exists=true" >> $GITHUB_ENV
+          else
+            echo "Version ${{ inputs.version }} does not exist."
+            echo "exists=false" >> $GITHUB_ENV
+          fi
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
@@ -68,12 +68,12 @@ jobs:
           context: .
           file: ./docker/${{ inputs.dockerfile }}
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image-name }}:${{ inputs.version }}, ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image-name }}:latest
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/${{ inputs.image-name }}:${{ inputs.version }}, ${{ vars.DOCKERHUB_USERNAME }}/${{ inputs.image-name }}:latest
 
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image-name }}
+          repository: ${{ vars.DOCKERHUB_USERNAME }}/${{ inputs.image-name }}
           readme-filepath: ${{ inputs.readme-file }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,9 @@ on:
       dockerfile:
         required: true
         type: string
+      readme-file:
+        required: true
+        type: string
     secrets:
       DOCKERHUB_USERNAME:
         required: true
@@ -72,5 +75,5 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ secrets.DOCKERHUB_USERNAME }}/dtaas-web
-          readme-filepath: client/README.md
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image-name }}
+          readme-filepath: ${{ inputs.readme-file }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,11 @@ on:
       dockerfile:
         required: true
         type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
 
 jobs:
   build-and-push-image:
@@ -30,29 +35,42 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Log in to the Container registry
+      # - name: Log in to the Container registry
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: ${{ inputs.registry }}
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
+
+      # - name: Check if version exists
+      #   id: check_version
+      #   run: |
+      #     if docker manifest inspect ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.version }} > /dev/null 2>&1; then
+      #       echo "Version ${{ inputs.version }} already exists."
+      #       echo "exists=true" >> $GITHUB_ENV
+      #     else
+      #       echo "Version ${{ inputs.version }} does not exist."
+      #       echo "exists=false" >> $GITHUB_ENV
+      #     fi
+
+      - name: Log in to DockerHub
         uses: docker/login-action@v3
         with:
-          registry: ${{ inputs.registry }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Check if version exists
-        id: check_version
-        run: |
-          if docker manifest inspect ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.version }} > /dev/null 2>&1; then
-            echo "Version ${{ inputs.version }} already exists."
-            echo "exists=true" >> $GITHUB_ENV
-          else
-            echo "Version ${{ inputs.version }} does not exist."
-            echo "exists=false" >> $GITHUB_ENV
-          fi
-
-      - name: Build and push Docker image
-        if: env.exists == 'false'
-        uses: docker/build-push-action@v5
+      - name: Build and push
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/${{ inputs.dockerfile }}
           push: true
-          tags: ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.version }}, ${{ inputs.registry }}/${{ inputs.image-name }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image-name }}:${{ inputs.version }}, ${{ secrets.DOCKERHUB_USERNAME }}/${{ inputs.image-name }}:latest
+
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/dtaas-web
+          readme-filepath: client/README.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,10 +3,10 @@ name: Build and Push Docker Image
 on:
   workflow_call:
     inputs:
-      registry:
-        required: false
-        type: string
-        default: "ghcr.io"
+      # registry:
+      #   required: false
+      #   type: string
+      #   default: "ghcr.io"
       image-name:
         required: true
         type: string
@@ -48,7 +48,7 @@ jobs:
       - name: Check if version exists
         id: check_version
         run: |
-          if docker manifest inspect ${{ inputs.registry }}/${{ inputs.image-name }}:${{ inputs.version }} > /dev/null 2>&1; then
+          if docker manifest inspect ${{ inputs.image-name }}:${{ inputs.version }} > /dev/null 2>&1; then
             echo "Version ${{ inputs.version }} already exists."
             echo "exists=true" >> $GITHUB_ENV
           else
@@ -62,7 +62,8 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push Docker image
+        if: env.exists == 'false'
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -162,10 +162,20 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
 
-  publish-docker-image:
-    name: Publish Docker image
+  publish-docker-image-ghcr:
+    name: Publish Docker image (GHCR)
     needs: [get_version, test-lib-ms]
-    uses: ./.github/workflows/docker.yml
+    uses: ./.github/workflows/docker-ghcr.yml
+    with: 
+      image-name: libms
+      version: ${{ needs.get_version.outputs.version }}
+      dockerfile: libms.dockerfile
+    secrets: inherit
+
+  publish-docker-image-dockerhub:
+    name: Publish Docker image (DockerHub)
+    needs: [get_version, test-lib-ms]
+    uses: ./.github/workflows/docker-dockerhub.yml
     with: 
       image-name: libms
       version: ${{ needs.get_version.outputs.version }}

--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -117,7 +117,7 @@ jobs:
 
     name: Publish NPM Package to GitHub Packages
     runs-on: ubuntu-latest
-    needs: [get_version, test-lib-ms]
+    needs: test-lib-ms
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -185,7 +185,7 @@ jobs:
     needs: [get_version, test-lib-ms]
     uses: ./.github/workflows/docker-dockerhub.yml
     with: 
-      image-name: libms
+      image-name: intocps/libms
       version: ${{ needs.get_version.outputs.version }}
       dockerfile: libms.dockerfile
       readme-file: servers/lib/DOCKER.md

--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -185,7 +185,7 @@ jobs:
     needs: [get_version, test-lib-ms]
     uses: ./.github/workflows/docker-dockerhub.yml
     with: 
-      image-name: into-cps-association/libms
+      image-name: libms
       version: ${{ needs.get_version.outputs.version }}
       dockerfile: libms.dockerfile
       readme-file: servers/lib/DOCKER.md

--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -189,4 +189,6 @@ jobs:
       version: ${{ needs.get_version.outputs.version }}
       dockerfile: libms.dockerfile
       readme-file: servers/lib/DOCKER.md
-    secrets: inherit
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -171,7 +171,7 @@ jobs:
     needs: [get_version, test-lib-ms]
     uses: ./.github/workflows/docker-ghcr.yml
     with: 
-      image-name: libms
+      image-name: into-cps-association/libms
       version: ${{ needs.get_version.outputs.version }}
       dockerfile: libms.dockerfile
     secrets: inherit
@@ -185,7 +185,7 @@ jobs:
     needs: [get_version, test-lib-ms]
     uses: ./.github/workflows/docker-dockerhub.yml
     with: 
-      image-name: libms
+      image-name: into-cps-association/libms
       version: ${{ needs.get_version.outputs.version }}
       dockerfile: libms.dockerfile
       readme-file: servers/lib/DOCKER.md

--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -110,7 +110,7 @@ jobs:
           files: servers/lib/coverage/clover.xml
           flags: lib-microservice-tests
 
-  publish-package:
+  publish-npm-package:
     if: | 
       github.event_name == 'push' &&
       (startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/release-v'))

--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -170,5 +170,5 @@ jobs:
       image-name: libms
       version: ${{ needs.get_version.outputs.version }}
       dockerfile: libms.dockerfile
-      readme-file: servers/lib/README.md
+      readme-file: servers/lib/DOCKER.md
     secrets: inherit

--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -131,7 +131,7 @@ jobs:
       github.event_name == 'push' &&
       (startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/release-v'))
 
-    name: Publish to GitHub Packages
+    name: Publish NPM Package to GitHub Packages
     runs-on: ubuntu-latest
     needs: [get_version, test-lib-ms]
     permissions:

--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -112,7 +112,6 @@ jobs:
 
 
   publish-package:
-
     if: | 
       github.event_name == 'push' &&
       (startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/release-v'))
@@ -169,7 +168,8 @@ jobs:
     needs: [ publish-package, get_version]
     uses: ./.github/workflows/docker.yml
     with: 
-        registry: ghcr.io
-        image-name: into-cps-association/libms
-        version: ${{ needs.get_version.outputs.version }}
-        dockerfile: libms.dockerfile
+      image-name: libms
+      version: ${{ needs.get_version.outputs.version }}
+      dockerfile: libms.dockerfile
+      readme-file: servers/lib/README.md
+    secrets: inherit

--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -110,22 +110,6 @@ jobs:
           files: servers/lib/coverage/clover.xml
           flags: lib-microservice-tests
 
-  get_version:
-    name: Get version
-    runs-on: ubuntu-latest
-    steps:
-        - name: Checkout Repository
-          uses: actions/checkout@v4
-        - name: Install jq
-          run: sudo apt-get install -y jq
-        - name: get version
-          id: get_version
-          run: | 
-            version=`cat ./servers/lib/package.json | jq -r '.version'`
-            echo "version=$version" >> $GITHUB_OUTPUT
-    outputs:
-      version: ${{ steps.get_version.outputs.version }}
-
   publish-package:
     if: | 
       github.event_name == 'push' &&
@@ -161,6 +145,22 @@ jobs:
           yarn publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+
+  get_version:
+    name: Get version
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout Repository
+          uses: actions/checkout@v4
+        - name: Install jq
+          run: sudo apt-get install -y jq
+        - name: get version
+          id: get_version
+          run: | 
+            version=`cat ./servers/lib/package.json | jq -r '.version'`
+            echo "version=$version" >> $GITHUB_OUTPUT
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
 
   publish-docker-image-ghcr:
     if: | 

--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -163,6 +163,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
 
   publish-docker-image-ghcr:
+    if: | 
+      github.event_name == 'push' &&
+      (startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/release-v'))
+
     name: Publish Docker image (GHCR)
     needs: [get_version, test-lib-ms]
     uses: ./.github/workflows/docker-ghcr.yml
@@ -173,6 +177,10 @@ jobs:
     secrets: inherit
 
   publish-docker-image-dockerhub:
+    if: | 
+      github.event_name == 'push' &&
+      (startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/release-v'))
+
     name: Publish Docker image (DockerHub)
     needs: [get_version, test-lib-ms]
     uses: ./.github/workflows/docker-dockerhub.yml

--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -110,6 +110,21 @@ jobs:
           files: servers/lib/coverage/clover.xml
           flags: lib-microservice-tests
 
+  get_version:
+    name: Get version
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout Repository
+          uses: actions/checkout@v4
+        - name: Install jq
+          run: sudo apt-get install -y jq
+        - name: get version
+          id: get_version
+          run: | 
+            version=`cat ./servers/lib/package.json | jq -r '.version'`
+            echo "version=$version" >> $GITHUB_OUTPUT
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
 
   publish-package:
     if: | 
@@ -118,7 +133,7 @@ jobs:
 
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
-    needs: test-lib-ms
+    needs: [get_version, test-lib-ms]
     permissions:
       packages: write
       contents: read
@@ -147,25 +162,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
 
-  get_version:
-    name: Get version
-    runs-on: ubuntu-latest
-    steps:
-        - name: Checkout Repository
-          uses: actions/checkout@v4
-        - name: Install jq
-          run: sudo apt-get install -y jq
-        - name: get version
-          id: get_version
-          run: | 
-            version=`cat ./servers/lib/package.json | jq -r '.version'`
-            echo "version=$version" >> $GITHUB_OUTPUT
-    outputs:
-      version: ${{ steps.get_version.outputs.version }}
-
   publish-docker-image:
     name: Publish Docker image
-    needs: [ publish-package, get_version]
+    needs: [get_version, test-lib-ms]
     uses: ./.github/workflows/docker.yml
     with: 
       image-name: libms

--- a/client/DOCKER.md
+++ b/client/DOCKER.md
@@ -26,24 +26,53 @@ If you would like to adjust the configuration, please change this file.
 
 ### Use
 
-The commands to start and stop the appliation are:
+Create a file `compose.client.yml` and copy the following:
 
-```bash
-git clone https://github.com/INTO-CPS-Association/DTaaS.git
-cd client
-docker compose -f compose.client.yml up -d
+```yml
+services:
+  client:
+    image: intocps/dtaas-web:latest
+    restart: unless-stopped
+    volumes:
+      - ./config/test.js:/dtaas/client/build/env.js
+    ports:
+      - "4000:4000"
 ```
 
-This command brings up the client docker container and makes
-the website available at <http://localhost:4000>.
-The `config/test.js` file is used as client configuration.
-If you wish to adjust the client configuration, please change
-configuration values in this file and restart the container.
+Create a file `config/test.js` with the following contents:
+
+```js
+if (typeof window !== 'undefined') {
+  window.env = {
+    REACT_APP_ENVIRONMENT: 'test',
+    REACT_APP_URL: 'http://localhost:4000/',
+    REACT_APP_URL_BASENAME: '',
+    REACT_APP_URL_DTLINK: '/lab',
+    REACT_APP_URL_LIBLINK: '',
+    REACT_APP_WORKBENCHLINK_VNCDESKTOP: '/tools/vnc/?password=vncpassword',
+    REACT_APP_WORKBENCHLINK_VSCODE: '/tools/vscode/',
+    REACT_APP_WORKBENCHLINK_JUPYTERLAB: '/lab',
+    REACT_APP_WORKBENCHLINK_JUPYTERNOTEBOOK: '',
+
+    REACT_APP_CLIENT_ID: '1be55736756190b3ace4c2c4fb19bde386d1dcc748d20b47ea8cfb5935b8446c',
+    REACT_APP_AUTH_AUTHORITY: 'https://gitlab.com/',
+    REACT_APP_REDIRECT_URI: 'http://localhost:4000/Library',
+    REACT_APP_LOGOUT_REDIRECT_URI: 'http://localhost:4000/',
+    REACT_APP_GITLAB_SCOPES: 'openid profile read_user read_repository api',
+  };
+};
+```
+
+Note that you will need a GitLab account (at https://gitlab.com) to be authorized to access the client application.
+
+Use the following commands to run and stop the container respectively:
 
 ```bash
+docker compose -f compose.client.yml up -d
 docker compose -f compose.client.yml down
-docker compose -f compose.client.yml up -d
 ```
+
+The website is available at <http://localhost:4000>.
 
 ## Missing Workspace
 

--- a/client/DOCKER.md
+++ b/client/DOCKER.md
@@ -1,0 +1,65 @@
+# Introduction
+
+Client (frontend) for Digital Twin as a Service (DTaaS) software.
+This software shall be used for providing a React single page web
+application for the Digital Twin support platform.
+
+## Authorization
+
+The react client website uses OAuth authorization.
+The [authorization page](../docs/admin/client/auth.md)
+provides details on setting up oauth authorization for
+the client application.
+
+## Use in Docker Environment
+
+### Adjust Configuration
+
+The client application requires configuration.
+See the [config page](../docs/admin/client/config.md)
+for an explanation of client configuration.
+
+The docker version of client application uses configuration
+file available in `config/test.js`. This default configuration
+works well if you have an account on <https://gitlab.com>.
+If you would like to adjust the configuration, please change this file.
+
+### Use
+
+The commands to start and stop the appliation are:
+
+```bash
+git clone https://github.com/INTO-CPS-Association/DTaaS.git
+cd client
+docker compose -f compose.client.yml up -d
+```
+
+This command brings up the client docker container and makes
+the website available at <http://localhost:4000>.
+The `config/test.js` file is used as client configuration.
+If you wish to adjust the client configuration, please change
+configuration values in this file and restart the container.
+
+```bash
+docker compose -f compose.client.yml down
+docker compose -f compose.client.yml up -d
+```
+
+## Missing Workspace
+
+The development environment does not have user workspaces and
+traefik gateway running in the background. As a consequence, the iframe
+links pointing to user workspace will not work correctly. Instead, you
+will see the following error.
+
+```txt
+Unexpected Application Error!
+404 Not Found
+```
+
+This error can be seen on the **Library** and **Digital Twins** pages.
+This error is expected.
+
+If you would like to try the complete DTaaS application, please see
+localhost installation in
+[docs](https://into-cps-association.github.io/DTaaS/development/admin/localhost.html).

--- a/client/DOCKER.md
+++ b/client/DOCKER.md
@@ -7,7 +7,7 @@ application for the Digital Twin support platform.
 ## Authorization
 
 The react client website uses OAuth authorization.
-The [authorization page](../docs/admin/client/auth.md)
+The [authorization page](https://into-cps-association.github.io/DTaaS/development/admin/client/auth.html)
 provides details on setting up oauth authorization for
 the client application.
 
@@ -16,7 +16,7 @@ the client application.
 ### Adjust Configuration
 
 The client application requires configuration.
-See the [config page](../docs/admin/client/config.md)
+See the [config page](https://into-cps-association.github.io/DTaaS/development/admin/client/config.html)
 for an explanation of client configuration.
 
 The docker version of client application uses configuration

--- a/client/DOCKER.md
+++ b/client/DOCKER.md
@@ -1,32 +1,23 @@
 # Introduction
 
-Client (frontend) for Digital Twin as a Service (DTaaS) software.
-This software shall be used for providing a React single page web
-application for the Digital Twin support platform.
+This is a container image for client application of
+the Digital Twin as a Service (DTaaS) software.
+This image can be used for providing a React single page web
+application for the DTaaS.
 
 ## Authorization
 
 The react client website uses OAuth authorization.
 The [authorization page](https://into-cps-association.github.io/DTaaS/development/admin/client/auth.html)
-provides details on setting up oauth authorization for
+provides details on setting up OAuth authorization for
 the client application.
 
 ## Use in Docker Environment
 
-### Adjust Configuration
+### Create Docker Compose File
 
-The client application requires configuration.
-See the [config page](https://into-cps-association.github.io/DTaaS/development/admin/client/config.html)
-for an explanation of client configuration.
-
-The docker version of client application uses configuration
-file available in `config/test.js`. This default configuration
-works well if you have an account on <https://gitlab.com>.
-If you would like to adjust the configuration, please change this file.
-
-### Use
-
-Create a file `compose.client.yml` and copy the following:
+Create an empty file named `compose.client.yml` and copy
+the following into the file:
 
 ```yml
 services:
@@ -34,12 +25,22 @@ services:
     image: intocps/dtaas-web:latest
     restart: unless-stopped
     volumes:
-      - ./config/test.js:/dtaas/client/build/env.js
+      - ./config.js:/dtaas/client/build/env.js
     ports:
       - "4000:4000"
 ```
 
-Create a file `config/test.js` with the following contents:
+### Create Configuration
+
+The client application requires configuration.
+See the [config page](https://into-cps-association.github.io/DTaaS/development/admin/client/config.html)
+for an explanation of client configuration.
+
+The docker version of client application uses configuration
+saved in `config.js` file. Please create this file
+in the same file system location as that of the `compose.client.yml` file.
+
+Create a file `config.js` with the following contents:
 
 ```js
 if (typeof window !== 'undefined') {
@@ -63,23 +64,27 @@ if (typeof window !== 'undefined') {
 };
 ```
 
-Note that you will need a GitLab account (at https://gitlab.com) to be authorized to access the client application.
+This default configuration
+works well if you have an account on <https://gitlab.com>.
+If you would like to adjust the configuration, please change this file.
 
-Use the following commands to run and stop the container respectively:
+### Run
+
+Use the following commands to start and stop the container respectively:
 
 ```bash
 docker compose -f compose.client.yml up -d
 docker compose -f compose.client.yml down
 ```
 
-The website is available at <http://localhost:4000>.
+The website will become available at <http://localhost:4000>.
 
 ## Missing Workspace
 
-The development environment does not have user workspaces and
-traefik gateway running in the background. As a consequence, the iframe
-links pointing to user workspace will not work correctly. Instead, you
-will see the following error.
+The docker compose only brings up the client application.
+This development environment does not have user workspaces and
+traefik gateway running in the background. As a consequence,
+you will see the following error.
 
 ```txt
 Unexpected Application Error!
@@ -87,7 +92,7 @@ Unexpected Application Error!
 ```
 
 This error can be seen on the **Library** and **Digital Twins** pages.
-This error is expected.
+The error is expected.
 
 If you would like to try the complete DTaaS application, please see
 localhost installation in

--- a/servers/lib/DOCKER.md
+++ b/servers/lib/DOCKER.md
@@ -1,0 +1,393 @@
+# Overview
+
+The **lib microservice** is a simplified file manager providing graphQL API.
+It has two features:
+
+* provide a listing of directory contents.
+* transfer a file to user.
+
+## Use in Docker Environment
+
+### Adjust Configuration
+
+The microservices require configuration,
+see the [Configure](#gear-configure) section for more info.
+
+The docker version of the microservices uses the configuration
+file available in `config/.env.default`.
+If you would like to adjust the configuration, please change this file.
+
+### Use
+
+The commands to start and stop the appliation are:
+
+```bash
+git clone https://github.com/INTO-CPS-Association/DTaaS.git
+cd servers/lib
+docker compose -f compose.lib.yml up -d
+```
+
+This command brings up the lib docker container and makes
+the website available at <http://localhost:4001>.
+The `config/.env.default` file is used as the microservice configuration.
+If the configuration values are changed, please restart the container.
+
+```bash
+docker compose -f compose.lib.yml down
+docker compose -f compose.lib.yml up -d
+```
+
+## :gear: Configure
+
+The microservices requires config specified in INI format.
+The template configuration file is:
+
+```ini
+PORT='4001'
+MODE='local' or 'gitlab'
+LOCAL_PATH ='/Users/<Username>/DTaaS/files'
+LOG_LEVEL='debug'
+APOLLO_PATH='/lib' or ''
+GRAPHQL_PLAYGROUND='false' or 'true'
+```
+
+The `LOCAL_PATH` variable is the absolute filepath to the
+location of the local directory which will be served to users
+by the Library microservice.
+
+Replace the default values the appropriate values for your setup.
+Please save this config in a file.
+
+## :rocket: Use
+
+Display help.
+
+```bash
+$libms -h
+Usage: libms [options]
+
+The lib microservice is a file server. It supports file transfer
+over GraphQL and HTTP protocols.
+
+Options:
+  -c, --config <file>  provide the config file (default .env)
+  -H, --http <file>    enable the HTTP server with the specified config
+  -h, --help           display help for libms
+```
+
+Both the options are not mandatory.
+
+### Configuration file
+
+The config is saved `.env` file by convention. If `-c` is not specified
+The **libms** looks for
+`.env` file in the working directory from which it is run.
+If you want to run **libms** without explicitly specifying the configuration
+file, run
+
+```bash
+libms
+```
+
+To run **libms** with a custom config file,
+
+```bash
+libms -c FILE-PATH
+libms --config FILE-PATH
+```
+
+If the environment file is named something other than `.env`,
+for example as `config/.env.default`, you can run
+
+```sh
+libms -c "config/.env.default"
+```
+
+You can press `Ctl+C` to halt the application.
+
+### Protocol Support
+
+The **libms** supports GraphQL protocol by default.
+It is possible to enable the HTTP protocol by setting
+the `-H` option.
+
+To run **libms** with a custom config for HTTP protocol, use
+
+```bash
+libms -H FILE-PATH
+libms --http FILE-PATH
+```
+
+<details>
+<summary>Please see this sample HTTP config file</summary>
+
+```json
+{
+  "name": "DTaaS Fileserver",
+  "auth": false,
+  "editor": "edward",
+  "packer": "zip",
+  "diff": true,
+  "zip": true,
+  "buffer": true,
+  "dirStorage": true,
+  "online": false,
+  "open": false,
+  "oneFilePanel": true,
+  "keysPanel": false,
+  "prefix": "/lib/files",
+  "confirmCopy": true,
+  "confirmMove": true,
+  "showConfig": false,
+  "showFileName": true,
+  "contact": false,
+  "configDialog": false,
+  "console": false,
+  "terminal": false,
+  "vim": false,
+  "columns": "name-size-date-owner-mode",
+  "export": false,
+  "import": false,
+  "dropbox": false,
+  "dropboxToken": "",
+  "log": true
+}
+```
+
+</details>
+
+## Application Programming Interface (API)
+
+The lib microservice application provides services at
+two end points:
+
+### HTTP protocol
+
+Endpoint: `localhost:PORT/lib/files`
+
+This option needs to be enabled with `-H http.json` flag.
+The regular file upload and download options become available.
+
+### GraphQL protocol
+
+Endpoint: `localhost:PORT/lib`
+
+<details>
+<summary>GraphQL API details</summary>
+The lib microservice takes two distinct GraphQL queries.
+
+#### Directory Listing
+
+This query receives directory path and provides list of files
+in that directory. A sample query and response are given here.
+
+``` graphql
+query {
+  listDirectory(path: "user1") {
+    repository {
+      tree {
+        blobs {
+          edges {
+            node {
+              name
+              type
+            }
+          }
+        }
+        trees {
+          edges {
+            node {
+              name
+              type
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+``` graphql
+{
+  "data": {
+    "listDirectory": {
+      "repository": {
+        "tree": {
+          "blobs": {
+            "edges": []
+          },
+          "trees": {
+            "edges": [
+              {
+                "node": {
+                  "name": "common",
+                  "type": "tree"
+                }
+              },
+              {
+                "node": {
+                  "name": "data",
+                  "type": "tree"
+                }
+              },
+              {
+                "node": {
+                  "name": "digital twins",
+                  "type": "tree"
+                }
+              },
+              {
+                "node": {
+                  "name": "functions",
+                  "type": "tree"
+                }
+              },
+              {
+                "node": {
+                  "name": "models",
+                  "type": "tree"
+                }
+              },
+              {
+                "node": {
+                  "name": "tools",
+                  "type": "tree"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Fetch a File
+
+This query receives directory path and send the file contents to user in response.
+
+To check this query, create a file `files/user2/data/welcome.txt`
+with content of `hello world`.
+
+A sample query and response are given here.
+
+```graphql
+query {
+  readFile(path: "user2/data/sample.txt") {
+    repository {
+      blobs {
+        nodes {
+          name
+          rawBlob
+          rawTextBlob
+        }
+      }
+    }
+  }
+}
+```
+
+```graphql
+{
+  "data": {
+    "readFile": {
+      "repository": {
+        "blobs": {
+          "nodes": [
+            {
+              "name": "sample.txt",
+              "rawBlob": "hello world",
+              "rawTextBlob": "hello world"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### Direct HTTP API Calls in lieu of GraphQL API Calls
+
+The lib microservice also supports making API calls using HTTP POST requests.
+Simply send a POST request to the URL endpoint with the GraphQL query in
+the request body. Make sure to set the Content-Type header to
+"application/json".
+
+The easiest way to perform HTTP requests is to use
+[HTTPie](https://github.com/httpie/desktop/releases)
+desktop application.
+You can download the Ubuntu AppImage and run it. Select the following options:
+
+```txt
+Method: POST
+URL: localhost:4001
+Body: <<copy the json code from examples below>>
+Content Type: text/json
+```
+
+Here are examples of the HTTP requests and responses for the HTTP API calls.
+
+#### Directory listing
+
+<!-- markdownlint-disable MD013 -->
+
+```http
+POST /lib HTTP/1.1
+Host: localhost:4001
+Content-Type: application/json
+Content-Length: 388
+
+{
+   "query":"query {\n  listDirectory(path: \"user1\") {\n    repository {\n      tree {\n        blobs {\n          edges {\n            node {\n              name\n              type\n            }\n          }\n        }\n        trees {\n          edges {\n            node {\n              name\n              type\n            }\n          }\n        }\n      }\n    }\n  }\n}"
+}
+```
+
+This HTTP POST request will generate the following HTTP response message.
+
+```http
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: *
+Connection: close
+Content-Length: 306
+Content-Type: application/json; charset=utf-8
+Date: Tue, 26 Sep 2023 20:26:49 GMT
+X-Powered-By: Express
+
+{"data":{"listDirectory":{"repository":{"tree":{"blobs":{"edges":[]},"trees":{"edges":[{"node":{"name":"data","type":"tree"}},{"node":{"name":"digital twins","type":"tree"}},{"node":{"name":"functions","type":"tree"}},{"node":{"name":"models","type":"tree"}},{"node":{"name":"tools","type":"tree"}}]}}}}}}
+```
+
+#### Fetch a file
+
+This query receives directory path and send the file contents to user in response.
+
+To check this query, create a file `files/user2/data/welcome.txt`
+with content of `hello world`.
+
+```http
+POST /lib HTTP/1.1
+Host: localhost:4001
+Content-Type: application/json
+Content-Length: 217
+
+{
+   "query":"query {\n  readFile(path: \"user2/data/welcome.txt\") {\n    repository {\n      blobs {\n        nodes {\n          name\n          rawBlob\n          rawTextBlob\n        }\n      }\n    }\n  }\n}"
+}
+```
+
+```http
+HTTP/1.1 200 OK
+Access-Control-Allow-Origin: *
+Connection: close
+Content-Length: 134
+Content-Type: application/json; charset=utf-8
+Date: Wed, 27 Sep 2023 09:17:18 GMT
+X-Powered-By: Express
+
+{"data":{"readFile":{"repository":{"blobs":{"nodes":[{"name":"welcome.txt","rawBlob":"hello world","rawTextBlob":"hello world"}]}}}}}
+```
+
+<!-- markdownlint-enable MD013 -->
+</details>

--- a/servers/lib/DOCKER.md
+++ b/servers/lib/DOCKER.md
@@ -37,7 +37,7 @@ docker compose -f compose.lib.yml down
 docker compose -f compose.lib.yml up -d
 ```
 
-## :gear: Configure
+## ⚙ Configure
 
 The microservices requires config specified in INI format.
 The template configuration file is:
@@ -58,7 +58,7 @@ by the Library microservice.
 Replace the default values the appropriate values for your setup.
 Please save this config in a file.
 
-## :rocket: Use
+## 🚀 Use
 
 Display help.
 

--- a/servers/lib/DOCKER.md
+++ b/servers/lib/DOCKER.md
@@ -6,155 +6,45 @@ It has two features:
 * provide a listing of directory contents.
 * transfer a file to user.
 
-## Use in Docker Environment
+## Use
 
-### Adjust Configuration
+Create a file `compose.lib.yml` and copy the following into it:
 
-The microservices require configuration,
-see the [Configure](#gear-configure) section for more info.
-
-The docker version of the microservices uses the configuration
-file available in `config/.env.default`.
-If you would like to adjust the configuration, please change this file.
-
-### Use
-
-The commands to start and stop the appliation are:
-
-```bash
-git clone https://github.com/INTO-CPS-Association/DTaaS.git
-cd servers/lib
-docker compose -f compose.lib.yml up -d
+```yml
+services:
+  libms:
+    image: intocps/libms:latest
+    restart: unless-stopped
+    volumes:
+      - ./files:/dtaas/libms/files
+    ports:
+      - "4001:4001"
 ```
 
-This command brings up the lib docker container and makes
-the website available at <http://localhost:4001>.
-The `config/.env.default` file is used as the microservice configuration.
-If the configuration values are changed, please restart the container.
+Create a directory `files` with the following structure:
+
+```text
+files/
+  data/
+  digital_twins/
+  functions/
+  models/
+  tools/
+  common/
+    data/
+    functions/
+    models/
+    tools/
+```
+
+Use the following commands to run and stop the container respectively:
 
 ```bash
+docker compose -f compose.lib.yml up -d
 docker compose -f compose.lib.yml down
-docker compose -f compose.lib.yml up -d
 ```
 
-## ⚙ Configure
-
-The microservices requires config specified in INI format.
-The template configuration file is:
-
-```ini
-PORT='4001'
-MODE='local' or 'gitlab'
-LOCAL_PATH ='/Users/<Username>/DTaaS/files'
-LOG_LEVEL='debug'
-APOLLO_PATH='/lib' or ''
-GRAPHQL_PLAYGROUND='false' or 'true'
-```
-
-The `LOCAL_PATH` variable is the absolute filepath to the
-location of the local directory which will be served to users
-by the Library microservice.
-
-Replace the default values the appropriate values for your setup.
-Please save this config in a file.
-
-## 🚀 Use
-
-Display help.
-
-```bash
-$libms -h
-Usage: libms [options]
-
-The lib microservice is a file server. It supports file transfer
-over GraphQL and HTTP protocols.
-
-Options:
-  -c, --config <file>  provide the config file (default .env)
-  -H, --http <file>    enable the HTTP server with the specified config
-  -h, --help           display help for libms
-```
-
-Both the options are not mandatory.
-
-### Configuration file
-
-The config is saved `.env` file by convention. If `-c` is not specified
-The **libms** looks for
-`.env` file in the working directory from which it is run.
-If you want to run **libms** without explicitly specifying the configuration
-file, run
-
-```bash
-libms
-```
-
-To run **libms** with a custom config file,
-
-```bash
-libms -c FILE-PATH
-libms --config FILE-PATH
-```
-
-If the environment file is named something other than `.env`,
-for example as `config/.env.default`, you can run
-
-```sh
-libms -c "config/.env.default"
-```
-
-You can press `Ctl+C` to halt the application.
-
-### Protocol Support
-
-The **libms** supports GraphQL protocol by default.
-It is possible to enable the HTTP protocol by setting
-the `-H` option.
-
-To run **libms** with a custom config for HTTP protocol, use
-
-```bash
-libms -H FILE-PATH
-libms --http FILE-PATH
-```
-
-<details>
-<summary>Please see this sample HTTP config file</summary>
-
-```json
-{
-  "name": "DTaaS Fileserver",
-  "auth": false,
-  "editor": "edward",
-  "packer": "zip",
-  "diff": true,
-  "zip": true,
-  "buffer": true,
-  "dirStorage": true,
-  "online": false,
-  "open": false,
-  "oneFilePanel": true,
-  "keysPanel": false,
-  "prefix": "/lib/files",
-  "confirmCopy": true,
-  "confirmMove": true,
-  "showConfig": false,
-  "showFileName": true,
-  "contact": false,
-  "configDialog": false,
-  "console": false,
-  "terminal": false,
-  "vim": false,
-  "columns": "name-size-date-owner-mode",
-  "export": false,
-  "import": false,
-  "dropbox": false,
-  "dropboxToken": "",
-  "log": true
-}
-```
-
-</details>
+The website is available at <http://localhost:4001>.
 
 ## Application Programming Interface (API)
 
@@ -170,7 +60,7 @@ The regular file upload and download options become available.
 
 ### GraphQL protocol
 
-Endpoint: `localhost:PORT/lib`
+Endpoint: `localhost:4001/lib`
 
 <details>
 <summary>GraphQL API details</summary>

--- a/servers/lib/DOCKER.md
+++ b/servers/lib/DOCKER.md
@@ -1,14 +1,17 @@
 # Overview
 
-The **lib microservice** is a simplified file manager providing graphQL API.
+The **libms microservice** is a simplified file manager providing graphQL API.
 It has two features:
 
 * provide a listing of directory contents.
 * transfer a file to user.
 
-## Use
+## Use in Docker Environment
 
-Create a file `compose.lib.yml` and copy the following into it:
+### Create Docker Compose File
+
+Create an empty file named `compose.lib.yml` and copy
+the following into the file:
 
 ```yml
 services:
@@ -21,7 +24,11 @@ services:
       - "4001:4001"
 ```
 
-Create a directory `files` with the following structure:
+### Create Files Directory
+
+The **libms microservice** serves files available from
+`files` directory.
+So, create a directory named `files` with the following structure:
 
 ```text
 files/
@@ -37,14 +44,19 @@ files/
     tools/
 ```
 
-Use the following commands to run and stop the container respectively:
+Please create this `files` directory
+in the same file system location as that of the `compose.lib.yml` file.
+
+### Run
+
+Use the following commands to start and stop the container respectively:
 
 ```bash
 docker compose -f compose.lib.yml up -d
 docker compose -f compose.lib.yml down
 ```
 
-The website is available at <http://localhost:4001>.
+The lib microservice website will become available at <http://localhost:4001>.
 
 ## Application Programming Interface (API)
 
@@ -53,14 +65,14 @@ two end points:
 
 ### HTTP protocol
 
-Endpoint: `localhost:PORT/lib/files`
+**URL:** `localhost:4001/lib/files`
 
-This option needs to be enabled with `-H http.json` flag.
-The regular file upload and download options become available.
+The regular file upload and download options become available
+via web browser.
 
 ### GraphQL protocol
 
-Endpoint: `localhost:4001/lib`
+**URL:** `localhost:4001/lib`
 
 <details>
 <summary>GraphQL API details</summary>
@@ -73,7 +85,7 @@ in that directory. A sample query and response are given here.
 
 ``` graphql
 query {
-  listDirectory(path: "user1") {
+  listDirectory(path: ".") {
     repository {
       tree {
         blobs {
@@ -158,14 +170,14 @@ query {
 
 This query receives directory path and send the file contents to user in response.
 
-To check this query, create a file `files/user2/data/welcome.txt`
+To check this query, create a file `files/data/welcome.txt`
 with content of `hello world`.
 
 A sample query and response are given here.
 
 ```graphql
 query {
-  readFile(path: "user2/data/sample.txt") {
+  readFile(path: "data/welcome.txt") {
     repository {
       blobs {
         nodes {
@@ -187,7 +199,7 @@ query {
         "blobs": {
           "nodes": [
             {
-              "name": "sample.txt",
+              "name": "welcome.txt",
               "rawBlob": "hello world",
               "rawTextBlob": "hello world"
             }
@@ -231,7 +243,7 @@ Content-Type: application/json
 Content-Length: 388
 
 {
-   "query":"query {\n  listDirectory(path: \"user1\") {\n    repository {\n      tree {\n        blobs {\n          edges {\n            node {\n              name\n              type\n            }\n          }\n        }\n        trees {\n          edges {\n            node {\n              name\n              type\n            }\n          }\n        }\n      }\n    }\n  }\n}"
+   "query":"query {\n  listDirectory(path: \".\") {\n    repository {\n      tree {\n        blobs {\n          edges {\n            node {\n              name\n              type\n            }\n          }\n        }\n        trees {\n          edges {\n            node {\n              name\n              type\n            }\n          }\n        }\n      }\n    }\n  }\n}"
 }
 ```
 
@@ -253,7 +265,7 @@ X-Powered-By: Express
 
 This query receives directory path and send the file contents to user in response.
 
-To check this query, create a file `files/user2/data/welcome.txt`
+To check this query, create a file `files/data/welcome.txt`
 with content of `hello world`.
 
 ```http
@@ -263,7 +275,7 @@ Content-Type: application/json
 Content-Length: 217
 
 {
-   "query":"query {\n  readFile(path: \"user2/data/welcome.txt\") {\n    repository {\n      blobs {\n        nodes {\n          name\n          rawBlob\n          rawTextBlob\n        }\n      }\n    }\n  }\n}"
+   "query":"query {\n  readFile(path: \"data/welcome.txt\") {\n    repository {\n      blobs {\n        nodes {\n          name\n          rawBlob\n          rawTextBlob\n        }\n      }\n    }\n  }\n}"
 }
 ```
 


### PR DESCRIPTION
Intended to fix #783. 

Overview:
- Uses DockerHub as the container registry for the software's Docker images instead of GitHub Packages. (Note: the previously published GitHub packages will still show up under the `packages` tab of the sidebar)
- The DockerHub username must be a repository/environment variable called `DOCKERHUB_USERNAME`
- The DockerHub token must be a repository secret called `DOCKERHUB_TOKEN`
- Adds new markdown files to serve as DockerHub READMEs for the `client` and `libms` images