### PR TITLE
Fixes bugs for users containers naming and deletion

### DIFF
--- a/cli/dtaas.toml
+++ b/cli/dtaas.toml
@@ -1,7 +1,7 @@
 # This is the config for DTaaS CLI
 
 name = "Digital Twin as a Service (DTaaS)"
-version = "0.2.2"
+version = "0.2.4"
 owner = "The INTO-CPS-Association"
 git-repo = "https://github.com/into-cps-association/DTaaS.git"
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dtaas"
-version = "0.2.3"
+version = "0.2.4"
 description = "DTaaS CLI"
 authors = ["Astitva Sehgal"]
 license = "INTO-CPS-Association"

--- a/cli/src/pkg/users.py
+++ b/cli/src/pkg/users.py
@@ -189,6 +189,35 @@ def add_users(config_obj):
     return None
 
 
+def _categorize_users(user_list, existing_services):
+    """Categorize users into existing and missing.
+
+    Args:
+        user_list: List of usernames to categorize
+        existing_services: Dict of existing services
+
+    Returns:
+        Tuple of (existing list, missing list)
+    """
+    existing, missing = [], []
+    for username in user_list:
+        if username in existing_services:
+            existing.append(username)
+        else:
+            missing.append(username)
+    return existing, missing
+
+
+def _report_missing_users(missing):
+    """Report users that don't exist.
+
+    Args:
+        missing: List of usernames that don't exist
+    """
+    for username in missing:
+        print(f"'{username}' does not exist, skipping deletion")
+
+
 def _remove_users_from_compose(compose, user_list):
     """Remove users from compose configuration."""
     for username in user_list:
@@ -201,11 +230,17 @@ def delete_user(config_obj):
     try:
         compose, err = utils.import_yaml(COMPOSE_USERS_YML)
         utils.check_error(err)
+        if compose is None:
+            return Exception("Failed to load compose configuration")
         user_list, err = config_obj.get_delete_users_list()
         utils.check_error(err)
-        err = stop_user_containers(user_list)
-        utils.check_error(err)
-        _remove_users_from_compose(compose, user_list)
+        existing_services = compose.get("services", {})
+        existing, missing = _categorize_users(user_list, existing_services)
+        _report_missing_users(missing)
+        if existing:
+            err = stop_user_containers(existing)
+            utils.check_error(err)
+        _remove_users_from_compose(compose, existing)
         err = utils.export_yaml(compose, COMPOSE_USERS_YML)
         utils.check_error(err)
     except Exception as e:

--- a/cli/src/pkg/users.py
+++ b/cli/src/pkg/users.py
@@ -1,6 +1,5 @@
 """This file has functions that handle the user cli commands"""
 
-import os
 import subprocess
 import shutil
 from src.pkg import utils

--- a/cli/tests/test_users.py
+++ b/cli/tests/test_users.py
@@ -172,3 +172,18 @@ def test_delete_user(mock_config, mock_utils, mock_user_operations, export_error
 
     err = users.delete_user(mock_config)
     assert (err is not None) if export_error else err is None
+
+
+def test_delete_user_skips_nonexistent(mock_config, mock_utils, mock_user_operations, capsys):
+    """Test delete_user skips users not present in compose services"""
+    compose = {"version": "3", "services": {"user1": {}}}
+    mock_config.get_delete_users_list.return_value = (["user1", "ghost"], None)
+    mock_utils["import"].return_value = (compose, None)
+    mock_utils["export"].return_value = None
+
+    err = users.delete_user(mock_config)
+
+    assert err is None
+    captured = capsys.readouterr()
+    assert "'ghost' does not exist, skipping deletion" in captured.out
+    mock_user_operations["stop"].assert_called_once_with(["user1"])

--- a/cli/tests/test_utils.py
+++ b/cli/tests/test_utils.py
@@ -6,6 +6,7 @@ from src.pkg import utils
 def test_import_yaml_users():
     """Test importing YAML user configuration template"""
     expected = {
+        "container_name": "${username}",
         "image": "intocps/workspace:main-967bc10",
         "restart": "unless-stopped",
         "volumes": [

--- a/cli/users.server.secure.yml
+++ b/cli/users.server.secure.yml
@@ -1,3 +1,4 @@
+container_name: ${username}
 image: intocps/workspace:main-967bc10
 restart: unless-stopped
 volumes:

--- a/cli/users.server.secure.yml
+++ b/cli/users.server.secure.yml
@@ -1,4 +1,4 @@
-container_name: ${username}
+container_name: dtaas-cli-${username}
 image: intocps/workspace:main-967bc10
 restart: unless-stopped
 volumes:

--- a/cli/users.server.yml
+++ b/cli/users.server.yml
@@ -1,3 +1,4 @@
+container_name: ${username}
 image: intocps/workspace:main-967bc10
 restart: unless-stopped
 volumes:

--- a/cli/users.server.yml
+++ b/cli/users.server.yml
@@ -1,4 +1,4 @@
-container_name: ${username}
+container_name: dtaas-cli-${username}
 image: intocps/workspace:main-967bc10
 restart: unless-stopped
 volumes:


### PR DESCRIPTION
# Bug fix for top level CLI

##
This PR solves #1611 and #1608 

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [X] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Now the "dtaas admin user delete" command skips users that is given in delete =[...] and that does not exist.

And container name entry is added to the compose templates for users so it does not use the directory name in the user name.

