### PR TITLE
Fix GitHub actions workflows

### DIFF
--- a/.github/workflows/docker-dockerhub.yml
+++ b/.github/workflows/docker-dockerhub.yml
@@ -42,10 +42,6 @@ permissions:
       DOCKERHUB_TOKEN:
         required: true
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   registry: docker.io
   username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker-dockerhub.yml
+++ b/.github/workflows/docker-dockerhub.yml
@@ -42,6 +42,10 @@ permissions:
       DOCKERHUB_TOKEN:
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   registry: docker.io
   username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -18,10 +18,6 @@ name: Build and Push Docker Image (GHCR)
         required: true
         type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   registry: ghcr.io
   password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -18,6 +18,10 @@ name: Build and Push Docker Image (GHCR)
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   registry: ghcr.io
   password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lib-ms.yml
+++ b/.github/workflows/lib-ms.yml
@@ -193,6 +193,7 @@ jobs:
   publish-package-npm:
     permissions:
       contents: read  # Required for checking out the code
+      packages: write  # Required by the publish-npm reusable workflow
     if: |
       github.event_name == 'push' &&
       (

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -19,6 +19,10 @@ name: Test and Publish
       NPM_TOKEN:
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish-package:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -19,10 +19,6 @@ name: Test and Publish
       NPM_TOKEN:
         required: true
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   publish-package:
     runs-on: ubuntu-latest

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -120,6 +120,7 @@ jobs:
   publish-package-npm:
     permissions:
       contents: read  # Required for checking out the code
+      packages: write  # Required by the publish-npm reusable workflow
     if: |
       github.event_name == 'push' &&
       (

--- a/developer/client.built.dockerfile
+++ b/developer/client.built.dockerfile
@@ -1,5 +1,5 @@
 #! docker should be run from the root directory of the project
-FROM node:24.12.0-slim as build
+FROM node:24.12.0-slim AS build
 
 ARG REACT_APP_IS_DOCKER
 ENV REACT_APP_IS_DOCKER=$REACT_APP_IS_DOCKER

--- a/developer/client.dockerfile
+++ b/developer/client.dockerfile
@@ -1,5 +1,5 @@
 #! docker should be run from the root directory of the project
-FROM node:24.12.0-slim as build
+FROM node:24.12.0-slim AS build
 
 # Set the working directory inside the container
 WORKDIR /dtaas/client

--- a/developer/libms.dockerfile
+++ b/developer/libms.dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.12.0-slim as build
+FROM node:24.12.0-slim AS build
 
 #! docker should be run from the root directory of the project
 


### PR DESCRIPTION
## Title

Fix GitHub Actions workflow errors: concurrency deadlock and permission mismatches

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Fixes two classes of GitHub Actions errors on the `feature/distributed-demo` branch, plus a minor Dockerfile warning.

### 1. Concurrency deadlock in reusable workflows (fixes #1650)

`docker-dockerhub.yml`, `docker-ghcr.yml`, and `publish-npm.yml` had concurrency groups keyed on `${{ github.workflow }}`. In a reusable workflow context, that variable resolves to the **calling** workflow's name, so the reusable workflow and its caller competed for the same concurrency lock — causing a deadlock. All Docker and npm publish jobs were cancelled with:

```
Canceling since a deadlock was detected for concurrency group:
'React website-refs/heads/feature/distributed-demo'
```

The `concurrency` block was introduced in commit `f328473e` ("Improve Github actions files #1621"), after which Docker image publishing stopped working.

**Fix:** Add `${{ github.job }}` to the group key in the three reusable workflows. `github.job` resolves to the job name *within* the reusable workflow (e.g. `build-and-push-image`), making the caller's and callee's groups distinct and eliminating the deadlock while preserving `cancel-in-progress` behaviour.

### 2. Missing `packages:write` on `publish-package-npm` jobs (fixes run #27962358162)

The `publish-npm.yml` reusable workflow's job declares `packages: write`. The `publish-package-npm` calling jobs in `lib-ms.yml` and `runner.yml` only had `contents: read`, so GitHub rejected the nested job at startup with:

```
The nested job 'publish-package' is requesting 'packages: write',
but is only allowed 'packages: none'.
```

**Fix:** Add `packages: write` to the `publish-package-npm` jobs in `lib-ms.yml` and `runner.yml`.

### 3. Dockerfile `AS` keyword casing

Fixed `as build` → `AS build` in `client.dockerfile`, `client.built.dockerfile`, and `libms.dockerfile` to eliminate Docker multi-stage build warnings about keyword case mismatch.

## Testing

All permission mismatches were verified programmatically by loading each workflow YAML and comparing the permissions declared in every calling job against what the invoked reusable workflow's jobs request. No mismatches remain after the fix.

Client unit tests (1046) and integration tests (136) pass locally against the current codebase.

## Impact

- Docker images will be published to GHCR and DockerHub again on pushes to `feature/distributed-demo` and `release-v*` branches.
- npm packages (`@into-cps-association/libms`, runner) will publish without startup permission errors.
- No behavioural changes to the workflows beyond fixing the above failures.

## Additional Information

The root cause of issue #1650 was the concurrency group key in reusable workflows (`${{ github.workflow }}`) resolving to the caller's name rather than the reusable workflow's own name. This is a known GitHub Actions subtlety documented at https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-concurrency.
