### PR TITLE
Install and uninstall commands to admin CLI

### DIFF
--- a/cli/DEVELOPER.md
+++ b/cli/DEVELOPER.md
@@ -21,6 +21,13 @@ The CLI is written in Python and uses the following libraries:
   has been wrapped in a function in _cli/src/pkg/utils.py_ file.
   This function should be used directly to read toml files.
 
+- [python-on-whales](https://gabrieldemarmiesse.github.io/python-on-whales/) :
+  Used by the `admin install` / `admin uninstall` commands
+  (_cli/src/pkg/deploy.py_) to drive `docker compose up`/`down`. It wraps the
+  docker CLI (which must be installed on the host) and raises a
+  `python_on_whales.exceptions.DockerException` carrying the real command
+  output (return code and stderr) when a compose operation fails.
+
 - [Poetry Package](https://python-poetry.org/docs/) to manage
   dependencies and build the CLI. The configuration file for this is
   _cli/pyproject.toml_. New source packages and dependencies need to be
@@ -35,7 +42,8 @@ The CLI has two layers of code:
 - Command line definition layer: This is the _src/cmd.py_ file. It
   deals with defining the structure of the CLI, and the specific
   CLI commands itself. The CLI functions in this file call
-  the Package layer functions.
+  the Package layer functions. Non-command helpers shared by the
+  command definitions live alongside it in _src/cmd_utils.py_.
 
 - Package layer: This is the _cli/src/pkg_ directory.
   It contains the
@@ -56,7 +64,7 @@ It has the following sections:
 
 ```toml
 name="Digital Twin as a Service (DTaaS)"
-version="0.6.0"
+version="0.7.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -219,9 +219,11 @@ dtaas admin uninstall --remove-user-files --yes
 
 - `--output-dir` (default: `.`): Installation directory containing the
   generated deployment.
-- `--remove-user-files`: Also delete per-user workspace files. This is opt-in
-  to avoid accidental data loss, and is guarded against deleting paths outside
-  the installation directory.
+- `--remove-user-files`: Also delete per-user workspace files. Opt-in to avoid
+  accidental data loss: it requires a generated deployment in `--output-dir`,
+  prompts for confirmation, deletes only `<output-dir>/files`, and refuses to
+  follow a symlinked `files/`. It does not protect against pointing
+  `--output-dir` at the wrong directory, so double-check the path.
 - `--yes` / `-y`: Skip the confirmation prompt for `--remove-user-files`.
 
 ### 📁 Select Template

--- a/cli/README.md
+++ b/cli/README.md
@@ -162,6 +162,68 @@ It reads the source location from `[common.security].certs-src` in
 `dtaas.toml` and copies the latest `fullchain.pem` and `privkey.pem` into
 `<output-dir>/certs/`.
 
+### 🚀 Install Deployment
+
+Once a deployment has been generated (and `dtaas.toml` configured), bring it up
+with a single command:
+
+```bash
+dtaas admin install
+```
+
+This runs `docker compose up -d` against the generated `docker-compose.yml` in
+the installation directory.
+
+**Options:**
+
+- `--output-dir` (default: `.`): Installation directory containing the
+  generated deployment.
+
+The `docker-compose.yml` must live in `--output-dir`. The CLI looks for
+`dtaas.toml` in `--output-dir` first and, if not found there, falls back to the
+current working directory, so a single top-level `dtaas.toml` can serve a
+deployment generated into a subdirectory (e.g.
+`dtaas admin install --output-dir insecure`).
+
+The command fails with a clear error if the deployment has not been generated
+(`docker-compose.yml` missing), if `dtaas.toml` is missing from both locations,
+or if the Docker daemon is not reachable.
+
+### 🧹 Uninstall Deployment
+
+To tear the deployment down:
+
+```bash
+dtaas admin uninstall
+```
+
+This runs `docker compose down`, stopping and removing the deployment's
+containers and networks. **Per-user workspace files are preserved by default.**
+
+To additionally delete the per-user workspace files (the `files/` directory
+created by `generate-deployment` and `admin user add`), pass
+`--remove-user-files`:
+
+```bash
+dtaas admin uninstall --remove-user-files
+```
+
+Because this is destructive, the command prompts for confirmation. Supply
+`--yes` (or `-y`) to skip the prompt in non-interactive scripts:
+
+```bash
+dtaas admin uninstall --remove-user-files --yes
+```
+
+**Options:**
+
+- `--output-dir` (default: `.`): Installation directory containing the
+  generated deployment.
+- `--remove-user-files`: Also delete per-user workspace files. This is opt-in
+  to avoid accidental data loss, and is guarded against deleting paths outside
+  the installation directory.
+- `--yes` / `-y`: Skip the confirmation prompt for `--remove-user-files`.
+
 ### 📁 Select Template
 
 The _cli_ uses YAML templates provided in this directory to create

--- a/cli/poetry.lock
+++ b/cli/poetry.lock
@@ -18,7 +18,7 @@ version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
@@ -1076,7 +1076,7 @@ version = "2.13.4"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba"},
     {file = "pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6"},
@@ -1098,7 +1098,7 @@ version = "2.46.4"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4"},
     {file = "pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5"},
@@ -1334,6 +1334,22 @@ pytest = ">=7"
 
 [package.extras]
 testing = ["process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "python-on-whales"
+version = "0.81.0"
+description = "A Docker client for Python, designed to be fun and intuitive!"
+optional = false
+python-versions = "<4,>=3.8"
+groups = ["main"]
+files = [
+    {file = "python_on_whales-0.81.0-py3-none-any.whl", hash = "sha256:6d5f81f56d0f95fd311a7cce29a01a1a60841074e4936000dc5f2dc9a7ffafac"},
+    {file = "python_on_whales-0.81.0.tar.gz", hash = "sha256:bb6172014e3fe949f908092748bddf34df758cb92c2c3d0536b75bf236abce1b"},
+]
+
+[package.dependencies]
+pydantic = ">=2.1.dev0,<3"
+typing-extensions = "*"
 
 [[package]]
 name = "pyyaml"
@@ -1822,7 +1838,7 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
@@ -1834,7 +1850,7 @@ version = "0.4.2"
 description = "Runtime typing introspection tools"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
     {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
@@ -1884,4 +1900,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "1ea104e5333487531552cf1d1c82045fe327ca4793b291e7b472ae183210ae7c"
+content-hash = "e595900ae7dfaf8e38056b512efefa988b757d2c9d629f362aa95a1f6369932a"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dtaas"
-version = "0.6.0"
+version = "0.7.0"
 description = "DTaaS CLI"
 authors = ["Astitva Sehgal"]
 license = "INTO-CPS-Association"
@@ -16,6 +16,7 @@ python = "^3.10"
 PyYAML = "^6.0.3"
 click = "^8.4.1"
 tomlkit = "^0.15.0"
+python-on-whales = "^0.81.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.3"

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -1,45 +1,17 @@
 """This file defines all cli entrypoints for DTaaS"""
 
-from pathlib import Path
 import click
-from .pkg import config as configPkg
+from python_on_whales.exceptions import DockerException
 from .pkg import users as userPkg
 from .pkg import project as projectPkg
-from .pkg import certs as certsPkg
-from .pkg import deploy_config as deployConfigPkg
-from .pkg import utils as utilsPkg
+from .pkg import deploy as deployPkg
 from .pkg.project import DEPLOY_TYPES
-
-
-class VerticalChoicesCommand(click.Command):
-    """Format Choice options as a vertical list in help text."""
-
-    def format_help_text(self, ctx, formatter):
-        if self.help:
-            formatter.write_paragraph()
-            with formatter.indentation():
-                formatter.write_text(self.help)
-
-    def format_options(self, ctx, formatter):
-        rows = []
-        for param in self.get_params(ctx):
-            rows.extend(self._param_rows(param, ctx))
-        if rows:
-            with formatter.section("Options"):
-                formatter.write_dl(rows)
-
-    @staticmethod
-    def _param_rows(param, ctx):
-        """Return the help rows for a single param (empty list if hidden)."""
-        rv = param.get_help_record(ctx)
-        if rv is None:
-            return []
-        if not isinstance(param.type, click.Choice):
-            return [rv]
-        prefix = f"{rv[1]}. " if rv[1] else ""
-        rows = [(rv[0], f"{prefix}One of:")]
-        rows.extend(("", choice) for choice in param.type.choices)
-        return rows
+from .cmd_utils import (
+    VerticalChoicesCommand,
+    apply_deploy_config,
+    run_user_command,
+    confirm_remove_user_files,
+)
 
 
 ### Groups
@@ -103,93 +75,15 @@ def generate_deployment(deploy_type, output_dir, force):
         projectPkg.generate_deploy_project(deploy_type, output_dir, force)
     except (ValueError, RuntimeError, OSError) as exc:
         raise click.ClickException(str(exc)) from exc
-    _apply_deploy_config(deploy_type, output_dir, force)
+    apply_deploy_config(deploy_type, output_dir, force)
     projectPkg.set_files_permissions(output_dir)
     click.echo(f"Project files for '{deploy_type}' generated successfully")
-
-
-def _find_toml(output_dir):
-    """Return path to dtaas.toml, checking output_dir first then cwd, or None."""
-    for candidate in [Path(output_dir) / "dtaas.toml", Path("dtaas.toml")]:
-        if candidate.is_file():
-            return candidate
-    return None
-
-
-def _apply_deploy_config(deploy_type, output_dir, force=False):
-    """Read dtaas.toml and substitute values into generated deployment files."""
-    toml_path = _find_toml(output_dir)
-    if toml_path is None:
-        click.echo("Note: dtaas.toml not found; template values not substituted.")
-        return
-    toml_data, err = utilsPkg.import_toml(str(toml_path))
-    if err is not None:
-        raise click.ClickException(f"Error reading dtaas.toml: {err}")
-    _substitute_config(deploy_type, output_dir, toml_data)
-    _create_user_dirs(output_dir, toml_data)
-    _copy_deploy_certs(deploy_type, output_dir, toml_data, force)
-
-
-def _substitute_config(deploy_type, output_dir, toml_data):
-    """Build file specs from toml and substitute them into the generated files."""
-    try:
-        specs = deployConfigPkg.build_file_specs(deploy_type, toml_data)
-        deployConfigPkg.apply_config(output_dir, specs)
-    except (OSError, ValueError, TypeError) as exc:
-        raise click.ClickException(f"Error substituting config values: {exc}") from exc
-    for warning in deployConfigPkg.check_placeholders(output_dir, specs):
-        click.echo(warning)
-
-
-def _certs_src(toml_data):
-    """Resolve [common.security].certs-src from dtaas.toml, or '' if unset."""
-    common = toml_data.get("common", {}) if toml_data else {}
-    security = common.get("security", {}) if isinstance(common, dict) else {}
-    if not isinstance(security, dict):
-        return ""
-    certs_src = security.get("certs-src", "")
-    return certs_src.strip() if isinstance(certs_src, str) else ""
-
-
-def _copy_deploy_certs(deploy_type, output_dir, toml_data, force):
-    """Copy TLS certificates into output_dir/certs for secure deployments."""
-    try:
-        note = certsPkg.copy_certs(
-            deploy_type, output_dir, _certs_src(toml_data), force
-        )
-    except OSError as exc:
-        raise click.ClickException(f"Error copying certificates: {exc}") from exc
-    if note:
-        click.echo(note)
-
-
-def _create_user_dirs(output_dir, toml_data):
-    """Create per-user directories from the [users].add list in dtaas.toml."""
-    users = toml_data.get("users", {}) if toml_data else {}
-    usernames = users.get("add", []) if isinstance(users, dict) else []
-    if not usernames:
-        return
-    try:
-        projectPkg.create_user_dirs(output_dir, usernames)
-    except OSError as exc:
-        raise click.ClickException(f"Error creating user directories: {exc}") from exc
 
 
 @admin.group()
 def user():
     """user management commands"""
     return
-
-
-def _run_user_command(action, success_msg, error_prefix):
-    try:
-        config_obj = configPkg.Config()
-    except RuntimeError as exc:
-        raise click.ClickException(str(exc)) from exc
-    err = action(config_obj)
-    if err is not None:
-        raise click.ClickException(f"{error_prefix}: {err}")
-    click.echo(success_msg)
 
 
 #### user group commands
@@ -199,7 +93,7 @@ def add():
     add a list of users to DTaaS at once\n
     Specify the list in dtaas.toml [users].add\n
     """
-    _run_user_command(
+    run_user_command(
         userPkg.add_users, "Users added successfully", "Error while adding users"
     )
 
@@ -210,6 +104,52 @@ def delete():
     removes the USERNAME user from DTaaS\n
     Specify the users in dtaas.toml [users].delete\n
     """
-    _run_user_command(
+    run_user_command(
         userPkg.delete_user, "User deleted successfully", "Error while deleting users"
     )
+
+
+@admin.command(name="install")
+@click.option(
+    "--output-dir",
+    default=".",
+    show_default=True,
+    help="Installation directory containing the generated deployment.",
+)
+def install(output_dir):
+    """Bring the generated deployment up with 'docker compose up -d'."""
+    try:
+        deployPkg.install(output_dir)
+    except (OSError, DockerException) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo("Deployment installed successfully")
+
+
+@admin.command(name="uninstall")
+@click.option(
+    "--output-dir",
+    default=".",
+    show_default=True,
+    help="Installation directory containing the generated deployment.",
+)
+@click.option(
+    "--remove-user-files",
+    is_flag=True,
+    help="Also delete per-user workspace files (destructive).",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Skip the confirmation prompt for --remove-user-files.",
+)
+def uninstall(output_dir, remove_user_files, yes):
+    """Tear the deployment down with 'docker compose down'."""
+    confirm_remove_user_files(remove_user_files, yes)
+    try:
+        message = deployPkg.uninstall(output_dir, remove_user_files)
+    except (OSError, DockerException) as exc:
+        raise click.ClickException(str(exc)) from exc
+    if message:
+        click.echo(message)
+    click.echo("Deployment uninstalled successfully")

--- a/cli/src/cmd_utils.py
+++ b/cli/src/cmd_utils.py
@@ -1,0 +1,133 @@
+"""Helper functions shared by the DTaaS CLI command definitions in cmd.py.
+
+This module holds everything that is not a Click command itself: the help-text
+formatter, the deployment-config orchestration used by generate-deployment,
+the user-command wrapper, and the destructive-action confirmation prompt.
+"""
+
+from pathlib import Path
+import click
+from .pkg import config as configPkg
+from .pkg import project as projectPkg
+from .pkg import certs as certsPkg
+from .pkg import deploy_config as deployConfigPkg
+from .pkg import utils as utilsPkg
+
+
+class VerticalChoicesCommand(click.Command):
+    """Format Choice options as a vertical list in help text."""
+
+    def format_help_text(self, ctx, formatter):
+        if self.help:
+            formatter.write_paragraph()
+            with formatter.indentation():
+                formatter.write_text(self.help)
+
+    def format_options(self, ctx, formatter):
+        rows = []
+        for param in self.get_params(ctx):
+            rows.extend(self._param_rows(param, ctx))
+        if rows:
+            with formatter.section("Options"):
+                formatter.write_dl(rows)
+
+    @staticmethod
+    def _param_rows(param, ctx):
+        """Return the help rows for a single param (empty list if hidden)."""
+        rv = param.get_help_record(ctx)
+        if rv is None:
+            return []
+        if not isinstance(param.type, click.Choice):
+            return [rv]
+        prefix = f"{rv[1]}. " if rv[1] else ""
+        rows = [(rv[0], f"{prefix}One of:")]
+        rows.extend(("", choice) for choice in param.type.choices)
+        return rows
+
+
+def _find_toml(output_dir):
+    """Return path to dtaas.toml, checking output_dir first then cwd, or None."""
+    for candidate in [Path(output_dir) / "dtaas.toml", Path("dtaas.toml")]:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def apply_deploy_config(deploy_type, output_dir, force=False):
+    """Read dtaas.toml and substitute values into generated deployment files."""
+    toml_path = _find_toml(output_dir)
+    if toml_path is None:
+        click.echo("Note: dtaas.toml not found; template values not substituted.")
+        return
+    toml_data, err = utilsPkg.import_toml(str(toml_path))
+    if err is not None:
+        raise click.ClickException(f"Error reading dtaas.toml: {err}")
+    _substitute_config(deploy_type, output_dir, toml_data)
+    _create_user_dirs(output_dir, toml_data)
+    _copy_deploy_certs(deploy_type, output_dir, toml_data, force)
+
+
+def _substitute_config(deploy_type, output_dir, toml_data):
+    """Build file specs from toml and substitute them into the generated files."""
+    try:
+        specs = deployConfigPkg.build_file_specs(deploy_type, toml_data)
+        deployConfigPkg.apply_config(output_dir, specs)
+    except (OSError, ValueError, TypeError) as exc:
+        raise click.ClickException(f"Error substituting config values: {exc}") from exc
+    for warning in deployConfigPkg.check_placeholders(output_dir, specs):
+        click.echo(warning)
+
+
+def _certs_src(toml_data):
+    """Resolve [common.security].certs-src from dtaas.toml, or '' if unset."""
+    common = toml_data.get("common", {}) if toml_data else {}
+    security = common.get("security", {}) if isinstance(common, dict) else {}
+    if not isinstance(security, dict):
+        return ""
+    certs_src = security.get("certs-src", "")
+    return certs_src.strip() if isinstance(certs_src, str) else ""
+
+
+def _copy_deploy_certs(deploy_type, output_dir, toml_data, force):
+    """Copy TLS certificates into output_dir/certs for secure deployments."""
+    try:
+        note = certsPkg.copy_certs(
+            deploy_type, output_dir, _certs_src(toml_data), force
+        )
+    except OSError as exc:
+        raise click.ClickException(f"Error copying certificates: {exc}") from exc
+    if note:
+        click.echo(note)
+
+
+def _create_user_dirs(output_dir, toml_data):
+    """Create per-user directories from the [users].add list in dtaas.toml."""
+    users = toml_data.get("users", {}) if toml_data else {}
+    usernames = users.get("add", []) if isinstance(users, dict) else []
+    if not usernames:
+        return
+    try:
+        projectPkg.create_user_dirs(output_dir, usernames)
+    except OSError as exc:
+        raise click.ClickException(f"Error creating user directories: {exc}") from exc
+
+
+def run_user_command(action, success_msg, error_prefix):
+    """Run a user-management action against a fresh Config, mapping errors."""
+    try:
+        config_obj = configPkg.Config()
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+    err = action(config_obj)
+    if err is not None:
+        raise click.ClickException(f"{error_prefix}: {err}")
+    click.echo(success_msg)
+
+
+def confirm_remove_user_files(remove_user_files, yes):
+    """Prompt before destructive file removal unless --yes is given."""
+    if remove_user_files and not yes:
+        click.confirm(
+            "This permanently deletes all per-user workspace files. Continue?",
+            abort=True,
+        )

--- a/cli/src/pkg/build.py
+++ b/cli/src/pkg/build.py
@@ -59,5 +59,5 @@ def main() -> int:
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())

--- a/cli/src/pkg/deploy.py
+++ b/cli/src/pkg/deploy.py
@@ -25,6 +25,15 @@ def _toml_present(directory):
     return (Path(directory) / "dtaas.toml").is_file() or Path("dtaas.toml").is_file()
 
 
+def _require_compose_file(directory):
+    """Raise OSError if the generated compose file is missing from *directory*."""
+    if not (Path(directory) / COMPOSE_FILE).is_file():
+        raise OSError(
+            f"No '{COMPOSE_FILE}' found in '{directory}'. "
+            "Run 'dtaas generate-deployment' first."
+        )
+
+
 def _require_deployment(directory):
     """Raise OSError if the generated deployment files are missing.
 
@@ -32,11 +41,7 @@ def _require_deployment(directory):
     *directory* or in the current working directory, matching the lookup used
     by generate-deployment.
     """
-    if not (Path(directory) / COMPOSE_FILE).is_file():
-        raise OSError(
-            f"No '{COMPOSE_FILE}' found in '{directory}'. "
-            "Run 'dtaas generate-deployment' first."
-        )
+    _require_compose_file(directory)
     if not _toml_present(directory):
         raise OSError(
             f"No 'dtaas.toml' found in '{directory}' or the current "
@@ -55,11 +60,11 @@ def install(directory="."):
 
 
 def _check_within_base(files_dir, base):
-    """Raise OSError if *files_dir* is a symlink or resolves outside *base*."""
+    """Reject a symlinked or escaping per-user files directory."""
     if files_dir.is_symlink() or not files_dir.resolve().is_relative_to(base):
         raise OSError(
-            f"Refusing to delete '{USER_FILES_DIR}': it resolves outside "
-            "the installation directory."
+            f"Refusing to delete '{USER_FILES_DIR}': it is a symlink or "
+            "resolves outside the installation directory."
         )
 
 
@@ -88,9 +93,12 @@ def delete_user_files(directory):
 def uninstall(directory=".", remove_user_files=False):
     """Tear the deployment down with 'docker compose down'.
 
-    Returns a message about removed files when *remove_user_files* is set,
-    otherwise None. Raises DockerException if compose itself fails.
+    Requires a generated compose file in *directory* so that teardown and any
+    file removal act only on a real deployment. Returns a message about
+    removed files when *remove_user_files* is set, otherwise None. Raises
+    DockerException if compose itself fails.
     """
+    _require_compose_file(directory)
     _client(directory).compose.down()
     if remove_user_files:
         return delete_user_files(directory)

--- a/cli/src/pkg/deploy.py
+++ b/cli/src/pkg/deploy.py
@@ -1,0 +1,97 @@
+"""Handlers for the 'dtaas admin install and uninstall' commands.
+
+Installation brings the generated deployment up with 'docker compose'.
+Uninstallation tears it down and can optionally remove per-user workspace
+files. Compose is driven through python-on-whales, which wraps the docker
+CLI and raises python_on_whales.exceptions.DockerException carrying the real
+command output (return code and stderr) when a compose operation fails.
+"""
+
+import shutil
+from pathlib import Path
+from python_on_whales import DockerClient
+
+COMPOSE_FILE = "docker-compose.yml"
+USER_FILES_DIR = "files"
+
+
+def _client(directory):
+    """Return a DockerClient bound to the deployment's compose file."""
+    return DockerClient(compose_files=[str(Path(directory) / COMPOSE_FILE)])
+
+
+def _toml_present(directory):
+    """True if dtaas.toml exists in *directory* or the current directory."""
+    return (Path(directory) / "dtaas.toml").is_file() or Path("dtaas.toml").is_file()
+
+
+def _require_deployment(directory):
+    """Raise OSError if the generated deployment files are missing.
+
+    The compose file must live in *directory*; dtaas.toml may live either in
+    *directory* or in the current working directory, matching the lookup used
+    by generate-deployment.
+    """
+    if not (Path(directory) / COMPOSE_FILE).is_file():
+        raise OSError(
+            f"No '{COMPOSE_FILE}' found in '{directory}'. "
+            "Run 'dtaas generate-deployment' first."
+        )
+    if not _toml_present(directory):
+        raise OSError(
+            f"No 'dtaas.toml' found in '{directory}' or the current "
+            "directory. Run 'dtaas generate-project' first."
+        )
+
+
+def install(directory="."):
+    """Bring the generated deployment up with 'docker compose up -d'.
+
+    Raises OSError if the deployment has not been generated, or
+    DockerException (from python-on-whales) if compose itself fails.
+    """
+    _require_deployment(directory)
+    _client(directory).compose.up(detach=True)
+
+
+def _check_within_base(files_dir, base):
+    """Raise OSError if *files_dir* is a symlink or resolves outside *base*."""
+    if files_dir.is_symlink() or not files_dir.resolve().is_relative_to(base):
+        raise OSError(
+            f"Refusing to delete '{USER_FILES_DIR}': it resolves outside "
+            "the installation directory."
+        )
+
+
+def _user_files_dir(directory):
+    """Return the per-user files directory inside *directory*, or None if absent.
+
+    Raises OSError if the directory would escape the installation directory.
+    """
+    base = Path(directory).resolve()
+    files_dir = base / USER_FILES_DIR
+    if not files_dir.exists():
+        return None
+    _check_within_base(files_dir, base)
+    return files_dir
+
+
+def delete_user_files(directory):
+    """Delete the per-user workspace files directory. Return a status message."""
+    files_dir = _user_files_dir(directory)
+    if files_dir is None:
+        return f"No '{USER_FILES_DIR}' directory found; nothing to remove."
+    shutil.rmtree(files_dir)
+    return f"Removed user files at '{files_dir}'."
+
+
+def uninstall(directory=".", remove_user_files=False):
+    """Tear the deployment down with 'docker compose down'.
+
+    Returns a message about removed files when *remove_user_files* is set,
+    otherwise None. Raises DockerException if compose itself fails.
+    """
+    _client(directory).compose.down()
+    if remove_user_files:
+        return delete_user_files(directory)
+    return None

--- a/cli/src/templates/dtaas.toml
+++ b/cli/src/templates/dtaas.toml
@@ -1,7 +1,7 @@
 # This is the config for DTaaS CLI
 
 name="Digital Twin as a Service (DTaaS)"
-version="0.6.0"
+version="0.7.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Shared test fixtures and constants."""
+
+CONF_SERVER_CONTENT = (
+    "rule.libms.action=auth\n"
+    "rule.libms.rule=PathPrefix(`/lib`)\n"
+    "\n"
+    "rule.onlyu1.action=auth\n"
+    "rule.onlyu1.rule=PathPrefix(`/user1`)\n"
+    "rule.onlyu1.whitelist=user1@example.com\n"
+    "\n"
+    "rule.onlyu2.action=auth\n"
+    "rule.onlyu2.rule=PathPrefix(`/user2`)\n"
+    "rule.onlyu2.whitelist=user2@example.com\n"
+)

--- a/cli/tests/dtaas.test.toml
+++ b/cli/tests/dtaas.test.toml
@@ -1,7 +1,7 @@
 # This is the config for DTaaS CLI
 
 name="Digital Twin as a Service (DTaaS)"
-version="0.6.0"
+version="0.7.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 

--- a/cli/tests/test_build.py
+++ b/cli/tests/test_build.py
@@ -5,7 +5,7 @@ import stat
 from pathlib import Path
 
 import pytest
-from src.pkg.build import build, _copy_one, _SOURCES, _DEST_ROOT, _EXCLUDE
+from src.pkg.build import build, main, _copy_one, _SOURCES, _DEST_ROOT, _EXCLUDE
 
 
 def _force_remove(func, path, _excinfo):
@@ -16,8 +16,9 @@ def _force_remove(func, path, _excinfo):
 
 @pytest.fixture(autouse=True, scope="session")
 def built_templates():
+    """Run build() once per session, wiping any stale output directory first."""
     if _DEST_ROOT.exists():
-        shutil.rmtree(_DEST_ROOT, onerror=_force_remove)
+        shutil.rmtree(_DEST_ROOT, onerror=_force_remove)  # pylint: disable=deprecated-argument
     build()
 
 
@@ -61,3 +62,19 @@ def test_copy_one_raises_when_source_missing():
     """_copy_one raises FileNotFoundError when the source directory does not exist."""
     with pytest.raises(FileNotFoundError, match="Source not found"):
         _copy_one("localhost", "nonexistent/path/that/cannot/exist")
+
+
+def test_copy_one_overwrites_existing_dest():
+    """_copy_one removes and recreates the destination when it already exists."""
+    deploy_type = next(iter(_SOURCES))
+    dest = _DEST_ROOT / deploy_type
+    assert dest.exists(), "fixture must have created the dest dir first"
+    _copy_one(deploy_type, _SOURCES[deploy_type])
+    assert dest.is_dir()
+
+
+def test_main_returns_zero(capsys):
+    """main() prints a summary line and returns 0."""
+    result = main()
+    assert result == 0
+    assert str(len(_SOURCES)) in capsys.readouterr().out

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -1,8 +1,10 @@
 """Tests for CLI commands."""
 
 from unittest.mock import patch, MagicMock
+from pathlib import Path
 import pytest
 from click.testing import CliRunner
+from python_on_whales.exceptions import DockerException
 from src.cmd import dtaas
 # pylint: disable=redefined-outer-name
 
@@ -18,7 +20,7 @@ def mock_user_pkg():
     """Mock user package functions and Config to avoid filesystem dependency"""
     with patch("src.cmd.userPkg.add_users") as mock_add, patch(
         "src.cmd.userPkg.delete_user"
-    ) as mock_delete, patch("src.cmd.configPkg.Config") as mock_cfg:
+    ) as mock_delete, patch("src.cmd_utils.configPkg.Config") as mock_cfg:
         mock_cfg.return_value = MagicMock()
         yield {"add": mock_add, "delete": mock_delete, "config": mock_cfg}
 
@@ -66,7 +68,7 @@ def test_generate_project_error(runner):
 def test_generate_deployment_without_config_prints_note(runner):
     """generate-deployment prints a note when dtaas.toml is absent"""
     with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
-        "src.cmd._find_toml", return_value=None
+        "src.cmd_utils._find_toml", return_value=None
     ):
         result = runner.invoke(dtaas, ["generate-deployment", "--type", "localhost"])
 
@@ -76,12 +78,11 @@ def test_generate_deployment_without_config_prints_note(runner):
 
 def test_generate_deployment_malformed_toml_errors(runner):
     """generate-deployment fails when dtaas.toml exists but cannot be parsed"""
-    from pathlib import Path
 
     with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
-        "src.cmd._find_toml", return_value=Path("dtaas.toml")
+        "src.cmd_utils._find_toml", return_value=Path("dtaas.toml")
     ), patch(
-        "src.cmd.utilsPkg.import_toml",
+        "src.cmd_utils.utilsPkg.import_toml",
         return_value=(None, Exception("parse error")),
     ):
         result = runner.invoke(dtaas, ["generate-deployment", "--type", "localhost"])
@@ -114,29 +115,17 @@ def test_generate_deployment_help_lists_choices_vertically(runner):
         assert deploy_type in result.output
 
 
-def test_param_rows_skips_hidden_param():
-    """_param_rows returns no rows for a param with no help record (hidden)."""
-    from src.cmd import VerticalChoicesCommand
-
-    param = MagicMock()
-    param.get_help_record.return_value = None
-
-    rows = VerticalChoicesCommand._param_rows(param, ctx=None)  # pylint: disable=protected-access
-    assert not rows
-
-
 def test_generate_deployment_prints_placeholder_warnings(runner):
     """Warnings from check_placeholders are echoed to the user."""
-    from pathlib import Path
 
     with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
-        "src.cmd._find_toml", return_value=Path("dtaas.toml")
+        "src.cmd_utils._find_toml", return_value=Path("dtaas.toml")
     ), patch(
-        "src.cmd.utilsPkg.import_toml", return_value=({"localhost": {}}, None)
-    ), patch("src.cmd.deployConfigPkg.build_file_specs", return_value=[]), patch(
-        "src.cmd.deployConfigPkg.apply_config"
+        "src.cmd_utils.utilsPkg.import_toml", return_value=({"localhost": {}}, None)
+    ), patch("src.cmd_utils.deployConfigPkg.build_file_specs", return_value=[]), patch(
+        "src.cmd_utils.deployConfigPkg.apply_config"
     ), patch(
-        "src.cmd.deployConfigPkg.check_placeholders",
+        "src.cmd_utils.deployConfigPkg.check_placeholders",
         return_value=["Warning: placeholder FOO left unset"],
     ):
         result = runner.invoke(dtaas, ["generate-deployment", "--type", "localhost"])
@@ -147,14 +136,14 @@ def test_generate_deployment_prints_placeholder_warnings(runner):
 
 def test_generate_deployment_substitution_error(runner):
     """A failure during config substitution is reported as a ClickException."""
-    from pathlib import Path
 
     with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
-        "src.cmd._find_toml", return_value=Path("dtaas.toml")
+        "src.cmd_utils._find_toml", return_value=Path("dtaas.toml")
     ), patch(
-        "src.cmd.utilsPkg.import_toml", return_value=({"localhost": {}}, None)
+        "src.cmd_utils.utilsPkg.import_toml", return_value=({"localhost": {}}, None)
     ), patch(
-        "src.cmd.deployConfigPkg.build_file_specs", side_effect=ValueError("bad spec")
+        "src.cmd_utils.deployConfigPkg.build_file_specs",
+        side_effect=ValueError("bad spec"),
     ):
         result = runner.invoke(dtaas, ["generate-deployment", "--type", "localhost"])
 
@@ -164,59 +153,40 @@ def test_generate_deployment_substitution_error(runner):
 
 def test_generate_deployment_user_dir_error(runner):
     """An OSError while creating user directories surfaces as a ClickException."""
-    from pathlib import Path
 
     with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
-        "src.cmd._find_toml", return_value=Path("dtaas.toml")
+        "src.cmd_utils._find_toml", return_value=Path("dtaas.toml")
     ), patch(
-        "src.cmd.utilsPkg.import_toml",
+        "src.cmd_utils.utilsPkg.import_toml",
         return_value=({"users": {"add": ["alice"]}, "localhost": {}}, None),
-    ), patch("src.cmd.deployConfigPkg.build_file_specs", return_value=[]), patch(
-        "src.cmd.deployConfigPkg.apply_config"
-    ), patch("src.cmd.projectPkg.create_user_dirs", side_effect=OSError("disk full")):
+    ), patch("src.cmd_utils.deployConfigPkg.build_file_specs", return_value=[]), patch(
+        "src.cmd_utils.deployConfigPkg.apply_config"
+    ), patch(
+        "src.cmd_utils.projectPkg.create_user_dirs", side_effect=OSError("disk full")
+    ):
         result = runner.invoke(dtaas, ["generate-deployment", "--type", "localhost"])
 
     assert result.exit_code != 0
     assert "Error creating user directories" in result.output
 
 
-def test_find_toml_prefers_output_dir(tmp_path):
-    """_find_toml returns the output_dir copy when present."""
-    from src.cmd import _find_toml
-
-    toml = tmp_path / "dtaas.toml"
-    toml.write_text("x = 1")
-
-    assert _find_toml(str(tmp_path)) == toml
-
-
-def test_find_toml_returns_none_when_absent(tmp_path, monkeypatch):
-    """_find_toml returns None when no dtaas.toml exists in either location."""
-    from src.cmd import _find_toml
-
-    empty = tmp_path / "empty"
-    empty.mkdir()
-    monkeypatch.chdir(empty)  # cwd has no dtaas.toml either
-
-    assert _find_toml(str(empty)) is None
-
-
 def test_generate_deployment_copies_certs(runner):
     """The certs-src from dtaas.toml is forwarded to certsPkg.copy_certs."""
-    from pathlib import Path
 
     with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
         "src.cmd.projectPkg.set_files_permissions"
-    ), patch("src.cmd._find_toml", return_value=Path("dtaas.toml")), patch(
-        "src.cmd.utilsPkg.import_toml",
+    ), patch("src.cmd_utils._find_toml", return_value=Path("dtaas.toml")), patch(
+        "src.cmd_utils.utilsPkg.import_toml",
         return_value=(
             {"common": {"security": {"certs-src": "/etc/certs"}}, "secure-server": {}},
             None,
         ),
-    ), patch("src.cmd.deployConfigPkg.build_file_specs", return_value=[]), patch(
-        "src.cmd.deployConfigPkg.apply_config"
-    ), patch("src.cmd.deployConfigPkg.check_placeholders", return_value=[]), patch(
-        "src.cmd.certsPkg.copy_certs", return_value="certs copied"
+    ), patch("src.cmd_utils.deployConfigPkg.build_file_specs", return_value=[]), patch(
+        "src.cmd_utils.deployConfigPkg.apply_config"
+    ), patch(
+        "src.cmd_utils.deployConfigPkg.check_placeholders", return_value=[]
+    ), patch(
+        "src.cmd_utils.certsPkg.copy_certs", return_value="certs copied"
     ) as mock_copy:
         result = runner.invoke(
             dtaas, ["generate-deployment", "--type", "secure-server"]
@@ -229,17 +199,18 @@ def test_generate_deployment_copies_certs(runner):
 
 def test_generate_deployment_cert_copy_error(runner):
     """An OSError while copying certificates surfaces as a ClickException."""
-    from pathlib import Path
 
     with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
-        "src.cmd._find_toml", return_value=Path("dtaas.toml")
+        "src.cmd_utils._find_toml", return_value=Path("dtaas.toml")
     ), patch(
-        "src.cmd.utilsPkg.import_toml",
+        "src.cmd_utils.utilsPkg.import_toml",
         return_value=({"common": {"security": {"certs-src": "/etc/certs"}}}, None),
-    ), patch("src.cmd.deployConfigPkg.build_file_specs", return_value=[]), patch(
-        "src.cmd.deployConfigPkg.apply_config"
-    ), patch("src.cmd.deployConfigPkg.check_placeholders", return_value=[]), patch(
-        "src.cmd.certsPkg.copy_certs", side_effect=OSError("permission denied")
+    ), patch("src.cmd_utils.deployConfigPkg.build_file_specs", return_value=[]), patch(
+        "src.cmd_utils.deployConfigPkg.apply_config"
+    ), patch(
+        "src.cmd_utils.deployConfigPkg.check_placeholders", return_value=[]
+    ), patch(
+        "src.cmd_utils.certsPkg.copy_certs", side_effect=OSError("permission denied")
     ):
         result = runner.invoke(
             dtaas, ["generate-deployment", "--type", "secure-server"]
@@ -249,19 +220,94 @@ def test_generate_deployment_cert_copy_error(runner):
     assert "Error copying certificates" in result.output
 
 
-def test_certs_src_handles_missing_section():
-    """_certs_src returns '' when common.security is absent or malformed."""
-    from src.cmd import _certs_src
-
-    assert _certs_src({}) == ""
-    assert _certs_src({"common": {"security": "oops"}}) == ""
-    assert _certs_src({"common": {"security": {"certs-src": " /x "}}}) == "/x"
-
-
 def test_add_users_config_error(runner):
     """add command raises ClickException when Config() fails"""
-    with patch("src.cmd.configPkg.Config", side_effect=RuntimeError("no config")):
+    with patch("src.cmd_utils.configPkg.Config", side_effect=RuntimeError("no config")):
         result = runner.invoke(dtaas, ["admin", "user", "add"])
 
     assert result.exit_code != 0
     assert "no config" in result.output
+
+
+@pytest.fixture
+def mock_deploy_pkg():
+    """Mock the deploy package handlers used by install/uninstall."""
+    with patch("src.cmd.deployPkg.install") as mock_install, patch(
+        "src.cmd.deployPkg.uninstall"
+    ) as mock_uninstall:
+        yield {"install": mock_install, "uninstall": mock_uninstall}
+
+
+def test_admin_install_success(runner, mock_deploy_pkg):
+    """install reports success and forwards the default output dir."""
+    result = runner.invoke(dtaas, ["admin", "install"])
+
+    assert result.exit_code == 0
+    assert "Deployment installed successfully" in result.output
+    mock_deploy_pkg["install"].assert_called_once_with(".")
+
+
+def test_admin_install_error(runner, mock_deploy_pkg):
+    """install converts an OSError into a ClickException."""
+    mock_deploy_pkg["install"].side_effect = OSError("not generated")
+
+    result = runner.invoke(dtaas, ["admin", "install"])
+
+    assert result.exit_code != 0
+    assert "not generated" in result.output
+
+
+def test_admin_install_docker_error(runner, mock_deploy_pkg):
+    """A python-on-whales DockerException surfaces with its real message."""
+    mock_deploy_pkg["install"].side_effect = DockerException(
+        ["docker", "compose", "up", "-d"], 1, stderr=b"Cannot connect to the daemon"
+    )
+
+    result = runner.invoke(dtaas, ["admin", "install"])
+
+    assert result.exit_code != 0
+    assert "Cannot connect to the daemon" in result.output
+
+
+def test_admin_uninstall_success(runner, mock_deploy_pkg):
+    """uninstall reports success and preserves files by default."""
+    mock_deploy_pkg["uninstall"].return_value = None
+
+    result = runner.invoke(dtaas, ["admin", "uninstall"])
+
+    assert result.exit_code == 0
+    assert "Deployment uninstalled successfully" in result.output
+    mock_deploy_pkg["uninstall"].assert_called_once_with(".", False)
+
+
+def test_admin_uninstall_remove_user_files_with_yes(runner, mock_deploy_pkg):
+    """--remove-user-files with --yes skips the prompt and reports removal."""
+    mock_deploy_pkg["uninstall"].return_value = "Removed user files at '/x/files'."
+
+    result = runner.invoke(
+        dtaas, ["admin", "uninstall", "--remove-user-files", "--yes"]
+    )
+
+    assert result.exit_code == 0
+    assert "Removed user files" in result.output
+    mock_deploy_pkg["uninstall"].assert_called_once_with(".", True)
+
+
+def test_admin_uninstall_remove_user_files_aborts(runner, mock_deploy_pkg):
+    """Declining the confirmation prompt aborts before any teardown."""
+    result = runner.invoke(
+        dtaas, ["admin", "uninstall", "--remove-user-files"], input="n\n"
+    )
+
+    assert result.exit_code != 0
+    mock_deploy_pkg["uninstall"].assert_not_called()
+
+
+def test_admin_uninstall_error(runner, mock_deploy_pkg):
+    """uninstall converts an OSError into a ClickException."""
+    mock_deploy_pkg["uninstall"].side_effect = OSError("daemon down")
+
+    result = runner.invoke(dtaas, ["admin", "uninstall"])
+
+    assert result.exit_code != 0
+    assert "daemon down" in result.output

--- a/cli/tests/test_cmd_utils.py
+++ b/cli/tests/test_cmd_utils.py
@@ -1,0 +1,37 @@
+"""Tests for the CLI helper functions in cmd_utils.py."""
+
+from unittest.mock import MagicMock
+from src.cmd_utils import VerticalChoicesCommand, _find_toml, _certs_src
+
+
+def test_param_rows_skips_hidden_param():
+    """_param_rows returns no rows for a param with no help record (hidden)."""
+    param = MagicMock()
+    param.get_help_record.return_value = None
+
+    rows = VerticalChoicesCommand._param_rows(param, ctx=None)  # pylint: disable=protected-access
+    assert not rows
+
+
+def test_find_toml_prefers_output_dir(tmp_path):
+    """_find_toml returns the output_dir copy when present."""
+    toml = tmp_path / "dtaas.toml"
+    toml.write_text("x = 1")
+
+    assert _find_toml(str(tmp_path)) == toml
+
+
+def test_find_toml_returns_none_when_absent(tmp_path, monkeypatch):
+    """_find_toml returns None when no dtaas.toml exists in either location."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.chdir(empty)  # cwd has no dtaas.toml either
+
+    assert _find_toml(str(empty)) is None
+
+
+def test_certs_src_handles_missing_section():
+    """_certs_src returns '' when common.security is absent or malformed."""
+    assert _certs_src({}) == ""
+    assert _certs_src({"common": {"security": "oops"}}) == ""
+    assert _certs_src({"common": {"security": {"certs-src": " /x "}}}) == "/x"

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -57,24 +57,6 @@ def test_config_init_error(mock_utils):
         config.Config()
 
 
-def test_get_config_not_initialized():
-    """Test getConfig when data is None"""
-    cfg = config.Config.__new__(config.Config)
-    cfg.data = None
-    _, err = cfg.get_config()
-    assert err is not None
-
-
-def test_get_from_config_missing_key(mock_utils, mock_toml_data):
-    """Test getFromConfig with missing key"""
-    mock_utils.return_value = (mock_toml_data, None)
-    cfg = config.Config()
-    result, err = cfg.get_from_config("missing_key")
-    assert result is None
-    assert err is not None
-    assert "Missing missing_key tag" in str(err)
-
-
 def test_get_string_from_common_missing_key(mock_utils, mock_toml_data):
     """Test getStringFromCommon with missing key"""
     mock_utils.return_value = (mock_toml_data, None)
@@ -82,24 +64,6 @@ def test_get_string_from_common_missing_key(mock_utils, mock_toml_data):
     result, err = cfg.get_string_from_common("missing_key")
     assert result is None
     assert err is not None
-
-
-def test_get_users_success(mock_utils, mock_toml_data):
-    """Test getUsers retrieves users section"""
-    mock_utils.return_value = (mock_toml_data, None)
-    cfg = config.Config()
-    users, err = cfg.get_users()
-    assert err is None
-    assert users == mock_toml_data["users"]
-
-
-def test_get_string_list_from_users_success(mock_utils, mock_toml_data):
-    """Test getStringListFromUsers retrieves list"""
-    mock_utils.return_value = (mock_toml_data, None)
-    cfg = config.Config()
-    add_list, err = cfg.get_string_list_from_users("add")
-    assert err is None
-    assert add_list == ["user1", "user2"]
 
 
 def test_get_string_list_from_users_missing_key(mock_utils, mock_toml_data):
@@ -195,24 +159,66 @@ def test_get_tls_success_true():
         assert tls is True
 
 
-def test_get_tls_success_false():
-    """Test getTLS retrieves tls flag when set to false"""
-    with patch("src.pkg.config.utils.import_toml") as mock_import:
-        mock_import.return_value = (
-            {"common": {"security": {"tls": False}}},
-            None,
-        )
-        cfg = Config()
-        tls, err = cfg.get_tls()
-        assert err is None
-        assert tls is False
+def test_get_from_config_when_data_is_none():
+    """get_from_config returns error when config is uninitialised."""
+    cfg = Config.__new__(Config)
+    cfg.data = None
+    result, err = cfg.get_from_config("any_key")
+    assert result is None
+    assert err is not None
 
 
-def test_get_tls_default_false():
-    """Test getTLS defaults to false when security section is missing"""
-    with patch("src.pkg.config.utils.import_toml") as mock_import:
-        mock_import.return_value = ({"common": {}}, None)
-        cfg = Config()
-        tls, err = cfg.get_tls()
-        assert err is None
-        assert tls is False
+def test_get_string_from_common_when_no_common_section(mock_utils):
+    """get_string_from_common returns error when 'common' section is absent."""
+    mock_utils.return_value = ({"users": {}}, None)
+    cfg = config.Config()
+    result, err = cfg.get_string_from_common("path")
+    assert result is None
+    assert err is not None
+
+
+def test_get_string_list_from_users_when_no_users_section(mock_utils):
+    """get_string_list_from_users returns error when 'users' section is absent."""
+    mock_utils.return_value = ({"common": {}}, None)
+    cfg = config.Config()
+    result, err = cfg.get_string_list_from_users("add")
+    assert result is None
+    assert err is not None
+
+
+def test_get_string_list_from_users_not_a_list(mock_utils):
+    """get_string_list_from_users returns error when the value is not a list."""
+    mock_utils.return_value = ({"users": {"add": "not-a-list"}}, None)
+    cfg = config.Config()
+    result, err = cfg.get_string_list_from_users("add")
+    assert result is None
+    assert err is not None
+    assert "must be a list" in str(err)
+
+
+def test_get_resource_limits_when_no_common_section(mock_utils):
+    """get_resource_limits returns error when 'common' section is absent."""
+    mock_utils.return_value = ({"users": {}}, None)
+    cfg = config.Config()
+    result, err = cfg.get_resource_limits()
+    assert result is None
+    assert err is not None
+
+
+def test_get_tls_when_no_common_section(mock_utils):
+    """get_tls returns False with error when 'common' section is absent."""
+    mock_utils.return_value = ({"users": {}}, None)
+    cfg = config.Config()
+    tls, err = cfg.get_tls()
+    assert tls is False
+    assert err is not None
+
+
+def test_get_tls_security_not_dict(mock_utils):
+    """get_tls returns False with error when security section is not a dict."""
+    mock_utils.return_value = ({"common": {"security": "not-a-dict"}}, None)
+    cfg = config.Config()
+    tls, err = cfg.get_tls()
+    assert tls is False
+    assert err is not None
+    assert "security section is not a dict" in str(err)

--- a/cli/tests/test_deploy.py
+++ b/cli/tests/test_deploy.py
@@ -1,0 +1,99 @@
+"""Tests for the deploy module (admin install / uninstall handlers)."""
+
+from unittest.mock import patch
+import pytest
+from python_on_whales.exceptions import DockerException
+from src.pkg import deploy
+# pylint: disable=protected-access
+
+
+def test_require_deployment_missing_compose(tmp_path):
+    """_require_deployment fails when the compose file is absent."""
+    with pytest.raises(OSError, match="docker-compose.yml"):
+        deploy._require_deployment(str(tmp_path))
+
+
+def test_require_deployment_missing_toml(tmp_path, monkeypatch):
+    """_require_deployment fails when dtaas.toml is absent from dir and cwd."""
+    (tmp_path / "docker-compose.yml").write_text("services: {}")
+    workdir = tmp_path / "cwd"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)  # no dtaas.toml in the cwd either
+    with pytest.raises(OSError, match="dtaas.toml"):
+        deploy._require_deployment(str(tmp_path))
+
+
+def test_require_deployment_toml_falls_back_to_cwd(tmp_path, monkeypatch):
+    """dtaas.toml in the cwd satisfies the check when absent from output dir."""
+    outdir = tmp_path / "insecure"
+    outdir.mkdir()
+    (outdir / "docker-compose.yml").write_text("services: {}")
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "dtaas.toml").write_text("x = 1")  # toml only in the cwd
+    deploy._require_deployment(str(outdir))  # does not raise
+
+
+def test_install_runs_compose_up(tmp_path):
+    """install validates inputs and runs 'docker compose up' detached."""
+    (tmp_path / "docker-compose.yml").write_text("services: {}")
+    (tmp_path / "dtaas.toml").write_text("x = 1")
+    with patch("src.pkg.deploy._client") as mock_client:
+        deploy.install(str(tmp_path))
+        mock_client.return_value.compose.up.assert_called_once_with(detach=True)
+
+
+def test_install_propagates_docker_exception(tmp_path):
+    """A compose failure surfaces as the real DockerException."""
+    (tmp_path / "docker-compose.yml").write_text("services: {}")
+    (tmp_path / "dtaas.toml").write_text("x = 1")
+    with patch("src.pkg.deploy._client") as mock_client:
+        mock_client.return_value.compose.up.side_effect = DockerException(
+            ["docker", "compose", "up", "-d"], 1, stderr=b"daemon down"
+        )
+        with pytest.raises(DockerException):
+            deploy.install(str(tmp_path))
+
+
+def test_check_within_base_rejects_escape(tmp_path):
+    """A files dir resolving outside the install dir is rejected."""
+    base = tmp_path / "install"
+    base.mkdir()
+    outside = tmp_path / "outside_files"
+    outside.mkdir()
+    with pytest.raises(OSError, match="resolves outside"):
+        deploy._check_within_base(outside, base)
+
+
+def test_user_files_dir_absent(tmp_path):
+    """_user_files_dir returns None when files/ does not exist."""
+    assert deploy._user_files_dir(str(tmp_path)) is None
+
+
+def test_delete_user_files_removes_dir(tmp_path):
+    """delete_user_files removes the files/ directory and reports it."""
+    (tmp_path / "files" / "alice").mkdir(parents=True)
+    message = deploy.delete_user_files(str(tmp_path))
+    assert "Removed user files" in message
+    assert not (tmp_path / "files").exists()
+
+
+def test_delete_user_files_absent(tmp_path):
+    """delete_user_files reports when there is nothing to remove."""
+    assert "nothing to remove" in deploy.delete_user_files(str(tmp_path))
+
+
+def test_uninstall_runs_compose_down(tmp_path):
+    """uninstall runs 'docker compose down' and preserves files by default."""
+    with patch("src.pkg.deploy._client") as mock_client:
+        assert deploy.uninstall(str(tmp_path)) is None
+        mock_client.return_value.compose.down.assert_called_once_with()
+
+
+def test_uninstall_removes_user_files(tmp_path):
+    """uninstall with remove_user_files deletes the files/ directory."""
+    (tmp_path / "files" / "bob").mkdir(parents=True)
+    with patch("src.pkg.deploy._client"):
+        message = deploy.uninstall(str(tmp_path), remove_user_files=True)
+        assert message is not None
+        assert "Removed user files" in message
+        assert not (tmp_path / "files").exists()

--- a/cli/tests/test_deploy.py
+++ b/cli/tests/test_deploy.py
@@ -64,6 +64,21 @@ def test_check_within_base_rejects_escape(tmp_path):
         deploy._check_within_base(outside, base)
 
 
+def test_check_within_base_rejects_symlink(tmp_path):
+    """A symlinked files/ pointing elsewhere is rejected (the primary guard)."""
+    base = tmp_path / "install"
+    base.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = base / "files"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation is not permitted on this platform")
+    with pytest.raises(OSError, match="symlink"):
+        deploy._check_within_base(link, base)
+
+
 def test_user_files_dir_absent(tmp_path):
     """_user_files_dir returns None when files/ does not exist."""
     assert deploy._user_files_dir(str(tmp_path)) is None
@@ -84,13 +99,23 @@ def test_delete_user_files_absent(tmp_path):
 
 def test_uninstall_runs_compose_down(tmp_path):
     """uninstall runs 'docker compose down' and preserves files by default."""
+    (tmp_path / "docker-compose.yml").write_text("services: {}")
     with patch("src.pkg.deploy._client") as mock_client:
         assert deploy.uninstall(str(tmp_path)) is None
         mock_client.return_value.compose.down.assert_called_once_with()
 
 
+def test_uninstall_requires_compose_file(tmp_path):
+    """uninstall refuses to act when no deployment exists in the directory."""
+    with patch("src.pkg.deploy._client") as mock_client:
+        with pytest.raises(OSError, match="docker-compose.yml"):
+            deploy.uninstall(str(tmp_path), remove_user_files=True)
+        mock_client.assert_not_called()
+
+
 def test_uninstall_removes_user_files(tmp_path):
     """uninstall with remove_user_files deletes the files/ directory."""
+    (tmp_path / "docker-compose.yml").write_text("services: {}")
     (tmp_path / "files" / "bob").mkdir(parents=True)
     with patch("src.pkg.deploy._client"):
         message = deploy.uninstall(str(tmp_path), remove_user_files=True)

--- a/cli/tests/test_deploy_config.py
+++ b/cli/tests/test_deploy_config.py
@@ -1,8 +1,9 @@
 """Tests for the deploy_config module."""
 
-import pytest
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 from src.pkg.deploy_config import (
     _set_yaml_value,
     _toml_lookup,

--- a/cli/tests/test_users.py
+++ b/cli/tests/test_users.py
@@ -5,6 +5,7 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch, MagicMock
 import pytest
 from src.pkg import users, users_utils
+from tests.conftest import CONF_SERVER_CONTENT
 # pylint: disable=redefined-outer-name,unused-argument
 
 
@@ -190,20 +191,6 @@ def test_delete_user_skips_nonexistent(
     captured = capsys.readouterr()
     assert "'ghost' does not exist, skipping deletion" in captured.out
     mock_user_operations["stop"].assert_called_once_with(["user1"])
-
-
-CONF_SERVER_CONTENT = (
-    "rule.libms.action=auth\n"
-    "rule.libms.rule=PathPrefix(`/lib`)\n"
-    "\n"
-    "rule.onlyu1.action=auth\n"
-    "rule.onlyu1.rule=PathPrefix(`/user1`)\n"
-    "rule.onlyu1.whitelist=user1@example.com\n"
-    "\n"
-    "rule.onlyu2.action=auth\n"
-    "rule.onlyu2.rule=PathPrefix(`/user2`)\n"
-    "rule.onlyu2.whitelist=user2@example.com\n"
-)
 
 
 def test_delete_user_removes_conf_server_rules(

--- a/cli/tests/test_users_utils.py
+++ b/cli/tests/test_users_utils.py
@@ -7,19 +7,7 @@ from src.pkg.users_utils import (
     add_conf_server_entry,
     remove_conf_server_entry,
 )
-
-CONF_SERVER_CONTENT = (
-    "rule.libms.action=auth\n"
-    "rule.libms.rule=PathPrefix(`/lib`)\n"
-    "\n"
-    "rule.onlyu1.action=auth\n"
-    "rule.onlyu1.rule=PathPrefix(`/user1`)\n"
-    "rule.onlyu1.whitelist=user1@example.com\n"
-    "\n"
-    "rule.onlyu2.action=auth\n"
-    "rule.onlyu2.rule=PathPrefix(`/user2`)\n"
-    "rule.onlyu2.whitelist=user2@example.com\n"
-)
+from tests.conftest import CONF_SERVER_CONTENT
 
 
 def test_next_rule_num_increments_max():

--- a/cli/tests/test_utils.py
+++ b/cli/tests/test_utils.py
@@ -27,7 +27,7 @@ def test_import_toml():
 
     expected = {
         "name": "Digital Twin as a Service (DTaaS)",
-        "version": "0.6.0",
+        "version": "0.7.0",
         "owner": "The INTO-CPS-Association",
         "git-repo": "https://github.com/into-cps-association/DTaaS.git",
         "common": {
@@ -85,7 +85,7 @@ def test_import_toml():
         "workspace-secure-server": {
             "oauth-secret": "your_random_secret_key_here",
             "keycloak-admin": "admin",
-            "keycloak-admin-password": "changeme", # NOSONAR
+            "keycloak-admin-password": "changeme",  # NOSONAR
             "keycloak-realm": "dtaas",
             "keycloak-issuer-url": "https://your_server_dns/auth/realms/dtaas",
             "keycloak-client-id": "dtaas-workspace",


### PR DESCRIPTION
# Add dtaas admin install / dtaas admin uninstall
#1641 
## Type of Change

- [X] New feature
- [X] Documentation update
- [X] Refactoring


## Description

Adds two deployment-lifecycle commands so operators can bring a generated DTaaS deployment up and tear it down with a single command, instead of running Docker Compose and cleanup steps by hand.

### Commands
`dtaas admin install` runs docker `compose up -d` against the generated docker-compose.yml.
Fails cleanly if the deployment hasn't been generated (no docker-compose.yml), if dtaas.toml is missing, or if Docker is unreachable.

`dtaas admin uninstall`  runs `docker compose down` (removes containers + networks). 
User workspace files are preserved by default. `--remove-user-files` additionally deletes the per-user files/ directory, and needs a confirmation prompt. 

Removal is guarded against symlink/traversal escapes outside the installation directory.