### PR TITLE
Copy TLS certificates into certs

### DIFF
--- a/cli/DEVELOPER.md
+++ b/cli/DEVELOPER.md
@@ -56,7 +56,7 @@ It has the following sections:
 
 ```toml
 name="Digital Twin as a Service (DTaaS)"
-version="0.5.0"
+version="0.6.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 ```
@@ -73,6 +73,7 @@ path="/Users/username/DTaaS"
 
 [common.security]
 tls=true
+certs-src="/etc/letsencrypt/archive/intocps.org"
 
 [common.resources]
 cpus=4
@@ -86,6 +87,9 @@ shm_size="512m"
 - _path_: absolute path to the DTaaS installation; required for workspace
   creation and docker services.
 - _tls_: `false` uses `user.server.yml`; `true` (default) uses `user.server.secure.yml`.
+- _certs-src_: source directory of the TLS certificates. For TLS deploy types,
+  `generate-deployment` copies the latest `fullchain.pem`/`privkey.pem` from
+  here into the deployment's `certs/` directory (see `src/pkg/certs.py`).
 - Resource fields set default container limits for user workspaces.
 
 #### [users]

--- a/cli/README.md
+++ b/cli/README.md
@@ -153,6 +153,15 @@ paths, and emails) are substituted across all types where they appear.
 If `dtaas.toml` is not found in either location, a note is printed and the
 files keep their default placeholder values.
 
+#### TLS certificate placement
+
+For the TLS deployment types (`secure-server`, `secure-server-gitlab`,
+`workspace-secure-server`), `generate-deployment` also populates the
+generated `certs/` directory so the reverse proxy can find its certificates.
+It reads the source location from `[common.security] certs-src` in
+`dtaas.toml` and copies the latest `fullchain.pem` and `privkey.pem` into
+`<output-dir>/certs/`.
+
 ### 📁 Select Template
 
 The _cli_ uses YAML templates provided in this directory to create
@@ -259,6 +268,9 @@ are described in the command sections above.
 Set `server-dns` to your server's public hostname (`localhost` for a local
 deployment) and `path` to the absolute path of your DTaaS installation.
 Set `[common.security] tls = true` for HTTPS deployments.
+
+For TLS deployments, set `[common.security] certs-src` to the directory
+holding your `fullchain.pem` and `privkey.pem`
 
 Adjust `[common.resources]` to match your hardware:
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -158,7 +158,7 @@ files keep their default placeholder values.
 For the TLS deployment types (`secure-server`, `secure-server-gitlab`,
 `workspace-secure-server`), `generate-deployment` also populates the
 generated `certs/` directory so the reverse proxy can find its certificates.
-It reads the source location from `[common.security] certs-src` in
+It reads the source location from `[common.security].certs-src` in
 `dtaas.toml` and copies the latest `fullchain.pem` and `privkey.pem` into
 `<output-dir>/certs/`.
 
@@ -269,8 +269,8 @@ Set `server-dns` to your server's public hostname (`localhost` for a local
 deployment) and `path` to the absolute path of your DTaaS installation.
 Set `[common.security] tls = true` for HTTPS deployments.
 
-For TLS deployments, set `[common.security] certs-src` to the directory
-holding your `fullchain.pem` and `privkey.pem`
+For TLS deployments, set `[common.security].certs-src` to the directory
+holding your `fullchain.pem` and `privkey.pem`.
 
 Adjust `[common.resources]` to match your hardware:
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dtaas"
-version = "0.5.0"
+version = "0.6.0"
 description = "DTaaS CLI"
 authors = ["Astitva Sehgal"]
 license = "INTO-CPS-Association"

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -147,7 +147,8 @@ def _certs_src(toml_data):
     security = common.get("security", {}) if isinstance(common, dict) else {}
     if not isinstance(security, dict):
         return ""
-    return str(security.get("certs-src", "")).strip()
+    certs_src = security.get("certs-src", "")
+    return certs_src.strip() if isinstance(certs_src, str) else ""
 
 
 def _copy_deploy_certs(deploy_type, output_dir, toml_data, force):

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -5,6 +5,7 @@ import click
 from .pkg import config as configPkg
 from .pkg import users as userPkg
 from .pkg import project as projectPkg
+from .pkg import certs as certsPkg
 from .pkg import deploy_config as deployConfigPkg
 from .pkg import utils as utilsPkg
 from .pkg.project import DEPLOY_TYPES
@@ -102,7 +103,7 @@ def generate_deployment(deploy_type, output_dir, force):
         projectPkg.generate_deploy_project(deploy_type, output_dir, force)
     except (ValueError, RuntimeError, OSError) as exc:
         raise click.ClickException(str(exc)) from exc
-    _apply_deploy_config(deploy_type, output_dir)
+    _apply_deploy_config(deploy_type, output_dir, force)
     projectPkg.set_files_permissions(output_dir)
     click.echo(f"Project files for '{deploy_type}' generated successfully")
 
@@ -115,7 +116,7 @@ def _find_toml(output_dir):
     return None
 
 
-def _apply_deploy_config(deploy_type, output_dir):
+def _apply_deploy_config(deploy_type, output_dir, force=False):
     """Read dtaas.toml and substitute values into generated deployment files."""
     toml_path = _find_toml(output_dir)
     if toml_path is None:
@@ -126,6 +127,7 @@ def _apply_deploy_config(deploy_type, output_dir):
         raise click.ClickException(f"Error reading dtaas.toml: {err}")
     _substitute_config(deploy_type, output_dir, toml_data)
     _create_user_dirs(output_dir, toml_data)
+    _copy_deploy_certs(deploy_type, output_dir, toml_data, force)
 
 
 def _substitute_config(deploy_type, output_dir, toml_data):
@@ -137,6 +139,27 @@ def _substitute_config(deploy_type, output_dir, toml_data):
         raise click.ClickException(f"Error substituting config values: {exc}") from exc
     for warning in deployConfigPkg.check_placeholders(output_dir, specs):
         click.echo(warning)
+
+
+def _certs_src(toml_data):
+    """Resolve [common.security].certs-src from dtaas.toml, or '' if unset."""
+    common = toml_data.get("common", {}) if toml_data else {}
+    security = common.get("security", {}) if isinstance(common, dict) else {}
+    if not isinstance(security, dict):
+        return ""
+    return str(security.get("certs-src", "")).strip()
+
+
+def _copy_deploy_certs(deploy_type, output_dir, toml_data, force):
+    """Copy TLS certificates into output_dir/certs for secure deployments."""
+    try:
+        note = certsPkg.copy_certs(
+            deploy_type, output_dir, _certs_src(toml_data), force
+        )
+    except OSError as exc:
+        raise click.ClickException(f"Error copying certificates: {exc}") from exc
+    if note:
+        click.echo(note)
 
 
 def _create_user_dirs(output_dir, toml_data):

--- a/cli/src/pkg/certs.py
+++ b/cli/src/pkg/certs.py
@@ -1,0 +1,96 @@
+"""TLS certificate placement for generated secure deployments."""
+
+import shutil
+from pathlib import Path
+
+# Deploy types that terminate TLS and reference certificates from certs/.
+TLS_DEPLOY_TYPES = {
+    "secure-server",
+    "secure-server-gitlab",
+    "workspace-secure-server",
+}
+
+# Certificate files expected by config/tls.yml.
+CERT_FILES = ("fullchain.pem", "privkey.pem")
+PRIVATE_KEY_NAME = "privkey.pem"
+
+
+def _find_latest_cert(src_dir, prefix):
+    """Return the newest '{prefix}.pem' / '{prefix}<N>.pem' file, or None.
+
+    Let's Encrypt/Certbot archive directories hold numbered certificates
+    (e.g. fullchain1.pem, fullchain2.pem); the newest by mtime is chosen.
+    """
+    candidates = [
+        p
+        for p in src_dir.glob(f"{prefix}*.pem")
+        if p.name == f"{prefix}.pem"
+        or (p.name.startswith(prefix) and p.name[len(prefix) : -4].isdigit())
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def _secure_private_key(key_path):
+    """Set 0600 on the private key. Best-effort; POSIX modes are a no-op on Windows."""
+    if not key_path.exists():
+        return
+    try:
+        key_path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def _cert_copy_message(certs_dir, copied, missing):
+    """Build an informative note describing the certificate copy outcome."""
+    parts = []
+    if copied:
+        parts.append(f"TLS certificates copied to {certs_dir}: {', '.join(copied)}.")
+    if missing:
+        parts.append(
+            "Note: certificate(s) not found in certs-src: " + ", ".join(missing) + "."
+        )
+    if not parts:
+        parts.append(f"TLS certificates already present in {certs_dir}; skipping.")
+    return "\n".join(parts)
+
+
+def _copy_cert_pair(src, certs_dir, force):
+    """Copy the latest fullchain/privkey from src into certs_dir.
+
+    Existing files are skipped unless force is True. Returns a status note.
+    Raises OSError on copy failure.
+    """
+    copied, missing = [], []
+    for name in CERT_FILES:
+        latest = _find_latest_cert(src, name[: -len(".pem")])
+        if latest is None:
+            missing.append(name)
+            continue
+        dest = certs_dir / name
+        if dest.exists() and not force:
+            continue
+        shutil.copy2(latest, dest)
+        copied.append(name)
+    _secure_private_key(certs_dir / PRIVATE_KEY_NAME)
+    return _cert_copy_message(certs_dir, copied, missing)
+
+
+def copy_certs(deploy_type, dest_dir, certs_src, force=False):
+    """Copy TLS certificates into dest_dir/certs for a secure deployment.
+
+    Returns an informative note, or None when nothing applies (non-TLS deploy).
+    Skips gracefully with a note when no source is configured or the source
+    directory is missing. Raises OSError only on an actual copy failure.
+    """
+    if deploy_type not in TLS_DEPLOY_TYPES:
+        return None
+    if not certs_src:
+        return "Note: certs-src not set in dtaas.toml; TLS certificates not copied."
+    src = Path(certs_src)
+    if not src.is_dir():
+        return f"Note: certs-src not found ({src}); TLS certificates not copied."
+    certs_dir = Path(dest_dir) / "certs"
+    certs_dir.mkdir(parents=True, exist_ok=True)
+    return _copy_cert_pair(src, certs_dir, force)

--- a/cli/src/pkg/project.py
+++ b/cli/src/pkg/project.py
@@ -204,10 +204,18 @@ def set_files_permissions(dest_dir):
         pass
 
 
+def _has_template_files(src):
+    """True if *src* holds deployment files."""
+    return any(p.is_file() and p.name != ".gitkeep" for p in src.rglob("*"))
+
+
 def generate_deploy_project(deploy_type, dest_dir=".", force=False):
     """Copy a deploy template directory tree to the destination."""
     src = DEPLOY_TEMPLATES_DIR / deploy_type
     dest = Path(dest_dir)
     _validate_deploy_inputs(deploy_type, src, dest)
+    if not _has_template_files(src):
+        click.echo(f"Warning: no deployment templates found for '{deploy_type}'")
+        return
     _copy_tree(src, dest, force)
     _copy_example_files(dest, force)

--- a/cli/src/templates/dtaas.toml
+++ b/cli/src/templates/dtaas.toml
@@ -1,7 +1,7 @@
 # This is the config for DTaaS CLI
 
 name="Digital Twin as a Service (DTaaS)"
-version="0.5.0"
+version="0.6.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 
@@ -20,6 +20,13 @@ path="/home/XXX/DTaaS"
 [common.security]
 # Enable HTTPS/TLS for secure server deployment
 tls=true
+# Source directory holding the TLS certificates (fullchain.pem, privkey.pem)
+# for secure deployments. generate-deployment copies the latest pair into the
+# installation's certs/ directory. Leave unset to copy certificates by hand.
+# Certs path on Linux / MacOS
+certs-src='/etc/letsencrypt/archive/intocps.org'
+# Certs path on Windows
+#certs-src='C:/Certbot/archive/intocps.org'
 
 [common.resources]
 # These are the default resource limits for user containers.

--- a/cli/tests/dtaas.test.toml
+++ b/cli/tests/dtaas.test.toml
@@ -1,32 +1,114 @@
 # This is the config for DTaaS CLI
 
-name = "Digital Twin as a Service (DTaaS)"
-version = "0.6.0"
-owner = "The INTO-CPS-Association"
-git-repo = "https://github.com/into-cps-association/DTaaS.git"
+name="Digital Twin as a Service (DTaaS)"
+version="0.6.0"
+owner="The INTO-CPS-Association"
+git-repo="https://github.com/into-cps-association/DTaaS.git"
 
 [common]
 # absolute path to the DTaaS application directory
-server-dns = "localhost"
+server-dns="localhost"
+# Specify the directory of DTaaS installation
+# Linux example
+# "REPLACE_WITH_ABSOLUTE_PATH_TO_DTAAS"
+#path="/home/XXX/DTaaS"
+# Windows example
 path = "/home/Desktop/DTaaS"
+# Note: You have to either use / or \\ when specifying path, else you would get
+# "Error while getting toml file: dtaas.toml, Invalid unicode value"
 
 [common.security]
 # Enable HTTPS/TLS for secure server deployment
-tls = false
+tls=false
+# Source directory holding the TLS certificates (fullchain.pem, privkey.pem)
+# for secure deployments. generate-deployment copies the latest pair into the
+# installation's certs/ directory. Leave unset to copy certificates by hand.
+# Certs path on Linux / MacOS
+certs-src='/etc/letsencrypt/archive/intocps.org'
+# Certs path on Windows
+#certs-src='C:/Certbot/archive/intocps.org'
+
+[common.resources]
+# These are the default resource limits for user containers.
+cpus=4 # Virtual CPU
+mem_limit="4G"
+pids_limit=4960 # Number of processes
+shm_size="512m" # Shared memory size
+
 
 [users]
 # matching user info must present in this config file
-add = ["username1","username2", "username3"]
-delete = ["username2", "username3"]
+add=["username1","username2", "username3"]
+delete=["username2", "username3"]
 
 [users.username1]
-email = "username1@intocps.org"
+email="username1@intocps.org"
 
 [users.username2]
-email = "username2@intocps.org"
+email="username2@intocps.org"
 
 [users.username3]
-email = "username3@intocps.org"
+email="username3@intocps.org"
 
-[client.web]
-config = "/home/Desktop/DTaaS/env.local.js"
+# Installation-specific configuration
+# For non-localhost deployments, usernames (USERNAME1, USERNAME2, ...)
+# are taken from the [users] add list above.
+
+# OAuth application for the DTaaS client website (React frontend).
+# This is a separate OAuth application from the server one used by
+# traefik-forward-auth in the [insecure-server] and [secure-server] sections.
+# Create it in your GitLab instance at:
+# Settings -> Applications (for personal) or
+# Admin Area -> Applications (for instance-wide)
+# with Redirect URI "https://<server-dns>/Library", Confidential unticked and
+# scopes: openid, profile, read_user, read_repository, api.
+[frontend]
+# Application ID of the client website OAuth application
+react-app-client-id="your_client_id_here"
+# URL of your GitLab instance (without trailing slash)
+react-app-oauth-url="https://gitlab.com"
+
+[localhost]
+default-user="user1"
+client-id="your_client_id_here"
+auth-authority="https://gitlab.com/"
+
+# OAuth application for the server (traefik-forward-auth).
+# This is a separate OAuth application from the client website one in [frontend].
+# Create it in your GitLab instance at:
+# Settings -> Applications (for personal) or
+# Admin Area -> Applications (for instance-wide)
+# with Redirect URI "https://<server-dns>/_oauth", Confidential ticked and
+# scopes: openid, profile, read_user.
+[insecure-server]
+oauth-url="https://gitlab.com"
+oauth-client-id="your_client_id_here"
+oauth-client-secret="your_client_secret_here"
+oauth-secret="your_random_secret_key_here"
+
+[secure-server]
+oauth-url="https://gitlab.com"
+oauth-client-id="your_client_id_here"
+oauth-client-secret="your_client_secret_here"
+oauth-secret="your_random_secret_key_here"
+
+[secure-server-gitlab]
+oauth-client-id="your_client_id_here"
+oauth-client-secret="your_client_secret_here"
+oauth-secret="your_random_secret_key_here"
+
+[workspace-localhost]
+default-user="user"
+client-id="mock"
+auth-authority="http://localhost:5556/dex"
+
+[workspace-secure-server]
+oauth-secret="your_random_secret_key_here"
+keycloak-admin="admin"
+keycloak-admin-password="changeme"
+keycloak-realm="dtaas"
+keycloak-issuer-url="https://your_server_dns/auth/realms/dtaas"
+keycloak-client-id="dtaas-workspace"
+keycloak-client-secret="your_keycloak_client_secret_here"
+client-id="dtaas-client"
+auth-authority="https://your_server_dns/auth/realms/dtaas"

--- a/cli/tests/dtaas.test.toml
+++ b/cli/tests/dtaas.test.toml
@@ -1,7 +1,7 @@
 # This is the config for DTaaS CLI
 
 name = "Digital Twin as a Service (DTaaS)"
-version = "0.5.0"
+version = "0.6.0"
 owner = "The INTO-CPS-Association"
 git-repo = "https://github.com/into-cps-association/DTaaS.git"
 

--- a/cli/tests/test_certs.py
+++ b/cli/tests/test_certs.py
@@ -1,0 +1,118 @@
+"""Tests for the certs module (TLS certificate placement)."""
+
+import os
+from src.pkg.certs import copy_certs, _find_latest_cert
+
+
+def _make_cert_src(src, files):
+    """Create a source cert dir with the given {name: text} files."""
+    src.mkdir(parents=True, exist_ok=True)
+    for name, text in files.items():
+        (src / name).write_text(text)
+
+
+def test_find_latest_cert_picks_newest_numbered(tmp_path):
+    """_find_latest_cert returns the newest fullchain<N>.pem by mtime."""
+    src = tmp_path / "archive"
+    _make_cert_src(src, {"fullchain1.pem": "old", "fullchain2.pem": "new"})
+    os.utime(src / "fullchain1.pem", (1, 1))
+    os.utime(src / "fullchain2.pem", (2, 2))
+
+    latest = _find_latest_cert(src, "fullchain")
+
+    assert latest == src / "fullchain2.pem"
+
+
+def test_find_latest_cert_ignores_unrelated_names(tmp_path):
+    """Files like fullchain-service.pem are not treated as candidates."""
+    src = tmp_path / "archive"
+    _make_cert_src(src, {"fullchain-service.pem": "x"})
+
+    assert _find_latest_cert(src, "fullchain") is None
+
+
+def test_copy_certs_skips_non_tls_deploy(tmp_path):
+    """copy_certs is a no-op (returns None) for non-TLS deploy types."""
+    assert copy_certs("localhost", str(tmp_path), str(tmp_path)) is None
+
+
+def test_copy_certs_notes_when_no_source(tmp_path):
+    """A TLS deploy with no certs-src returns an informative note, copies nothing."""
+    note = copy_certs("secure-server", str(tmp_path), "")
+
+    assert note is not None and "certs-src not set" in note
+    assert not (tmp_path / "certs").exists()
+
+
+def test_copy_certs_notes_when_source_missing(tmp_path):
+    """A non-existent certs-src directory yields a note without raising."""
+    note = copy_certs("secure-server", str(tmp_path), str(tmp_path / "nope"))
+
+    assert note is not None and "not found" in note
+
+
+def test_copy_certs_copies_latest_pair(tmp_path):
+    """The latest fullchain/privkey are copied into certs/."""
+    src = tmp_path / "archive"
+    _make_cert_src(
+        src,
+        {
+            "fullchain1.pem": "fc-old",
+            "fullchain2.pem": "fc-new",
+            "privkey1.pem": "pk-old",
+            "privkey2.pem": "pk-new",
+        },
+    )
+    for name, when in [("1.pem", 1), ("2.pem", 2)]:
+        os.utime(src / f"fullchain{name}", (when, when))
+        os.utime(src / f"privkey{name}", (when, when))
+    dest = tmp_path / "install"
+
+    note = copy_certs("secure-server", str(dest), str(src))
+
+    assert (dest / "certs" / "fullchain.pem").read_text() == "fc-new"
+    assert (dest / "certs" / "privkey.pem").read_text() == "pk-new"
+    assert note is not None and "copied" in note
+
+
+def test_copy_certs_sets_private_key_permissions(tmp_path):
+    """The copied private key is chmod-ed to 0600 (POSIX only)."""
+    src = tmp_path / "archive"
+    _make_cert_src(src, {"fullchain.pem": "fc", "privkey.pem": "pk"})
+    dest = tmp_path / "install"
+
+    copy_certs("secure-server", str(dest), str(src))
+
+    key = dest / "certs" / "privkey.pem"
+    assert key.exists()
+    if os.name == "posix":
+        assert (key.stat().st_mode & 0o777) == 0o600
+
+
+def test_copy_certs_skips_existing_without_force(tmp_path):
+    """Existing certs are preserved unless force is set."""
+    src = tmp_path / "archive"
+    _make_cert_src(src, {"fullchain.pem": "fc-new", "privkey.pem": "pk-new"})
+    dest = tmp_path / "install"
+    certs = dest / "certs"
+    certs.mkdir(parents=True)
+    (certs / "fullchain.pem").write_text("fc-old")
+    (certs / "privkey.pem").write_text("pk-old")
+
+    copy_certs("secure-server", str(dest), str(src), force=False)
+
+    assert (certs / "fullchain.pem").read_text() == "fc-old"
+
+
+def test_copy_certs_overwrites_with_force(tmp_path):
+    """Existing certs are replaced when force is True."""
+    src = tmp_path / "archive"
+    _make_cert_src(src, {"fullchain.pem": "fc-new", "privkey.pem": "pk-new"})
+    dest = tmp_path / "install"
+    certs = dest / "certs"
+    certs.mkdir(parents=True)
+    (certs / "fullchain.pem").write_text("fc-old")
+
+    copy_certs("secure-server", str(dest), str(src), force=True)
+
+    assert (certs / "fullchain.pem").read_text() == "fc-new"

--- a/cli/tests/test_certs.py
+++ b/cli/tests/test_certs.py
@@ -1,7 +1,8 @@
 """Tests for the certs module (TLS certificate placement)."""
 
 import os
-from src.pkg.certs import copy_certs, _find_latest_cert
+from unittest.mock import patch
+from src.pkg.certs import copy_certs, _find_latest_cert, _secure_private_key
 
 
 def _make_cert_src(src, files):
@@ -116,3 +117,29 @@ def test_copy_certs_overwrites_with_force(tmp_path):
     copy_certs("secure-server", str(dest), str(src), force=True)
 
     assert (certs / "fullchain.pem").read_text() == "fc-new"
+
+
+def test_secure_private_key_skips_missing_file(tmp_path):
+    """_secure_private_key is a no-op when the key file does not exist."""
+    _secure_private_key(tmp_path / "privkey.pem")  # must not raise
+
+
+def test_secure_private_key_swallows_oserror(tmp_path):
+    """_secure_private_key silently ignores a chmod OSError."""
+    key = tmp_path / "privkey.pem"
+    key.write_text("pk")
+    with patch.object(type(key), "chmod", side_effect=OSError("permission denied")):
+        _secure_private_key(key)  # must not raise
+
+
+def test_copy_certs_notes_partial_source(tmp_path):
+    """A note is emitted when only one cert is found in the source directory."""
+    src = tmp_path / "archive"
+    _make_cert_src(src, {"fullchain.pem": "fc"})  # privkey.pem absent
+    dest = tmp_path / "install"
+
+    note = copy_certs("secure-server", str(dest), str(src))
+
+    assert note is not None and "privkey.pem" in note
+    assert (dest / "certs" / "fullchain.pem").exists()
+    assert not (dest / "certs" / "privkey.pem").exists()

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -201,6 +201,65 @@ def test_find_toml_returns_none_when_absent(tmp_path, monkeypatch):
     assert _find_toml(str(empty)) is None
 
 
+def test_generate_deployment_copies_certs(runner):
+    """The certs-src from dtaas.toml is forwarded to projectPkg.copy_certs."""
+    from pathlib import Path
+
+    with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
+        "src.cmd.projectPkg.set_files_permissions"
+    ), patch("src.cmd._find_toml", return_value=Path("dtaas.toml")), patch(
+        "src.cmd.utilsPkg.import_toml",
+        return_value=(
+            {"common": {"security": {"certs-src": "/etc/certs"}}, "secure-server": {}},
+            None,
+        ),
+    ), patch(
+        "src.cmd.deployConfigPkg.build_file_specs", return_value=[]
+    ), patch("src.cmd.deployConfigPkg.apply_config"), patch(
+        "src.cmd.deployConfigPkg.check_placeholders", return_value=[]
+    ), patch(
+        "src.cmd.certsPkg.copy_certs", return_value="certs copied"
+    ) as mock_copy:
+        result = runner.invoke(
+            dtaas, ["generate-deployment", "--type", "secure-server"]
+        )
+
+    assert result.exit_code == 0
+    assert "certs copied" in result.output
+    mock_copy.assert_called_once_with("secure-server", ".", "/etc/certs", False)
+
+
+def test_generate_deployment_cert_copy_error(runner):
+    """An OSError while copying certificates surfaces as a ClickException."""
+    from pathlib import Path
+
+    with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
+        "src.cmd._find_toml", return_value=Path("dtaas.toml")
+    ), patch(
+        "src.cmd.utilsPkg.import_toml",
+        return_value=({"common": {"security": {"certs-src": "/etc/certs"}}}, None),
+    ), patch("src.cmd.deployConfigPkg.build_file_specs", return_value=[]), patch(
+        "src.cmd.deployConfigPkg.apply_config"
+    ), patch("src.cmd.deployConfigPkg.check_placeholders", return_value=[]), patch(
+        "src.cmd.certsPkg.copy_certs", side_effect=OSError("permission denied")
+    ):
+        result = runner.invoke(
+            dtaas, ["generate-deployment", "--type", "secure-server"]
+        )
+
+    assert result.exit_code != 0
+    assert "Error copying certificates" in result.output
+
+
+def test_certs_src_handles_missing_section():
+    """_certs_src returns '' when common.security is absent or malformed."""
+    from src.cmd import _certs_src
+
+    assert _certs_src({}) == ""
+    assert _certs_src({"common": {"security": "oops"}}) == ""
+    assert _certs_src({"common": {"security": {"certs-src": " /x "}}}) == "/x"
+
+
 def test_add_users_config_error(runner):
     """add command raises ClickException when Config() fails"""
     with patch("src.cmd.configPkg.Config", side_effect=RuntimeError("no config")):

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -202,7 +202,7 @@ def test_find_toml_returns_none_when_absent(tmp_path, monkeypatch):
 
 
 def test_generate_deployment_copies_certs(runner):
-    """The certs-src from dtaas.toml is forwarded to projectPkg.copy_certs."""
+    """The certs-src from dtaas.toml is forwarded to certsPkg.copy_certs."""
     from pathlib import Path
 
     with patch("src.cmd.projectPkg.generate_deploy_project"), patch(

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -213,11 +213,9 @@ def test_generate_deployment_copies_certs(runner):
             {"common": {"security": {"certs-src": "/etc/certs"}}, "secure-server": {}},
             None,
         ),
-    ), patch(
-        "src.cmd.deployConfigPkg.build_file_specs", return_value=[]
-    ), patch("src.cmd.deployConfigPkg.apply_config"), patch(
-        "src.cmd.deployConfigPkg.check_placeholders", return_value=[]
-    ), patch(
+    ), patch("src.cmd.deployConfigPkg.build_file_specs", return_value=[]), patch(
+        "src.cmd.deployConfigPkg.apply_config"
+    ), patch("src.cmd.deployConfigPkg.check_placeholders", return_value=[]), patch(
         "src.cmd.certsPkg.copy_certs", return_value="certs copied"
     ) as mock_copy:
         result = runner.invoke(

--- a/cli/tests/test_utils.py
+++ b/cli/tests/test_utils.py
@@ -27,7 +27,7 @@ def test_import_toml():
 
     expected = {
         "name": "Digital Twin as a Service (DTaaS)",
-        "version": "0.5.0",
+        "version": "0.6.0",
         "owner": "The INTO-CPS-Association",
         "git-repo": "https://github.com/into-cps-association/DTaaS.git",
         "common": {

--- a/cli/tests/test_utils.py
+++ b/cli/tests/test_utils.py
@@ -31,20 +31,68 @@ def test_import_toml():
         "owner": "The INTO-CPS-Association",
         "git-repo": "https://github.com/into-cps-association/DTaaS.git",
         "common": {
-            # absolute path to the DTaaS application directory
             "server-dns": "localhost",
             "path": "/home/Desktop/DTaaS",
-            "security": {"tls": False},
+            "security": {
+                "tls": False,
+                "certs-src": "/etc/letsencrypt/archive/intocps.org",
+            },
+            "resources": {
+                "cpus": 4,
+                "mem_limit": "4G",
+                "pids_limit": 4960,
+                "shm_size": "512m",
+            },
         },
         "users": {
-            # matching user info must present in this config file
             "add": ["username1", "username2", "username3"],
             "delete": ["username2", "username3"],
             "username1": {"email": "username1@intocps.org"},
             "username2": {"email": "username2@intocps.org"},
             "username3": {"email": "username3@intocps.org"},
         },
-        "client": {"web": {"config": "/home/Desktop/DTaaS/env.local.js"}},
+        "frontend": {
+            "react-app-client-id": "your_client_id_here",
+            "react-app-oauth-url": "https://gitlab.com",
+        },
+        "localhost": {
+            "default-user": "user1",
+            "client-id": "your_client_id_here",
+            "auth-authority": "https://gitlab.com/",
+        },
+        "insecure-server": {
+            "oauth-url": "https://gitlab.com",
+            "oauth-client-id": "your_client_id_here",
+            "oauth-client-secret": "your_client_secret_here",
+            "oauth-secret": "your_random_secret_key_here",
+        },
+        "secure-server": {
+            "oauth-url": "https://gitlab.com",
+            "oauth-client-id": "your_client_id_here",
+            "oauth-client-secret": "your_client_secret_here",
+            "oauth-secret": "your_random_secret_key_here",
+        },
+        "secure-server-gitlab": {
+            "oauth-client-id": "your_client_id_here",
+            "oauth-client-secret": "your_client_secret_here",
+            "oauth-secret": "your_random_secret_key_here",
+        },
+        "workspace-localhost": {
+            "default-user": "user",
+            "client-id": "mock",
+            "auth-authority": "http://localhost:5556/dex",
+        },
+        "workspace-secure-server": {
+            "oauth-secret": "your_random_secret_key_here",
+            "keycloak-admin": "admin",
+            "keycloak-admin-password": "changeme",
+            "keycloak-realm": "dtaas",
+            "keycloak-issuer-url": "https://your_server_dns/auth/realms/dtaas",
+            "keycloak-client-id": "dtaas-workspace",
+            "keycloak-client-secret": "your_keycloak_client_secret_here",
+            "client-id": "dtaas-client",
+            "auth-authority": "https://your_server_dns/auth/realms/dtaas",
+        },
     }
 
     assert expected == toml

--- a/cli/tests/test_utils.py
+++ b/cli/tests/test_utils.py
@@ -85,7 +85,7 @@ def test_import_toml():
         "workspace-secure-server": {
             "oauth-secret": "your_random_secret_key_here",
             "keycloak-admin": "admin",
-            "keycloak-admin-password": "changeme",
+            "keycloak-admin-password": "changeme", # NOSONAR
             "keycloak-realm": "dtaas",
             "keycloak-issuer-url": "https://your_server_dns/auth/realms/dtaas",
             "keycloak-client-id": "dtaas-workspace",


### PR DESCRIPTION
# Copying TLS cert when generate-deployment

## Type of Change

- [X] New feature
- [ ] Bug fix
- [X] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Extended dtaas generate-deployment so secure deployments get their TLS certificates placed automatically.
Only acts for  (secure-server, secure-server-gitlab, workspace-secure-server) deployment.
Copies fullchain.pem / privkey.pem picking the newest.

Added a new key for certs-src under [common.security] in dtaas.toml.

#1643