### PR TITLE
Fixes #986: Converts repository owner name to lowercase

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -21,7 +21,6 @@ on:
 
 env:
   registry: ghcr.io
-  ghcr-scope: ${{ github.repository_owner }}
   password: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -35,6 +34,14 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+
+      # Sets a new environment variable that can be accessed in later
+      # steps via ${{ env.ghcr-scope }}
+      - name: Get repository owner in lower-case
+        run: |
+          echo "ghcr-scope=${REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+        env:
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,6 +1,6 @@
 # Reusable workflow for building and pushing a Docker Image to GHCR.
 # 
-# Username is taken from the user who scheduled the workflow
+# Username is the repository owner converted to lowercase
 # Password is taken from the auto-generated GitHub token
 
 name: Build and Push Docker Image (GHCR)


### PR DESCRIPTION
## Fixes #986

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Instead of using `${{ github.repository_owner }}` directly for ghcr-scope, I use the bash substitution method to convert it to lower-case first, and THEN set it as an environment variable.

## Impact

Will allow developers to successfully publish a package to their repository even when their username is not fully in lower-case.

## Checklist

- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have added tests for all the new code and any changes made to
      existing code.
- [X] I have made corresponding changes to the documentation.
