### PR TITLE
Restrict GitHub Actions Permissions

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   client:
     name: Test react website
@@ -167,7 +170,6 @@ jobs:
   publish-docker-image-dockerhub:
     permissions:
       contents: read  # Required for checking out the code
-      packages: write  # Required for publishing to github package registry
     if: |
       github.event_name == 'push' &&
       (

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,6 +13,9 @@ name: Build Docker Image
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build-docker-image:
     name: Build Docker image

--- a/.github/workflows/docker-dockerhub.yml
+++ b/.github/workflows/docker-dockerhub.yml
@@ -14,7 +14,6 @@ name: Build and Push Docker Image (DockerHub)
 
 permissions:
   contents: read  # Required for checking out the code
-  packages: write  # Push to github package registry
 
 'on':
   workflow_call:
@@ -64,7 +63,6 @@ jobs:
 
     permissions:
       contents: read  # Required for checking out the code
-      packages: write  # Required for publishing to github package registry
     steps:
       - name: Checkout Repository
         # v6.0.1

--- a/.github/workflows/docker-dockerhub.yml
+++ b/.github/workflows/docker-dockerhub.yml
@@ -24,7 +24,6 @@ permissions:
       version:
         required: true
         type: string
-        default: "latest"
       dockerfile:
         required: true
         type: string

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -14,7 +14,6 @@ name: Build and Push Docker Image (GHCR)
       version:
         required: true
         type: string
-        default: "latest"
       dockerfile:
         required: true
         type: string

--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: 24
   HTTP_PORT: 4002
@@ -189,7 +192,6 @@ jobs:
 
   publish-package-npm:
     permissions:
-      packages: write  # Push to github package registry
       contents: read  # Required for checking out the code
     if: |
       github.event_name == 'push' &&
@@ -232,7 +234,6 @@ jobs:
   publish-docker-image-dockerhub:
     permissions:
       contents: read  # Required for checking out the code
-      packages: write  # Required for publishing to github package registry
     if: |
       github.event_name == 'push' &&
       (

--- a/.github/workflows/lint-scripts.yml
+++ b/.github/workflows/lint-scripts.yml
@@ -24,6 +24,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
 
 jobs:
   shellcheck:

--- a/.github/workflows/platform-services-cli.yml
+++ b/.github/workflows/platform-services-cli.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-services-cli:
     name: Test and Build Platform Services CLI

--- a/.github/workflows/python-cli.yml
+++ b/.github/workflows/python-cli.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-cli:
     name: Test and Build DTaaS CLI

--- a/.github/workflows/python-reusable.yml
+++ b/.github/workflows/python-reusable.yml
@@ -34,6 +34,9 @@ name: Python Reusable Workflow
         type: string
         default: 'dist'
 
+permissions:
+  contents: read
+
 jobs:
   python-tests:
     name: Test Python Package

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -13,6 +13,8 @@ name: Release Packages
       - '.github/workflows/release-packages.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 jobs:
   release-packages:

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -19,8 +19,7 @@ env:
   NODE_VERSION: 24
 
 permissions:
-  contents: read   # Required for checking out the code
-  packages: write  # Push to github package registry
+  contents: read  # Required for checking out the code
 
 jobs:
   test-runner:
@@ -121,7 +120,6 @@ jobs:
   publish-package-npm:
     permissions:
       contents: read  # Required for checking out the code
-      packages: write  # Push to github package registry
     if: |
       github.event_name == 'push' &&
       (

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -15,6 +15,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
 
 jobs:
   test-dex-companion-for-localhost:


### PR DESCRIPTION
# Restrict GitHub Actions workflow permissions for improved security

## Description

Apply least-privilege to GitHub Actions and align the `GITHUB_TOKEN` scope
with what each job actually needs.
- Added a restrictive top-level `permissions: contents: read` default to every
  workflow that lacked one.
- Removed unnecessary `packages: write`:
  - `docker-dockerhub.yml`: top-level and job (publishes to Docker Hub, not GitHub Packages).
  - `client.yml`: `publish-docker-image-dockerhub` job (Docker Hub only).
  - `lib-ms.yml`: `publish-package-npm` (npmjs.org) and `publish-docker-image-dockerhub` jobs.
  - `runner.yml`: top-level and `publish-package-npm` (npmjs.org) job.
- `packages: write` is kept only on jobs that publish to GHCR / GitHub Packages
  (`publish-docker-image-ghcr`, `publish-package-github`).
