### PR TITLE
Replaces GitLab Specific SignIn with Generic SignIn button

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@into-cps-association/dtaas-web",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Web client for Digital Twin as a Service (DTaaS)",
   "main": "index.tsx",
   "author": "prasadtalasila <prasad.talasila@gmail.com> (http://prasad.talasila.in/)",

--- a/client/src/route/auth/Signin.tsx
+++ b/client/src/route/auth/Signin.tsx
@@ -1,4 +1,3 @@
-import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import { useAuth } from 'react-oidc-context';
@@ -11,12 +10,7 @@ function SignIn() {
     auth.signinRedirect();
   };
 
-  return (
-    <BoxForSignIn>
-      {avatar}
-      {signInButton(startAuthProcess)}
-    </BoxForSignIn>
-  );
+  return <BoxForSignIn>{signInButton(startAuthProcess)}</BoxForSignIn>;
 }
 
 function BoxForSignIn(props: { children: React.ReactNode }) {
@@ -34,12 +28,6 @@ function BoxForSignIn(props: { children: React.ReactNode }) {
   );
 }
 
-const avatar: React.ReactElement = (
-  <Avatar sx={{ m: 1, bgcolor: 'secondary.main' }}>
-    <LockOutlinedIcon />
-  </Avatar>
-);
-
 const signInButton = (startAuthProcess: () => void) => (
   <Button
     onClick={startAuthProcess}
@@ -48,8 +36,6 @@ const signInButton = (startAuthProcess: () => void) => (
       display: 'inline-flex',
       alignItems: 'center',
       padding: '10px 20px',
-      backgroundColor: '#fc6d27',
-      color: 'white',
       border: 'none',
       borderRadius: '5px',
       fontSize: '16px',
@@ -57,27 +43,13 @@ const signInButton = (startAuthProcess: () => void) => (
       textDecoration: 'none',
       textTransform: 'none',
       '&:hover': {
-        backgroundColor: '#fc6d27',
         textDecoration: 'none',
       },
     }}
-    startIcon={startIcon}
+    startIcon={<LockOutlinedIcon />}
   >
-    Sign In with GitLab
+    SignIn
   </Button>
-);
-
-const startIcon = (
-  <img
-    src={
-      'https://gitlab.com/gitlab-com/gitlab-artwork/-/raw/master/logo/logo-square.png'
-    }
-    alt="GitLab logo"
-    style={{
-      height: '20px',
-      marginRight: '10px',
-    }}
-  />
 );
 
 export default SignIn;

--- a/client/test/e2e/tests/Auth.test.ts
+++ b/client/test/e2e/tests/Auth.test.ts
@@ -9,9 +9,7 @@ test.describe('Tests on Authentication Flow', () => {
   });
 
   test('Homepage has correct title and signin link', async ({ page }) => {
-    await page
-      .getByRole('button', { name: 'GitLab logo Sign In with GitLab' })
-      .click();
+    await page.getByRole('button', { name: 'SignIn' }).click();
     await page.getByRole('button', { name: 'Authorize' }).click();
     await expect(
       page.getByRole('button', { name: 'Open settings' }),
@@ -20,9 +18,7 @@ test.describe('Tests on Authentication Flow', () => {
   });
 
   test('Account Button Contents and Links', async ({ page, baseURL }) => {
-    await page
-      .getByRole('button', { name: 'GitLab logo Sign In with GitLab' })
-      .click();
+    await page.getByRole('button', { name: 'SignIn' }).click();
     await page.getByRole('button', { name: 'Authorize' }).click();
     await expect(
       page.getByRole('button', { name: 'Open settings' }),
@@ -46,7 +42,7 @@ test.describe('Tests on Authentication Flow', () => {
       await previousPromise;
       await page.goto(link.url.charAt(1).toUpperCase());
       await expect(page).toHaveURL(baseURL?.replace(/\/$/, '') ?? './');
-      await expect(page.locator('button:has-text("Sign In")')).toBeVisible({
+      await expect(page.locator('button:has-text("SignIn")')).toBeVisible({
         timeout: 10000,
       });
     }, Promise.resolve());

--- a/client/test/e2e/tests/ConcurrentExecution.test.ts
+++ b/client/test/e2e/tests/ConcurrentExecution.test.ts
@@ -8,9 +8,7 @@ test.describe('Concurrent Execution', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to the home page and authenticate
     await page.goto('./');
-    await page
-      .getByRole('button', { name: 'GitLab logo Sign In with GitLab' })
-      .click();
+    await page.getByRole('button', { name: 'SignIn' }).click();
     await page.getByRole('button', { name: 'Authorize' }).click();
     await expect(
       page.getByRole('button', { name: 'Open settings' }),

--- a/client/test/e2e/tests/DigitalTwins.test.ts
+++ b/client/test/e2e/tests/DigitalTwins.test.ts
@@ -8,9 +8,7 @@ test.describe('Digital Twin Log Cleaning', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to the home page and authenticate
     await page.goto('./');
-    await page
-      .getByRole('button', { name: 'GitLab logo Sign In with GitLab' })
-      .click();
+    await page.getByRole('button', { name: 'SignIn' }).click();
     await page.getByRole('button', { name: 'Authorize' }).click();
     await expect(
       page.getByRole('button', { name: 'Open settings' }),

--- a/client/test/e2e/tests/Menu.test.ts
+++ b/client/test/e2e/tests/Menu.test.ts
@@ -7,9 +7,7 @@ import links, { workbenchLinks } from './Links';
 test.describe('Menu Links from first page (Layout)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('./');
-    await page
-      .getByRole('button', { name: 'GitLab logo Sign In with GitLab' })
-      .click();
+    await page.getByRole('button', { name: 'SignIn' }).click();
     await page.getByRole('button', { name: 'Authorize' }).click();
     await expect(
       page.getByRole('button', { name: 'Open settings' }),

--- a/client/test/e2e/tests/Settings.test.ts
+++ b/client/test/e2e/tests/Settings.test.ts
@@ -13,9 +13,7 @@ test.describe('Account Settings Form', () => {
   test.beforeEach(async ({ page }) => {
     // Go to the Settings page
     await page.goto('./');
-    await page
-      .getByRole('button', { name: 'GitLab logo Sign In with GitLab' })
-      .click();
+    await page.getByRole('button', { name: 'SignIn' }).click();
     await page.getByRole('button', { name: 'Authorize' }).click();
     await expect(
       page.getByRole('button', { name: 'Open settings' }),

--- a/client/test/e2e/tests/auth.setup.ts
+++ b/client/test/e2e/tests/auth.setup.ts
@@ -17,8 +17,8 @@ setup('authenticate', async ({ page }) => {
   await page.getByRole('button', { name: 'SignIn' }).click({ timeout: 30000 });
   await page.waitForSelector('label[for="user_login"]', { timeout: 30000 }); // wait up to 30 seconds
   await page.locator('label').filter({ hasText: 'Remember me' }).click();
-  await page.fill('#user_login', testUsername.toString()); // Insert valid testing username.
-  await page.fill('#user_password', testPassword.toString()); // Insert valid testing password.
+  await page.fill('#user_login', testUsername.toString()); // Insert valid GitLab testing username.
+  await page.fill('#user_password', testPassword.toString()); // Insert valid GitLab testing password.
   await page.getByRole('button', { name: 'Sign In' }).click();
   await page
     .getByRole('button', { name: 'Authorize' })

--- a/client/test/e2e/tests/auth.setup.ts
+++ b/client/test/e2e/tests/auth.setup.ts
@@ -14,14 +14,12 @@ const testPassword = process.env.REACT_APP_TEST_PASSWORD ?? '';
 setup('authenticate', async ({ page }) => {
   // Perform authentication steps for authentication process.
   await page.goto('./');
-  await page
-    .getByRole('button', { name: 'GitLab logo Sign In with GitLab' })
-    .click({ timeout: 30000 });
+  await page.getByRole('button', { name: 'SignIn' }).click({ timeout: 30000 });
   await page.waitForSelector('label[for="user_login"]', { timeout: 30000 }); // wait up to 30 seconds
   await page.locator('label').filter({ hasText: 'Remember me' }).click();
-  await page.fill('#user_login', testUsername.toString()); // Insert valid GitLab testing username.
-  await page.fill('#user_password', testPassword.toString()); // Insert valid GitLab testing password.
-  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.fill('#user_login', testUsername.toString()); // Insert valid testing username.
+  await page.fill('#user_password', testPassword.toString()); // Insert valid testing password.
+  await page.getByRole('button', { name: 'Sign In' }).click();
   await page
     .getByRole('button', { name: 'Authorize' })
     .click({ timeout: 30000 });

--- a/client/test/integration/Auth/WaitAndNavigate.test.tsx
+++ b/client/test/integration/Auth/WaitAndNavigate.test.tsx
@@ -43,7 +43,7 @@ describe('WaitAndNavigate', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/Sign In with GitLab/i)).toBeVisible();
+      expect(screen.getByText(/SignIn/i)).toBeVisible();
     });
   });
 

--- a/client/test/integration/Auth/authRedux.test.tsx
+++ b/client/test/integration/Auth/authRedux.test.tsx
@@ -80,7 +80,7 @@ describe('Redux and Authentication integration test', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/Sign In with GitLab/i)).toBeInTheDocument();
+      expect(screen.getByText(/SignIn/i)).toBeInTheDocument();
     });
     expect(authReducer(undefined, { type: 'unknown' })).toEqual(
       initialState.auth,
@@ -108,7 +108,7 @@ describe('Redux and Authentication integration test', () => {
       isAuthenticated: false,
     });
     await waitFor(() => {
-      expect(screen.getByText(/Sign In with GitLab/i)).toBeInTheDocument();
+      expect(screen.getByText(/SignIn/i)).toBeInTheDocument();
     });
     expect(store.getState().userName).toBe(undefined);
   });

--- a/client/test/integration/Routes/Signin.test.tsx
+++ b/client/test/integration/Routes/Signin.test.tsx
@@ -21,11 +21,11 @@ describe('Signin', () => {
     await setup();
   });
 
-  it('renders the Sign in page with the Public Layout correctly', async () => {
+  it('renders the SignIn page with the Public Layout correctly', async () => {
     await testPublicLayout();
+    expect(screen.getByRole('button', { name: /SignIn/i })).toBeVisible();
     expect(
-      screen.getByRole('button', { name: /Sign In with GitLab/i }),
-    ).toBeVisible();
-    expect(screen.getByTestId(/LockOutlinedIcon/i)).toBeVisible();
+      screen.getAllByTestId(/LockOutlinedIcon/i).length,
+    ).toBeGreaterThanOrEqual(1);
   });
 });

--- a/client/test/unit/routes/SignIn.test.tsx
+++ b/client/test/unit/routes/SignIn.test.tsx
@@ -22,9 +22,7 @@ describe('SignIn', () => {
       </MemoryRouter>,
     );
 
-    expect(
-      screen.getByRole('button', { name: /Sign In With GitLab/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /SignIn/i })).toBeInTheDocument();
   });
 
   it('handles button click', () => {
@@ -35,7 +33,7 @@ describe('SignIn', () => {
     );
 
     const signInButton = screen.getByRole('button', {
-      name: /Sign In With GitLab/i,
+      name: /SignIn/i,
     });
     fireEvent.click(signInButton);
 


### PR DESCRIPTION
## Summary

Replaces the GitLab-specific logo and "Sign In with GitLab" text on the SignIn button with a generic **🔒 SignIn** button.

## Changes

- **client/src/route/auth/Signin.tsx**: Removed GitLab logo image and orange brand color. Replaced with MUI `LockOutlinedIcon` as the start icon and "SignIn" as button text.
- **Tests**: Updated all unit, integration, and e2e tests to match the new button text.

## Motivation

DTaaS now supports multiple authentication providers (Dex, Keycloak) in addition to GitLab. The SignIn button should be provider-agnostic.

Closes https://github.com/INTO-CPS-Association/DTaaS/issues/1541