### PR TITLE
Fix client website publish step

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -114,7 +114,7 @@ jobs:
     with: 
       image-name: dtaas-web
       version: ${{ needs.get_version.outputs.version }}
-      dockerfile: client.dockerfile
+      dockerfile: client.built.dockerfile
     secrets: inherit
 
   publish-docker-image-dockerhub:

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -128,7 +128,7 @@ jobs:
     with: 
       image-name: dtaas-web
       version: ${{ needs.get_version.outputs.version }}
-      dockerfile: client.dockerfile
+      dockerfile: client.built.dockerfile
       readme-file: client/DOCKER.md
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker-dockerhub.yml
+++ b/.github/workflows/docker-dockerhub.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup node
-        if: image-name == 'dtaas-web'
+        if: ${{ inputs.image-name }} == 'dtaas-web'
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -67,7 +67,7 @@ jobs:
           cache-dependency-path: "**/yarn.lock"
 
       - name: Build react client website
-        if: image-name == 'dtaas-web'
+        if: ${{ inputs.image-name }} == 'dtaas-web'
         run: |
           cd client/
           yarn install --network-timeout 1000000

--- a/.github/workflows/docker-dockerhub.yml
+++ b/.github/workflows/docker-dockerhub.yml
@@ -58,6 +58,21 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Setup node
+        if: image-name == 'dtaas-web'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "yarn"
+          cache-dependency-path: "**/yarn.lock"
+
+      - name: Build react client website
+        if: image-name == 'dtaas-web'
+        run: |
+          cd client/
+          yarn install --network-timeout 1000000
+          yarn build
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker-dockerhub.yml
+++ b/.github/workflows/docker-dockerhub.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup node
-        if: ${{ inputs.image-name }} == 'dtaas-web'
+        if: ${{ inputs.image-name == 'dtaas-web' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -67,7 +67,7 @@ jobs:
           cache-dependency-path: "**/yarn.lock"
 
       - name: Build react client website
-        if: ${{ inputs.image-name }} == 'dtaas-web'
+        if: ${{ inputs.image-name == 'dtaas-web' }}
         run: |
           cd client/
           yarn install --network-timeout 1000000

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup node for building the React client website
-        if: ${{ inputs.image-name }} == 'dtaas-web'
+        if: ${{ inputs.image-name == 'dtaas-web' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -44,7 +44,7 @@ jobs:
           cache-dependency-path: "**/yarn.lock"
 
       - name: Build react client website
-        if: ${{ inputs.image-name }} == 'dtaas-web'
+        if: ${{ inputs.image-name == 'dtaas-web' }}
         run: |
           cd client/
           yarn install --network-timeout 1000000

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -35,6 +35,21 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Setup node for building the React client website
+        if: ${{ inputs.image-name }} == 'dtaas-web'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "yarn"
+          cache-dependency-path: "**/yarn.lock"
+
+      - name: Build react client website
+        if: ${{ inputs.image-name }} == 'dtaas-web'
+        run: |
+          cd client/
+          yarn install --network-timeout 1000000
+          yarn build
+
       # Sets a new environment variable that can be accessed in later
       # steps via ${{ env.ghcr-scope }}
       - name: Get repository owner in lower-case

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,2 +1,4 @@
 playwright/.auth/
 test-results/
+node_modules/
+coverage/

--- a/client/config/dev.js
+++ b/client/config/dev.js
@@ -13,7 +13,7 @@ if (typeof window !== 'undefined') {
     REACT_APP_WORKBENCHLINK_DT_PREVIEW: '/preview/digitaltwins',
 
     REACT_APP_CLIENT_ID: '1be55736756190b3ace4c2c4fb19bde386d1dcc748d20b47ea8cfb5935b8446c',
-    REACT_APP_AUTH_AUTHORITY: 'https://gitlab.foo.com/',
+    REACT_APP_AUTH_AUTHORITY: 'https://gitlab.com/',
     REACT_APP_REDIRECT_URI: 'http://localhost:4000/Library',
     REACT_APP_LOGOUT_REDIRECT_URI: 'http://localhost:4000',
     REACT_APP_GITLAB_SCOPES: 'openid profile read_user read_repository api',

--- a/client/config/test.js
+++ b/client/config/test.js
@@ -12,8 +12,8 @@ if (typeof window !== 'undefined') {
     REACT_APP_WORKBENCHLINK_LIBRARY_PREVIEW: '/preview/library',
     REACT_APP_WORKBENCHLINK_DT_PREVIEW: '/preview/digitaltwins',
 
-    REACT_APP_CLIENT_ID: '38bf4764fad5ebb2ebbf49b4f57c7720145b61266f13bf4891ff7851dd5c6563',
-    REACT_APP_AUTH_AUTHORITY: 'https://maestro.cps.digit.au.dk/gitlab',
+    REACT_APP_CLIENT_ID: '1be55736756190b3ace4c2c4fb19bde386d1dcc748d20b47ea8cfb5935b8446c',
+    REACT_APP_AUTH_AUTHORITY: 'https://gitlab.com',
     REACT_APP_REDIRECT_URI: 'http://localhost:4000/Library',
     REACT_APP_LOGOUT_REDIRECT_URI: 'http://localhost:4000/',
     REACT_APP_GITLAB_SCOPES: 'openid profile read_user read_repository api',

--- a/servers/lib/.gitignore
+++ b/servers/lib/.gitignore
@@ -1,0 +1,3 @@
+test-results/
+node_modules/
+coverage/

--- a/servers/lib/.gitignore
+++ b/servers/lib/.gitignore
@@ -1,3 +1,2 @@
-test-results/
 node_modules/
 coverage/


### PR DESCRIPTION
Fix issue #1101 that relates the docker image publishing step for react client website.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description

The `yarn build` command for client website is failing inside the docker build. This is primarily due to react package incompatibilities. Hence, a new `client.built.dockerfile` has been created to copy the pre-compiled react website into the docker image during build stage.
Accordingly, the [github actions](https://github.com/INTO-CPS-Association/DTaaS/blob/feature/distributed-demo/.github/workflows/client.yml#L117) have been updated to use `client.built.dockerfile`.

## Testing

Tested on the personal fork.

## Impact

The docker images of the client should be published properly to both docker hub and github container registry.
