### PR TITLE
Adds gitlab container registry settings to installation files

### DIFF
--- a/deploy/docker/compose.local.secure.yml
+++ b/deploy/docker/compose.local.secure.yml
@@ -13,11 +13,15 @@ services:
       - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
       - "--providers.file.directory=/etc/traefik/dynamic"
       - "--providers.file.watch=true"
+      - "--certificatesresolvers.manual.acme.tlschallenge=true"
+      - "--certificatesresolvers.manual.acme.email=your-email@domain.com"
+      - "--certificatesresolvers.manual.acme.storage=/etc/traefik-certs/acme.json"
     ports:
       - "80:80"
       - "443:443"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "/etc/letsencrypt:/etc/letsencrypt:ro"
       - "${DTAAS_DIR}/deploy/docker/dynamic/tls.local.yml:/etc/traefik/dynamic/tls.yml"
       - "${DTAAS_DIR}/deploy/docker/certs:/etc/traefik-certs"
     networks:
@@ -31,8 +35,10 @@ services:
       - "${DTAAS_DIR}/deploy/config/client/env.local.js:/dtaas/client/build/env.js"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.client.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.client.rule=Host(`release.dtaas-digitaltwin.com`)"
+      - "traefik.http.routers.client.entrypoints=web-secure"
       - "traefik.http.routers.client.tls=true"
+      - "traefik.http.routers.client.tls.certresolver=manual"
       - "traefik.http.services.client.loadbalancer.server.port=4000"
     networks:
       - frontend
@@ -49,8 +55,10 @@ services:
     shm_size: 512m
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.u1.rule=PathPrefix(`/${username1}`)"
+      - "traefik.http.routers.u1.rule=Host(`release.dtaas-digitaltwin.com`) && PathPrefix(`/${username1}`)"
+      - "traefik.http.routers.u1.entrypoints=web-secure"
       - "traefik.http.routers.u1.tls=true"
+      - "traefik.http.routers.u1.tls.certresolver=manual"
     networks:
       - users
 

--- a/deploy/services/gitlab/compose.gitlab.yml
+++ b/deploy/services/gitlab/compose.gitlab.yml
@@ -1,4 +1,3 @@
-# Reference: https://docs.gitlab.com/ee/install/docker/installation.html
 services:
   gitlab:
     image: 'gitlab/gitlab-ce:17.9.2-ce.0'
@@ -9,23 +8,40 @@ services:
       GITLAB_OMNIBUS_CONFIG: |
         external_url 'https://${SERVER_DNS}/gitlab'
         gitlab_rails['gitlab_shell_ssh_port'] = 2424
+
         nginx['listen_port'] = 80
         nginx['enable'] = true
         nginx['listen_https'] = false
         nginx['redirect_http_to_https'] = false
         letsencrypt['enable'] = false
+
+        ## Container Registry (HTTP on port 5050)
+        gitlab_rails['registry_enabled'] = true
+        registry_external_url 'http://${SERVER_DNS}:5050'
+        registry['enable'] = true
+        registry_nginx['enable'] = true
+        registry_nginx['listen_port'] = 5050
+        registry_nginx['listen_https'] = false
+
     volumes:
       - '${DTAAS_DIR}/deploy/services/gitlab/config:/etc/gitlab'
       - '${DTAAS_DIR}/deploy/services/gitlab/logs:/var/log/gitlab'
       - '${DTAAS_DIR}/deploy/services/gitlab/data:/var/opt/gitlab'
     shm_size: '256m'
+
+    ports:
+      - '5050:5050'     # registry
+      - '2424:2424'     # ssh
+
     labels:
+      # GitLab Web UI via Traefik
       - "traefik.enable=true"
       - "traefik.http.routers.gitlab.entryPoints=web-secure"
-      - "traefik.http.routers.gitlab.rule=Host(`${SERVER_DNS}`)&&PathPrefix(`/gitlab`)"
+      - "traefik.http.routers.gitlab.rule=Host(`${SERVER_DNS}`) && PathPrefix(`/gitlab`)"
       - "traefik.http.routers.gitlab.service=gitlab"
       - "traefik.http.services.gitlab.loadbalancer.server.port=80"
       - "traefik.http.routers.gitlab.tls=true"
+
     networks:
       - dtaas-frontend
 


### PR DESCRIPTION
Updates `compose.gitlab.yml` to enable gitlab container registry. The changes to `compose.local.secure.yml` are invalid and need to be reverted.