### PR TITLE
Fix publish priorities in GitHub actions

### DIFF
--- a/.github/workflows/docker-dockerhub.yml
+++ b/.github/workflows/docker-dockerhub.yml
@@ -43,7 +43,7 @@ permissions:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.image-name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-docker-dockerhub-${{ inputs.image-name }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -19,7 +19,7 @@ name: Build and Push Docker Image (GHCR)
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.image-name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-docker-ghcr-${{ inputs.image-name }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/lint-scripts.yml
+++ b/.github/workflows/lint-scripts.yml
@@ -17,7 +17,7 @@ name: Lint Miscellaneous Scripts
       - '**.yml'
       - '**.yaml'
       - '.shellcheckrc'
-      - '.yamllint'
+      - '.yamllint.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -50,9 +50,11 @@ jobs:
 
       - name: Rename package name in package.json
         if: ${{ inputs.package-name != '' }}
+        env:
+          PACKAGE_NAME: ${{ inputs.package-name }}
         run: |
           sudo apt-get install -y jq
-          jq '.name = "${{inputs.package-name}}"' package.json > temp.json
+          jq --arg name "$PACKAGE_NAME" '.name = $name' package.json > temp.json
           mv temp.json package.json
 
       - name: Publish npm package


### PR DESCRIPTION
## Summary

Completes the GitHub Actions fixes started in #1659. Two of the three reported
failures are caused by a concurrency-group collision; the third is a token
configuration issue that **cannot** be fixed in a workflow file (details below).

### 1 & 2 — Cancelled jobs (concurrency collision) — FIXED

> `Canceling since a higher priority waiting request for React website-dtaas-web-refs/heads/feature/distributed-demo exists`

After #1659, `docker-ghcr.yml` and `docker-dockerhub.yml` both used the
concurrency group `${{ github.workflow }}-${{ inputs.image-name }}-${{ github.ref }}`.
When a parent workflow (e.g. `client.yml`, named **React website**) calls *both*
reusable workflows with the **same** `image-name` (`dtaas-web`), both groups
resolve to the identical string
`React website-dtaas-web-refs/heads/feature/distributed-demo`, so the two jobs
cancel each other. The same collision exists on the `lib-ms.yml` path (`libms`).

**Fix:** add a registry-specific literal to each group so they are distinct:
- `docker-ghcr.yml`  → `…-docker-ghcr-${{ inputs.image-name }}-…`
- `docker-dockerhub.yml` → `…-docker-dockerhub-${{ inputs.image-name }}-…`

`cancel-in-progress` is preserved so a newer push still supersedes an older
in-progress publish of the *same* image to the *same* registry.

### 3 — npm publish "2FA / bypass token required" — NOT fixable here

> `Two-factor authentication or granular access token with bypass 2fa enabled is required to publish packages.`

This is **not** a workflow bug. The error means npm received and recognised the
token, but the token lacks *bypass-2fa* capability. It is independent of the
package manager — `yarn publish` and `npm publish` behave identically here
(confirmed by [npm/cli#9268](https://github.com/npm/cli/issues/9268) and
[npm/cli#8869](https://github.com/npm/cli/issues/8869)). npm now requires a
bypass-capable token for non-interactive publishing **even when the account has
no 2FA enabled**. `yarn publish` is therefore retained (no change in behaviour).

### Extra hardening

`publish-npm.yml`: the package-name input is now passed via an env var and applied
with `jq --arg` instead of being interpolated directly into the shell command
(defence-in-depth; `package-name` is a maintainer-only repo variable so this is
not an exploitable vulnerability).

## Validation note

TODO

🤖 Generated with [Claude Code](https://claude.com/claude-code)