### PR TITLE
TLS Certs Update

### DIFF
--- a/cli/DEVELOPER.md
+++ b/cli/DEVELOPER.md
@@ -64,7 +64,7 @@ It has the following sections:
 
 ```toml
 name="Digital Twin as a Service (DTaaS)"
-version="0.7.0"
+version="0.8.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -226,6 +226,45 @@ dtaas admin uninstall --remove-user-files --yes
   `--output-dir` at the wrong directory, so double-check the path.
 - `--yes` / `-y`: Skip the confirmation prompt for `--remove-user-files`.
 
+### 🔁 Update TLS Certificates
+
+To rotate the TLS certificates of a running deployment in place, without
+regenerating the project or copying files by hand:
+
+```bash
+dtaas admin update --certs
+```
+
+This reads the certificate source from `[common.security].certs-src` in
+`dtaas.toml` (the same key used to seed `certs/` during
+`generate-deployment`), picks the newest `fullchain.pem` and `privkey.pem`
+there, and then:
+
+1. **Validates** the new pair before anything is replaced — it must be
+   parseable, the private key must match the certificate, and the certificate
+   must not already be expired.
+2. **Swaps** the validated files into `<output-dir>/certs/` atomically, so the
+   deployment is never left with a half-updated (mismatched) pair.
+3. **Restricts** the private key to `0600` (a no-op on Windows).
+4. **Reloads** the `traefik` service (`docker compose up -d --force-recreate
+   traefik`) so the new certificates take effect.
+
+If validation fails, the live certificates are left untouched and a clear
+error is raised. The command is safe to run repeatedly.
+
+**Options:**
+
+- `--certs`: Refresh the deployment's TLS certificates. Required; it is the
+  only update target today, and the `update` group leaves room for future ones.
+- `--output-dir` (default: `.`): Installation directory containing the
+  generated deployment (the `docker-compose.yml` and `certs/`). The CLI looks
+  for `dtaas.toml` here first, then in the current directory.
+
+The command fails with a clear error if the deployment has not been generated
+(`docker-compose.yml` missing), if `certs-src` is unset or missing, if either
+certificate is absent from `certs-src`, or if the Docker daemon is not
+reachable.
+
 ### 📁 Select Template
 
 The _cli_ uses YAML templates provided in this directory to create

--- a/cli/README.md
+++ b/cli/README.md
@@ -174,6 +174,12 @@ dtaas admin install
 This runs `docker compose up -d` against the generated `docker-compose.yml` in
 the installation directory.
 
+Before starting the stack, the command ensures the per-user workspace
+directories listed in `[users].add` exist — recreating each from
+`files/template` if missing — and sets their ownership to `1000:100`. This
+means a fresh install, or a reinstall after `uninstall --remove-user-files`,
+does not leave Docker to auto-create empty, root-owned mount directories.
+
 **Options:**
 
 - `--output-dir` (default: `.`): Installation directory containing the
@@ -198,10 +204,13 @@ dtaas admin uninstall
 ```
 
 This runs `docker compose down`, stopping and removing the deployment's
-containers and networks. **Per-user workspace files are preserved by default.**
+containers and networks. Containers added with `admin user add` run as a
+separate Compose project, so they are torn down first; otherwise they would
+survive and hold the shared network open. If nothing is currently installed,
+the command reports that there is no existing installation rather than claiming
+a successful teardown. **Per-user workspace files are preserved by default.**
 
-To additionally delete the per-user workspace files (the `files/` directory
-created by `generate-deployment` and `admin user add`), pass
+To additionally delete the generated per-user workspace directories, pass
 `--remove-user-files`:
 
 ```bash
@@ -219,11 +228,14 @@ dtaas admin uninstall --remove-user-files --yes
 
 - `--output-dir` (default: `.`): Installation directory containing the
   generated deployment.
-- `--remove-user-files`: Also delete per-user workspace files. Opt-in to avoid
-  accidental data loss: it requires a generated deployment in `--output-dir`,
-  prompts for confirmation, deletes only `<output-dir>/files`, and refuses to
-  follow a symlinked `files/`. It does not protect against pointing
-  `--output-dir` at the wrong directory, so double-check the path.
+- `--remove-user-files`: Also delete the generated per-user workspace
+  directories. Opt-in to avoid accidental data loss: it requires a generated
+  deployment in `--output-dir`, prompts for confirmation, and refuses to follow
+  a symlinked `files/`. It removes only the per-user directories inside
+  `<output-dir>/files`, keeping the shared `files/common` and the
+  `files/template` skeleton so a later `admin install` can recreate the user
+  directories. It does not protect against pointing `--output-dir` at the wrong
+  directory, so double-check the path.
 - `--yes` / `-y`: Skip the confirmation prompt for `--remove-user-files`.
 
 ### 🔁 Update TLS Certificates

--- a/cli/README.md
+++ b/cli/README.md
@@ -241,13 +241,17 @@ This reads the certificate source from `[common.security].certs-src` in
 there, and then:
 
 1. **Validates** the new pair before anything is replaced — it must be
-   parseable, the private key must match the certificate, and the certificate
-   must not already be expired.
-2. **Swaps** the validated files into `<output-dir>/certs/` atomically, so the
-   deployment is never left with a half-updated (mismatched) pair.
-3. **Restricts** the private key to `0600` (a no-op on Windows).
-4. **Reloads** the `traefik` service (`docker compose up -d --force-recreate
-   traefik`) so the new certificates take effect.
+   parseable, the private key must match the certificate, and neither the leaf
+   nor any intermediate in the chain may already be expired.
+2. **Stops** the `traefik` service so nothing holds the certificate files open
+   while they are replaced.
+3. **Swaps** the validated files into `<output-dir>/certs/`, backing up the
+   live pair first and restoring it on any failure, so the deployment is never
+   left with a half-updated (mismatched) pair.
+4. **Restricts** the private key to `0600` on POSIX hosts; on Windows it prints
+   a warning instead, because file permissions cannot be enforced there.
+5. **Restarts** `traefik` and waits for it to come back up, so certificates the
+   proxy rejects are reported as a failure rather than a false success.
 
 If validation fails, the live certificates are left untouched and a clear
 error is raised. The command is safe to run repeatedly.
@@ -258,12 +262,15 @@ error is raised. The command is safe to run repeatedly.
   only update target today, and the `update` group leaves room for future ones.
 - `--output-dir` (default: `.`): Installation directory containing the
   generated deployment (the `docker-compose.yml` and `certs/`). The CLI looks
-  for `dtaas.toml` here first, then in the current directory.
+  for `dtaas.toml` here first, then in the current directory. Keep
+  `dtaas.toml` inside `--output-dir`: if it is absent there, `certs-src` is read
+  from the `dtaas.toml` in the directory you run the command from, which may
+  belong to a different deployment.
 
 The command fails with a clear error if the deployment has not been generated
 (`docker-compose.yml` missing), if `certs-src` is unset or missing, if either
-certificate is absent from `certs-src`, or if the Docker daemon is not
-reachable.
+certificate is absent from `certs-src`, if the Docker daemon is not reachable,
+or if `traefik` does not come back up after the swap.
 
 ### 📁 Select Template
 

--- a/cli/poetry.lock
+++ b/cli/poetry.lock
@@ -244,154 +244,15 @@ files = [
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
 
 [[package]]
-name = "charset-normalizer"
-version = "3.4.7"
-description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943"},
-    {file = "charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00"},
-    {file = "charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6"},
-    {file = "charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110"},
-    {file = "charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c"},
-    {file = "charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e5f4d355f0a2b1a31bc3edec6795b46324349c9cb25eed068049e4f472fb4259"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16d971e29578a5e97d7117866d15889a4a07befe0e87e703ed63cd90cb348c01"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dca4bbc466a95ba9c0234ef56d7dd9509f63da22274589ebd4ed7f1f4d4c54e3"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e80c8378d8f3d83cd3164da1ad2df9e37a666cdde7b1cb2298ed0b558064be30"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36836d6ff945a00b88ba1e4572d721e60b5b8c98c155d465f56ad19d68f23734"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux_2_31_armv7l.whl", hash = "sha256:bd9b23791fe793e4968dba0c447e12f78e425c59fc0e3b97f6450f4781f3ee60"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aef65cd602a6d0e0ff6f9930fcb1c8fec60dd2cfcb6facaf4bdb0e5873042db0"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:82b271f5137d07749f7bf32f70b17ab6eaabedd297e75dce75081a24f76eb545"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_armv7l.whl", hash = "sha256:1efde3cae86c8c273f1eb3b287be7d8499420cf2fe7585c41d370d3e790054a5"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:c593052c465475e64bbfe5dbd81680f64a67fdc752c56d7a0ae205dc8aeefe0f"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_riscv64.whl", hash = "sha256:af21eb4409a119e365397b2adbaca4c9ccab56543a65d5dbd9f920d6ac29f686"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:84c018e49c3bf790f9c2771c45e9313a08c2c2a6342b162cd650258b57817706"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:dd915403e231e6b1809fe9b6d9fc55cf8fb5e02765ac625d9cd623342a7905d7"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-win32.whl", hash = "sha256:320ade88cfb846b8cd6b4ddf5ee9e80ee0c1f52401f2456b84ae1ae6a1a5f207"},
-    {file = "charset_normalizer-3.4.7-cp38-cp38-win_amd64.whl", hash = "sha256:1dc8b0ea451d6e69735094606991f32867807881400f808a106ee1d963c46a83"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:177a0ba5f0211d488e295aaf82707237e331c24788d8d76c96c5a41594723217"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e0d51f618228538a3e8f46bd246f87a6cd030565e015803691603f55e12afb5"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:14265bfe1f09498b9d8ec91e9ec9fa52775edf90fcbde092b25f4a33d444fea9"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:87fad7d9ba98c86bcb41b2dc8dbb326619be2562af1f8ff50776a39e55721c5a"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f22dec1690b584cea26fade98b2435c132c1b5f68e39f5a0b7627cd7ae31f1dc"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:d61f00a0869d77422d9b2aba989e2d24afa6ffd552af442e0e58de4f35ea6d00"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6370e8686f662e6a3941ee48ed4742317cafbe5707e36406e9df792cdb535776"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a6c5863edfbe888d9eff9c8b8087354e27618d9da76425c119293f11712a6319"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:ed065083d0898c9d5b4bbec7b026fd755ff7454e6e8b73a67f8c744b13986e24"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:2cd4a60d0e2fb04537162c62bbbb4182f53541fe0ede35cdf270a1c1e723cc42"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:813c0e0132266c08eb87469a642cb30aaff57c5f426255419572aaeceeaa7bf4"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:07d9e39b01743c3717745f4c530a6349eadbfa043c7577eef86c502c15df2c67"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c0f081d69a6e58272819b70288d3221a6ee64b98df852631c80f293514d3b274"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-win32.whl", hash = "sha256:8751d2787c9131302398b11e6c8068053dcb55d5a8964e114b6e196cf16cb366"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-win_amd64.whl", hash = "sha256:12a6fff75f6bc66711b73a2f0addfc4c8c15a20e805146a02d147a318962c444"},
-    {file = "charset_normalizer-3.4.7-cp39-cp39-win_arm64.whl", hash = "sha256:bb8cc7534f51d9a017b93e3e85b260924f909601c3df002bcdb58ddb4dc41a5c"},
-    {file = "charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"},
-    {file = "charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5"},
-]
-
-[[package]]
 name = "click"
-version = "8.4.1"
+version = "8.4.2"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2"},
-    {file = "click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96"},
+    {file = "click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"},
+    {file = "click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"},
 ]
 
 [package.dependencies]
@@ -534,61 +395,58 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "cryptography"
-version = "48.0.0"
+version = "49.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5"},
-    {file = "cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321"},
-    {file = "cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74"},
-    {file = "cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4"},
-    {file = "cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7"},
-    {file = "cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057"},
-    {file = "cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae"},
-    {file = "cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c"},
-    {file = "cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f"},
-    {file = "cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12"},
-    {file = "cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239"},
-    {file = "cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c"},
-    {file = "cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4"},
-    {file = "cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd"},
-    {file = "cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a"},
-    {file = "cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920"},
+    {file = "cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9"},
+    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f"},
+    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459"},
+    {file = "cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e"},
+    {file = "cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8"},
+    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3"},
+    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27"},
+    {file = "cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61"},
+    {file = "cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36"},
+    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e"},
+    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b"},
+    {file = "cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6"},
+    {file = "cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493"},
 ]
 
 [package.dependencies]
@@ -1242,14 +1100,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylint"
-version = "4.0.5"
+version = "4.0.6"
 description = "python code static checker"
 optional = false
 python-versions = ">=3.10.0"
 groups = ["dev"]
 files = [
-    {file = "pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2"},
-    {file = "pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c"},
+    {file = "pylint-4.0.6-py3-none-any.whl", hash = "sha256:d11a0e1fdb7b1cd46ec5d6fc78fee8b95f28695b2d6140e5809925f61e32ea54"},
+    {file = "pylint-4.0.6.tar.gz", hash = "sha256:52f19191bee08bf103f9705ad1a0ece4aa5a0a4ef2bdcbd969375a1e6f6579d5"},
 ]
 
 [package.dependencies]
@@ -1272,14 +1130,14 @@ testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pyright"
-version = "1.1.410"
+version = "1.1.411"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c"},
-    {file = "pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488"},
+    {file = "pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9"},
+    {file = "pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998"},
 ]
 
 [package.dependencies]
@@ -1293,14 +1151,14 @@ nodejs = ["nodejs-wheel-binaries"]
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
-    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
+    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
+    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
 ]
 
 [package.dependencies]
@@ -1559,28 +1417,6 @@ files = [
 ]
 
 [[package]]
-name = "requests"
-version = "2.34.2"
-description = "Python HTTP for Humans."
-optional = false
-python-versions = ">=3.10"
-groups = ["dev"]
-files = [
-    {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
-    {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
-]
-
-[package.dependencies]
-certifi = ">=2023.5.7"
-charset_normalizer = ">=2,<4"
-idna = ">=2.5,<4"
-urllib3 = ">=1.26,<3"
-
-[package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
-
-[[package]]
 name = "rich"
 version = "15.0.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
@@ -1619,18 +1455,19 @@ oldlibyaml = ["ruamel.yaml.clib ; platform_python_implementation == \"CPython\""
 
 [[package]]
 name = "safety"
-version = "3.7.0"
+version = "3.8.1"
 description = "Scan dependencies for known vulnerabilities and licenses."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "safety-3.7.0-py3-none-any.whl", hash = "sha256:65e71db45eb832e8840e3456333d44c23927423753d5610596a09e909a66d2bf"},
-    {file = "safety-3.7.0.tar.gz", hash = "sha256:daec15a393cafc32b846b7ef93f9c952a1708863e242341ab5bde2e4beabb54e"},
+    {file = "safety-3.8.1-py3-none-any.whl", hash = "sha256:953c1c3c60c873f53a6cc250b2a9c4b38bb6ef45f0625990e43f20bff916c965"},
+    {file = "safety-3.8.1.tar.gz", hash = "sha256:e646123b976bbb6707cfaacae8c926e2f886b744a60e0f410e8610a3a4eaf7be"},
 ]
 
 [package.dependencies]
 authlib = ">=1.2.0"
+certifi = "*"
 click = ">=8.0.2"
 dparse = ">=0.6.4"
 filelock = ">=3.16.1,<4.0"
@@ -1640,13 +1477,13 @@ marshmallow = ">=3.15.0"
 nltk = ">=3.9"
 packaging = ">=21.0"
 pydantic = ">=2.6.0"
-requests = "*"
 ruamel-yaml = ">=0.17.21"
 safety-schemas = "0.0.16"
 tenacity = ">=8.1.0"
 tomli = {version = "*", markers = "python_version < \"3.11\""}
 tomlkit = "*"
-typer = ">=0.16.0"
+truststore = {version = ">=0.10.4", markers = "python_version >= \"3.10\""}
+typer = ">=0.16.0,<0.26.0"
 typing-extensions = ">=4.7.1"
 
 [package.extras]
@@ -1815,6 +1652,18 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+description = "Verify certificates using native system trust stores"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"},
+    {file = "truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"},
+]
+
+[[package]]
 name = "typer"
 version = "0.25.1"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -1860,24 +1709,6 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
-name = "urllib3"
-version = "2.7.0"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
-optional = false
-python-versions = ">=3.10"
-groups = ["dev"]
-files = [
-    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
-    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
-]
-
-[package.extras]
-brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
-h2 = ["h2 (>=4,<5)"]
-socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
-
-[[package]]
 name = "zipp"
 version = "4.1.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -1900,4 +1731,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "327835b6acc2f75d8a2e3ac682569d6143384cfe0bd374c35b8b827edeff0591"
+content-hash = "caf7ca8f589feb3b7511641b0847381988ae70d8368fe43962912b23279b0893"

--- a/cli/poetry.lock
+++ b/cli/poetry.lock
@@ -151,7 +151,7 @@ version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "platform_python_implementation != \"PyPy\""
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
@@ -538,7 +538,7 @@ version = "48.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6"},
     {file = "cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c"},
@@ -1063,7 +1063,7 @@ version = "3.0"
 description = "C parser in Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
@@ -1900,4 +1900,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "e595900ae7dfaf8e38056b512efefa988b757d2c9d629f362aa95a1f6369932a"
+content-hash = "327835b6acc2f75d8a2e3ac682569d6143384cfe0bd374c35b8b827edeff0591"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dtaas"
-version = "0.7.0"
+version = "0.8.0"
 description = "DTaaS CLI"
 authors = ["Astitva Sehgal"]
 license = "INTO-CPS-Association"
@@ -17,6 +17,7 @@ PyYAML = "^6.0.3"
 click = "^8.4.1"
 tomlkit = "^0.15.0"
 python-on-whales = "^0.81.0"
+cryptography = "^48.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.3"
@@ -28,7 +29,6 @@ safety = "^3.7.0"
 pyright = "^1.1.410"
 nltk = "^3.9.4"
 authlib = "^1.7.2"
-cryptography = "^48.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "setuptools>=80.0.0"]

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -14,19 +14,19 @@ include = [
 [tool.poetry.dependencies]
 python = "^3.10"
 PyYAML = "^6.0.3"
-click = "^8.4.1"
+click = "^8.4.2"
 tomlkit = "^0.15.0"
 python-on-whales = "^0.81.0"
-cryptography = "^48.0.0"
+cryptography = "^49.0.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^9.0.3"
-pylint = "^4.0.5"
+pytest = "^9.1.1"
+pylint = "^4.0.6"
 pytest-cov = "^7.1.0"
 setuptools = "^82.0.1"
 zipp = "^4.1.0"
-safety = "^3.7.0"
-pyright = "^1.1.410"
+safety = "^3.8.1"
+pyright = "^1.1.411"
 nltk = "^3.9.4"
 authlib = "^1.7.2"
 

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -5,6 +5,8 @@ from python_on_whales.exceptions import DockerException
 from .pkg import users as userPkg
 from .pkg import project as projectPkg
 from .pkg import deploy as deployPkg
+from .pkg import cert_update as certUpdatePkg
+from .pkg.cert_validate import CertValidationError
 from .pkg.project import DEPLOY_TYPES
 from .cmd_utils import (
     VerticalChoicesCommand,
@@ -153,3 +155,30 @@ def uninstall(output_dir, remove_user_files, yes):
     if message:
         click.echo(message)
     click.echo("Deployment uninstalled successfully")
+
+
+@admin.command(name="update")
+@click.option(
+    "--certs",
+    is_flag=True,
+    help="Refresh the deployment's TLS certificates in place.",
+)
+@click.option(
+    "--output-dir",
+    default=".",
+    show_default=True,
+    help="Installation directory containing the generated deployment.",
+)
+def update(certs, output_dir):
+    """Update deployment assets in place.
+
+    Currently supports --certs, which validates the newest certificate pair
+    from certs-src and atomically swaps it in before reloading traefik.
+    """
+    if not certs:
+        raise click.ClickException("Nothing to update; pass --certs.")
+    try:
+        message = certUpdatePkg.update_certs(output_dir)
+    except (CertValidationError, OSError, DockerException) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(message)

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -173,12 +173,12 @@ def update(certs, output_dir):
     """Update deployment assets in place.
 
     Currently supports --certs, which validates the newest certificate pair
-    from certs-src and atomically swaps it in before reloading traefik.
+    from certs-src and swaps it in before reloading traefik.
     """
     if not certs:
         raise click.ClickException("Nothing to update; pass --certs.")
     try:
         message = certUpdatePkg.update_certs(output_dir)
-    except (CertValidationError, OSError, DockerException) as exc:
+    except (CertValidationError, OSError, DockerException, RuntimeError) as exc:
         raise click.ClickException(str(exc)) from exc
     click.echo(message)

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -11,9 +11,12 @@ from .pkg.project import DEPLOY_TYPES
 from .cmd_utils import (
     VerticalChoicesCommand,
     apply_deploy_config,
+    provision_user_files,
     run_user_command,
     confirm_remove_user_files,
 )
+
+NO_INSTALLATION_MESSAGE = "There is no existing DTaaS / Workspace installation"
 
 
 ### Groups
@@ -121,6 +124,7 @@ def delete():
 def install(output_dir):
     """Bring the generated deployment up with 'docker compose up -d'."""
     try:
+        provision_user_files(output_dir)
         deployPkg.install(output_dir)
     except (OSError, DockerException) as exc:
         raise click.ClickException(str(exc)) from exc
@@ -147,8 +151,11 @@ def install(output_dir):
 )
 def uninstall(output_dir, remove_user_files, yes):
     """Tear the deployment down with 'docker compose down'."""
-    confirm_remove_user_files(remove_user_files, yes)
     try:
+        if not deployPkg.installation_present(output_dir):
+            click.echo(NO_INSTALLATION_MESSAGE)
+            return
+        confirm_remove_user_files(remove_user_files, yes)
         message = deployPkg.uninstall(output_dir, remove_user_files)
     except (OSError, DockerException) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/cli/src/cmd_utils.py
+++ b/cli/src/cmd_utils.py
@@ -103,6 +103,18 @@ def _create_user_dirs(output_dir, toml_data):
         raise click.ClickException(f"Error creating user directories: {exc}") from exc
 
 
+def provision_user_files(output_dir):
+    """Ensure per-user workspace directories exist and are owned 1000:100."""
+    toml_path = _find_toml(output_dir)
+    if toml_path is None:
+        return
+    toml_data, err = utilsPkg.import_toml(str(toml_path))
+    if err is not None:
+        raise click.ClickException(f"Error reading dtaas.toml: {err}")
+    _create_user_dirs(output_dir, toml_data)
+    projectPkg.set_files_permissions(output_dir)
+
+
 def run_user_command(action, success_msg, error_prefix):
     """Run a user-management action against a fresh Config, mapping errors."""
     try:

--- a/cli/src/cmd_utils.py
+++ b/cli/src/cmd_utils.py
@@ -5,7 +5,6 @@ formatter, the deployment-config orchestration used by generate-deployment,
 the user-command wrapper, and the destructive-action confirmation prompt.
 """
 
-from pathlib import Path
 import click
 from .pkg import config as configPkg
 from .pkg import project as projectPkg
@@ -47,10 +46,7 @@ class VerticalChoicesCommand(click.Command):
 
 def _find_toml(output_dir):
     """Return path to dtaas.toml, checking output_dir first then cwd, or None."""
-    for candidate in [Path(output_dir) / "dtaas.toml", Path("dtaas.toml")]:
-        if candidate.is_file():
-            return candidate
-    return None
+    return utilsPkg.find_toml(output_dir)
 
 
 def apply_deploy_config(deploy_type, output_dir, force=False):
@@ -80,12 +76,7 @@ def _substitute_config(deploy_type, output_dir, toml_data):
 
 def _certs_src(toml_data):
     """Resolve [common.security].certs-src from dtaas.toml, or '' if unset."""
-    common = toml_data.get("common", {}) if toml_data else {}
-    security = common.get("security", {}) if isinstance(common, dict) else {}
-    if not isinstance(security, dict):
-        return ""
-    certs_src = security.get("certs-src", "")
-    return certs_src.strip() if isinstance(certs_src, str) else ""
+    return utilsPkg.resolve_certs_src(toml_data)
 
 
 def _copy_deploy_certs(deploy_type, output_dir, toml_data, force):

--- a/cli/src/pkg/cert_update.py
+++ b/cli/src/pkg/cert_update.py
@@ -1,0 +1,93 @@
+"""In-place TLS certificate refresh for an installed deployment."""
+
+import os
+import shutil
+from pathlib import Path
+from . import utils
+from . import deploy
+from .certs import _find_latest_cert, _secure_private_key, CERT_FILES, PRIVATE_KEY_NAME
+from .cert_validate import validate_cert_pair, CertValidationError
+
+CERTS_DIR = "certs"
+TRAEFIK_SERVICE = "traefik"
+STAGE_SUFFIX = ".new"
+
+
+def _read_toml(output_dir):
+    """Load dtaas.toml near *output_dir*, raising OSError when unusable."""
+    toml_path = utils.find_toml(output_dir)
+    if toml_path is None:
+        raise OSError("No 'dtaas.toml' found; cannot resolve certs-src.")
+    toml_data, err = utils.import_toml(str(toml_path))
+    if err is not None:
+        raise OSError(f"Error reading dtaas.toml: {err}")
+    return toml_data
+
+
+def _resolve_source(output_dir):
+    """Return the certs-src directory from dtaas.toml, raising on misconfig."""
+    certs_src = utils.resolve_certs_src(_read_toml(output_dir))
+    if not certs_src:
+        raise OSError("'[common.security].certs-src' is not set in dtaas.toml.")
+    source = Path(certs_src)
+    if not source.is_dir():
+        raise OSError(f"certs-src directory not found: {source}")
+    return source
+
+
+def _discard(staged):
+    """Delete any staged certificate files (cleanup on failure)."""
+    for path in staged.values():
+        path.unlink(missing_ok=True)
+
+
+def _stage_pair(source, certs_dir):
+    """Copy the newest fullchain/privkey from *source* into staged files.
+
+    Returns a {filename: staged_path} mapping. Raises OSError (after removing
+    anything already staged) when either certificate is missing from *source*.
+    """
+    staged = {}
+    for name in CERT_FILES:
+        latest = _find_latest_cert(source, name[: -len(".pem")])
+        if latest is None:
+            _discard(staged)
+            raise OSError(f"'{name}' not found in certs-src ({source}).")
+        dest = certs_dir / (name + STAGE_SUFFIX)
+        shutil.copy2(latest, dest)
+        staged[name] = dest
+    return staged
+
+
+def _validate_staged(staged):
+    """Validate the staged pair, discarding it and re-raising on failure."""
+    try:
+        validate_cert_pair(staged["fullchain.pem"], staged["privkey.pem"])
+    except CertValidationError:
+        _discard(staged)
+        raise
+
+
+def _activate(staged, certs_dir):
+    """Atomically move staged files into place and lock down the private key."""
+    for name, staged_path in staged.items():
+        os.replace(staged_path, certs_dir / name)
+    _secure_private_key(certs_dir / PRIVATE_KEY_NAME)
+
+
+def update_certs(output_dir):
+    """Validate and swap in the newest certificates, then reload Traefik.
+
+    Returns a status message. On any failure it raises OSError,
+    CertValidationError, or DockerException without replacing the live
+    certificates.
+    """
+    deploy.require_compose_file(output_dir)
+    source = _resolve_source(output_dir)
+    certs_dir = Path(output_dir) / CERTS_DIR
+    certs_dir.mkdir(parents=True, exist_ok=True)
+    staged = _stage_pair(source, certs_dir)
+    _validate_staged(staged)
+    _activate(staged, certs_dir)
+    deploy.restart_service(output_dir, TRAEFIK_SERVICE)
+    return f"TLS certificates updated in {certs_dir}; '{TRAEFIK_SERVICE}' reloaded."

--- a/cli/src/pkg/cert_update.py
+++ b/cli/src/pkg/cert_update.py
@@ -2,15 +2,25 @@
 
 import os
 import shutil
+import time
 from pathlib import Path
 from . import utils
 from . import deploy
-from .certs import _find_latest_cert, _secure_private_key, CERT_FILES, PRIVATE_KEY_NAME
+from .certs import (
+    find_latest_cert,
+    secure_private_key,
+    CERT_FILES,
+    CERT_CHAIN_NAME,
+    PRIVATE_KEY_NAME,
+)
 from .cert_validate import validate_cert_pair, CertValidationError
 
 CERTS_DIR = "certs"
 TRAEFIK_SERVICE = "traefik"
 STAGE_SUFFIX = ".new"
+BACKUP_SUFFIX = ".bak"
+LIVENESS_RETRIES = 10
+LIVENESS_DELAY_S = 0.5
 
 
 def _read_toml(output_dir):
@@ -49,12 +59,14 @@ def _stage_pair(source, certs_dir):
     """
     staged = {}
     for name in CERT_FILES:
-        latest = _find_latest_cert(source, name[: -len(".pem")])
+        latest = find_latest_cert(source, name[: -len(".pem")])
         if latest is None:
             _discard(staged)
             raise OSError(f"'{name}' not found in certs-src ({source}).")
         dest = certs_dir / (name + STAGE_SUFFIX)
         shutil.copy2(latest, dest)
+        if name == PRIVATE_KEY_NAME:
+            secure_private_key(dest, warn=False)
         staged[name] = dest
     return staged
 
@@ -62,25 +74,94 @@ def _stage_pair(source, certs_dir):
 def _validate_staged(staged):
     """Validate the staged pair, discarding it and re-raising on failure."""
     try:
-        validate_cert_pair(staged["fullchain.pem"], staged["privkey.pem"])
+        validate_cert_pair(staged[CERT_CHAIN_NAME], staged[PRIVATE_KEY_NAME])
     except CertValidationError:
         _discard(staged)
         raise
 
 
+def _backup_live(staged, certs_dir):
+    """Copy any existing live certificates aside so a failed swap can be undone."""
+    backups = {}
+    for name in staged:
+        live = certs_dir / name
+        if live.exists():
+            backup = certs_dir / (name + BACKUP_SUFFIX)
+            shutil.copy2(live, backup)
+            backups[name] = backup
+    return backups
+
+
+def _restore_backups(backups, certs_dir):
+    """Move the backed-up certificates back over the live files."""
+    for name, backup in backups.items():
+        os.replace(backup, certs_dir / name)
+
+
+def _drop_backups(backups):
+    """Delete the backup copies once the swap has fully succeeded."""
+    for backup in backups.values():
+        backup.unlink(missing_ok=True)
+
+
 def _activate(staged, certs_dir):
-    """Atomically move staged files into place and lock down the private key."""
-    for name, staged_path in staged.items():
-        os.replace(staged_path, certs_dir / name)
-    _secure_private_key(certs_dir / PRIVATE_KEY_NAME)
+    """Swap the staged pair in, rolling back if either file cannot be replaced.
+
+    The two files cannot be replaced in a single atomic step, so the live pair
+    is backed up first. If any replace fails (for example a file is still
+    locked on Windows), the originals are restored, so the deployment is never
+    left with a mismatched fullchain/privkey pair.
+    """
+    backups = _backup_live(staged, certs_dir)
+    try:
+        for name, staged_path in staged.items():
+            os.replace(staged_path, certs_dir / name)
+    except OSError:
+        _restore_backups(backups, certs_dir)
+        _discard(staged)
+        raise
+    _drop_backups(backups)
+    secure_private_key(certs_dir / PRIVATE_KEY_NAME)
+
+
+def _wait_until_running(output_dir, service):
+    """Poll until *service* reports running, raising if it never comes up.
+
+    'docker compose up -d' returns as soon as a container is started, so a
+    container that exits immediately (Traefik rejecting the new certificates)
+    would otherwise be reported as a successful update.
+    """
+    for _ in range(LIVENESS_RETRIES):
+        if deploy.service_running(output_dir, service):
+            return
+        time.sleep(LIVENESS_DELAY_S)
+    raise RuntimeError(
+        f"'{service}' is not running after the certificate update; the new "
+        "certificates may have been rejected. Check the service logs."
+    )
+
+
+def _swap_and_reload(output_dir, staged, certs_dir):
+    """Stop Traefik, swap the validated pair in, then bring Traefik back up.
+
+    Traefik is stopped first so nothing holds the certificate files open while
+    they are replaced. It is always restarted, even when activation fails, so
+    the deployment is not left down; the restart is then checked for liveness.
+    """
+    deploy.stop_service(output_dir, TRAEFIK_SERVICE)
+    try:
+        _activate(staged, certs_dir)
+    finally:
+        deploy.restart_service(output_dir, TRAEFIK_SERVICE)
+    _wait_until_running(output_dir, TRAEFIK_SERVICE)
 
 
 def update_certs(output_dir):
     """Validate and swap in the newest certificates, then reload Traefik.
 
     Returns a status message. On any failure it raises OSError,
-    CertValidationError, or DockerException without replacing the live
-    certificates.
+    CertValidationError, DockerException, or RuntimeError without leaving the
+    deployment with a mismatched certificate pair.
     """
     deploy.require_compose_file(output_dir)
     source = _resolve_source(output_dir)
@@ -88,6 +169,5 @@ def update_certs(output_dir):
     certs_dir.mkdir(parents=True, exist_ok=True)
     staged = _stage_pair(source, certs_dir)
     _validate_staged(staged)
-    _activate(staged, certs_dir)
-    deploy.restart_service(output_dir, TRAEFIK_SERVICE)
+    _swap_and_reload(output_dir, staged, certs_dir)
     return f"TLS certificates updated in {certs_dir}; '{TRAEFIK_SERVICE}' reloaded."

--- a/cli/src/pkg/cert_update.py
+++ b/cli/src/pkg/cert_update.py
@@ -81,14 +81,21 @@ def _validate_staged(staged):
 
 
 def _backup_live(staged, certs_dir):
-    """Copy any existing live certificates aside so a failed swap can be undone."""
+    """Copy any existing live certificates aside so a failed swap can be undone.
+
+    Cleans up its own partial work if a copy fails, so no stray backups leak.
+    """
     backups = {}
-    for name in staged:
-        live = certs_dir / name
-        if live.exists():
-            backup = certs_dir / (name + BACKUP_SUFFIX)
-            shutil.copy2(live, backup)
-            backups[name] = backup
+    try:
+        for name in staged:
+            live = certs_dir / name
+            if live.exists():
+                backup = certs_dir / (name + BACKUP_SUFFIX)
+                shutil.copy2(live, backup)
+                backups[name] = backup
+    except OSError:
+        _drop_backups(backups)
+        raise
     return backups
 
 
@@ -99,29 +106,37 @@ def _restore_backups(backups, certs_dir):
 
 
 def _drop_backups(backups):
-    """Delete the backup copies once the swap has fully succeeded."""
+    """Delete the backup copies once they are no longer needed."""
     for backup in backups.values():
         backup.unlink(missing_ok=True)
 
 
-def _activate(staged, certs_dir):
-    """Swap the staged pair in, rolling back if either file cannot be replaced.
+def _rollback_swap(replaced, backups, certs_dir):
+    """Undo the certificates already replaced during a failed swap."""
+    for name in replaced:
+        backup = backups.get(name)
+        if backup is not None:
+            os.replace(backup, certs_dir / name)
+        else:
+            (certs_dir / name).unlink(missing_ok=True)
+    _drop_backups(backups)
 
-    The two files cannot be replaced in a single atomic step, so the live pair
-    is backed up first. If any replace fails (for example a file is still
-    locked on Windows), the originals are restored, so the deployment is never
-    left with a mismatched fullchain/privkey pair.
-    """
-    backups = _backup_live(staged, certs_dir)
+
+def _activate(staged, certs_dir):
+    """Back up the live pair and swap the staged pair in."""
+    backups = {}
+    replaced = []
     try:
+        backups = _backup_live(staged, certs_dir)
         for name, staged_path in staged.items():
             os.replace(staged_path, certs_dir / name)
+            replaced.append(name)
     except OSError:
-        _restore_backups(backups, certs_dir)
+        _rollback_swap(replaced, backups, certs_dir)
         _discard(staged)
         raise
-    _drop_backups(backups)
     secure_private_key(certs_dir / PRIVATE_KEY_NAME)
+    return backups
 
 
 def _wait_until_running(output_dir, service):
@@ -141,19 +156,35 @@ def _wait_until_running(output_dir, service):
     )
 
 
+def _rollback_live(output_dir, backups, certs_dir):
+    """Restore the previous certificate pair and restart Traefik."""
+    if not backups:
+        return
+    _restore_backups(backups, certs_dir)
+    deploy.restart_service(output_dir, TRAEFIK_SERVICE)
+
+
 def _swap_and_reload(output_dir, staged, certs_dir):
     """Stop Traefik, swap the validated pair in, then bring Traefik back up.
 
     Traefik is stopped first so nothing holds the certificate files open while
     they are replaced. It is always restarted, even when activation fails, so
-    the deployment is not left down; the restart is then checked for liveness.
+    the deployment is not left down. The previous certificates are kept as
+    backups until Traefik is confirmed healthy on the new pair; if it never
+    comes up, the old pair is rolled back in and Traefik restarted again.
     """
     deploy.stop_service(output_dir, TRAEFIK_SERVICE)
+    backups = {}
     try:
-        _activate(staged, certs_dir)
+        backups = _activate(staged, certs_dir)
     finally:
         deploy.restart_service(output_dir, TRAEFIK_SERVICE)
-    _wait_until_running(output_dir, TRAEFIK_SERVICE)
+    try:
+        _wait_until_running(output_dir, TRAEFIK_SERVICE)
+    except RuntimeError:
+        _rollback_live(output_dir, backups, certs_dir)
+        raise
+    _drop_backups(backups)
 
 
 def update_certs(output_dir):

--- a/cli/src/pkg/cert_update.py
+++ b/cli/src/pkg/cert_update.py
@@ -51,6 +51,21 @@ def _discard(staged):
         path.unlink(missing_ok=True)
 
 
+def _stage_one(name, source, certs_dir):
+    """Copy the newest *name* certificate from *source* into a staged file.
+
+    Returns the staged path. Raises OSError when *name* is missing from *source*.
+    """
+    latest = find_latest_cert(source, name[: -len(".pem")])
+    if latest is None:
+        raise OSError(f"'{name}' not found in certs-src ({source}).")
+    dest = certs_dir / (name + STAGE_SUFFIX)
+    shutil.copy2(latest, dest)
+    if name == PRIVATE_KEY_NAME:
+        secure_private_key(dest, warn=False)
+    return dest
+
+
 def _stage_pair(source, certs_dir):
     """Copy the newest fullchain/privkey from *source* into staged files.
 
@@ -59,15 +74,11 @@ def _stage_pair(source, certs_dir):
     """
     staged = {}
     for name in CERT_FILES:
-        latest = find_latest_cert(source, name[: -len(".pem")])
-        if latest is None:
+        try:
+            staged[name] = _stage_one(name, source, certs_dir)
+        except OSError:
             _discard(staged)
-            raise OSError(f"'{name}' not found in certs-src ({source}).")
-        dest = certs_dir / (name + STAGE_SUFFIX)
-        shutil.copy2(latest, dest)
-        if name == PRIVATE_KEY_NAME:
-            secure_private_key(dest, warn=False)
-        staged[name] = dest
+            raise
     return staged
 
 

--- a/cli/src/pkg/cert_validate.py
+++ b/cli/src/pkg/cert_validate.py
@@ -17,14 +17,21 @@ class CertValidationError(Exception):
     """Raised when a certificate/key pair fails validation."""
 
 
-def _load_cert(cert_path: Path):
-    """Parse the leaf certificate from a PEM file."""
+def _load_chain(cert_path: Path):
+    """Parse the full certificate chain (leaf first) from a PEM file.
+
+    A Let's Encrypt fullchain.pem holds the leaf plus one or more
+    intermediates; all of them are returned so each can be checked.
+    """
     try:
-        return x509.load_pem_x509_certificate(cert_path.read_bytes())
+        chain = x509.load_pem_x509_certificates(cert_path.read_bytes())
     except (OSError, ValueError) as exc:
         raise CertValidationError(
             f"Could not parse certificate '{cert_path.name}': {exc}"
         ) from exc
+    if not chain:
+        raise CertValidationError(f"No certificate found in '{cert_path.name}'.")
+    return chain
 
 
 def _load_key(key_path: Path):
@@ -51,17 +58,28 @@ def _check_key_matches_cert(cert, key) -> None:
         raise CertValidationError("Private key does not match the certificate.")
 
 
-def _check_not_expired(cert) -> None:
-    """Raise when the certificate's validity period has already ended."""
-    if cert.not_valid_after_utc < datetime.now(timezone.utc):
-        raise CertValidationError(
-            f"Certificate expired on {cert.not_valid_after_utc:%Y-%m-%d}."
-        )
+def _check_chain_not_expired(chain) -> None:
+    """Raise when the leaf or any intermediate certificate has expired.
+
+    An expired intermediate still makes Traefik present an invalid chain to
+    browsers, so the whole chain is checked, not just the leaf.
+    """
+    now = datetime.now(timezone.utc)
+    for cert in chain:
+        if cert.not_valid_after_utc < now:
+            raise CertValidationError(
+                f"A certificate in the chain expired on "
+                f"{cert.not_valid_after_utc:%Y-%m-%d}."
+            )
 
 
 def validate_cert_pair(cert_path: Path, key_path: Path) -> None:
-    """Validate a fullchain/privkey pair, raising CertValidationError on failure."""
-    cert = _load_cert(cert_path)
+    """Validate a fullchain/privkey pair, raising CertValidationError on failure.
+
+    Confirms the chain parses, the private key matches the leaf certificate,
+    and neither the leaf nor any intermediate has already expired.
+    """
+    chain = _load_chain(cert_path)
     key = _load_key(key_path)
-    _check_key_matches_cert(cert, key)
-    _check_not_expired(cert)
+    _check_key_matches_cert(chain[0], key)
+    _check_chain_not_expired(chain)

--- a/cli/src/pkg/cert_validate.py
+++ b/cli/src/pkg/cert_validate.py
@@ -1,0 +1,67 @@
+"""Validate a TLS certificate/key pair before putting it into service.
+
+Used by 'dtaas admin update --certs' to refuse a replacement pair that cannot
+be parsed, whose private key does not match the certificate, or that has
+already expired, so the live certificates are never replaced by a bad pair.
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+
+class CertValidationError(Exception):
+    """Raised when a certificate/key pair fails validation."""
+
+
+def _load_cert(cert_path: Path):
+    """Parse the leaf certificate from a PEM file."""
+    try:
+        return x509.load_pem_x509_certificate(cert_path.read_bytes())
+    except (OSError, ValueError) as exc:
+        raise CertValidationError(
+            f"Could not parse certificate '{cert_path.name}': {exc}"
+        ) from exc
+
+
+def _load_key(key_path: Path):
+    """Parse an unencrypted private key from a PEM file."""
+    try:
+        return load_pem_private_key(key_path.read_bytes(), password=None)
+    except (OSError, ValueError, TypeError) as exc:
+        raise CertValidationError(
+            f"Could not parse private key '{key_path.name}': {exc}"
+        ) from exc
+
+
+def _public_pem(public_key) -> bytes:
+    """Serialise a public key to PEM bytes for equality comparison."""
+    return public_key.public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+def _check_key_matches_cert(cert, key) -> None:
+    """Raise when the private key does not belong to the certificate."""
+    if _public_pem(cert.public_key()) != _public_pem(key.public_key()):
+        raise CertValidationError("Private key does not match the certificate.")
+
+
+def _check_not_expired(cert) -> None:
+    """Raise when the certificate's validity period has already ended."""
+    if cert.not_valid_after_utc < datetime.now(timezone.utc):
+        raise CertValidationError(
+            f"Certificate expired on {cert.not_valid_after_utc:%Y-%m-%d}."
+        )
+
+
+def validate_cert_pair(cert_path: Path, key_path: Path) -> None:
+    """Validate a fullchain/privkey pair, raising CertValidationError on failure."""
+    cert = _load_cert(cert_path)
+    key = _load_key(key_path)
+    _check_key_matches_cert(cert, key)
+    _check_not_expired(cert)

--- a/cli/src/pkg/certs.py
+++ b/cli/src/pkg/certs.py
@@ -1,7 +1,10 @@
 """TLS certificate placement for generated secure deployments."""
 
+import os
 import shutil
 from pathlib import Path
+
+import click
 
 # Deploy types that terminate TLS and reference certificates from certs/.
 TLS_DEPLOY_TYPES = {
@@ -11,11 +14,12 @@ TLS_DEPLOY_TYPES = {
 }
 
 # Certificate files expected by config/tls.yml.
-CERT_FILES = ("fullchain.pem", "privkey.pem")
+CERT_CHAIN_NAME = "fullchain.pem"
 PRIVATE_KEY_NAME = "privkey.pem"
+CERT_FILES = (CERT_CHAIN_NAME, PRIVATE_KEY_NAME)
 
 
-def _find_latest_cert(src_dir, prefix):
+def find_latest_cert(src_dir, prefix):
     """Return the newest '{prefix}.pem' / '{prefix}<N>.pem' file, or None.
 
     Let's Encrypt/Certbot archive directories hold numbered certificates
@@ -32,14 +36,36 @@ def _find_latest_cert(src_dir, prefix):
     return max(candidates, key=lambda p: p.stat().st_mtime)
 
 
-def _secure_private_key(key_path):
-    """Set 0600 on the private key. Best-effort; POSIX modes are a no-op on Windows."""
-    if not key_path.exists():
-        return
+def _restrict_key_mode(key_path):
+    """Apply 0600 to the key, ignoring a chmod failure."""
     try:
         key_path.chmod(0o600)
     except OSError:
         pass
+
+
+def _warn_unenforceable_key():
+    """Tell the operator the key's permissions cannot be enforced here."""
+    click.echo(
+        "Warning: private-key file permissions cannot be enforced on this "
+        "platform; restrict access to the deployment directory manually.",
+        err=True,
+    )
+
+
+def secure_private_key(key_path, warn=True):
+    """Restrict the private key to 0600 on POSIX.
+
+    POSIX file modes do not protect the key on Windows, where a warning is
+    emitted instead. *warn* is set False when locking the short-lived staging
+    copy, so the operator is warned only once per update.
+    """
+    if not key_path.exists():
+        return
+    if os.name == "posix":
+        _restrict_key_mode(key_path)
+    elif warn:
+        _warn_unenforceable_key()
 
 
 def _cert_copy_message(certs_dir, copied, missing):
@@ -64,7 +90,7 @@ def _copy_cert_pair(src, certs_dir, force):
     """
     copied, missing = [], []
     for name in CERT_FILES:
-        latest = _find_latest_cert(src, name[: -len(".pem")])
+        latest = find_latest_cert(src, name[: -len(".pem")])
         if latest is None:
             missing.append(name)
             continue
@@ -73,7 +99,7 @@ def _copy_cert_pair(src, certs_dir, force):
             continue
         shutil.copy2(latest, dest)
         copied.append(name)
-    _secure_private_key(certs_dir / PRIVATE_KEY_NAME)
+    secure_private_key(certs_dir / PRIVATE_KEY_NAME)
     return _cert_copy_message(certs_dir, copied, missing)
 
 

--- a/cli/src/pkg/deploy.py
+++ b/cli/src/pkg/deploy.py
@@ -106,3 +106,24 @@ def restart_service(directory, service):
     """
     require_compose_file(directory)
     _client(directory).compose.up(services=[service], force_recreate=True, detach=True)
+
+
+def stop_service(directory, service):
+    """Stop one compose service so its files can be safely replaced.
+
+    Raises OSError if the deployment is missing, or DockerException if compose
+    itself fails.
+    """
+    require_compose_file(directory)
+    _client(directory).compose.stop(services=[service])
+
+
+def service_running(directory, service):
+    """Return True if *service*'s container is currently running.
+
+    A stopped or exited container is not listed by 'compose ps', so the absence
+    of a running container reads as False.
+    """
+    require_compose_file(directory)
+    containers = _client(directory).compose.ps(services=[service])
+    return any(container.state.running for container in containers)

--- a/cli/src/pkg/deploy.py
+++ b/cli/src/pkg/deploy.py
@@ -6,8 +6,13 @@ from python_on_whales import DockerClient
 from python_on_whales.utils import ValidPath
 
 COMPOSE_FILE = "docker-compose.yml"
+USERS_COMPOSE_FILE = "compose.users.yml"
 USER_FILES_DIR = "files"
 ENV_FILE = Path("config") / ".env"
+# files/ entries provided by the deployment template (shared workspace and the
+# per-user skeleton), as opposed to generated per-user directories. These are
+# kept by --remove-user-files so a later install can repopulate user dirs.
+SCAFFOLDING_ENTRIES = frozenset({"common", "template"})
 
 
 def _env_files(directory) -> list[ValidPath]:
@@ -24,6 +29,18 @@ def _client(directory):
         compose_files=[str(Path(directory) / COMPOSE_FILE)],
         compose_env_files=_env_files(directory),
     )
+
+
+def _users_client(directory):
+    """Return a DockerClient for the 'user add' compose file, or None if absent.
+
+    Users added via 'dtaas admin user add' run from compose.users.yml as a
+    separate compose project, so the main compose file does not know about them.
+    """
+    users_compose = Path(directory) / USERS_COMPOSE_FILE
+    if not users_compose.is_file():
+        return None
+    return DockerClient(compose_files=[str(users_compose)])
 
 
 def _toml_present(directory):
@@ -87,28 +104,81 @@ def _user_files_dir(directory):
     return files_dir
 
 
+def _remove_user_dirs(files_dir):
+    """Delete generated per-user directories, keeping template scaffolding.
+
+    Returns the names removed. The shared 'common' workspace and the per-user
+    'template' skeleton are preserved so a subsequent install can recreate the
+    user directories from them.
+    """
+    removed = []
+    for child in files_dir.iterdir():
+        if child.name in SCAFFOLDING_ENTRIES or not child.is_dir():
+            continue
+        if child.is_symlink():
+            continue
+        shutil.rmtree(child)
+        removed.append(child.name)
+    return removed
+
+
 def delete_user_files(directory):
-    """Delete the per-user workspace files directory. Return a status message."""
+    """Delete generated per-user workspace directories. Return a status message.
+
+    The deployment-provided scaffolding (files/common and files/template) is
+    kept so 'dtaas admin install' can repopulate the per-user directories.
+    """
     files_dir = _user_files_dir(directory)
     if files_dir is None:
         return f"No '{USER_FILES_DIR}' directory found; nothing to remove."
-    shutil.rmtree(files_dir)
+    removed = _remove_user_dirs(files_dir)
+    if not removed:
+        return f"No per-user directories found in '{files_dir}'; nothing to remove."
     return f"Removed user files at '{files_dir}'."
+
+
+def _down_user_containers(directory):
+    """Tear down containers added via 'dtaas admin user add', if any exist.
+
+    These live in compose.users.yml as a separate project, so the main
+    'compose down' would otherwise leave them running and hold the shared
+    network open.
+    """
+    client = _users_client(directory)
+    if client is not None:
+        client.compose.down(remove_orphans=True)
 
 
 def uninstall(directory=".", remove_user_files=False):
     """Tear the deployment down with 'docker compose down'.
 
     Requires a generated compose file in *directory* so that teardown and any
-    file removal act only on a real deployment. Returns a message about
-    removed files when *remove_user_files* is set, otherwise None. Raises
-    DockerException if compose itself fails.
+    file removal act only on a real deployment. User-added containers are torn
+    down first so the shared network is free when the main project is removed.
+    Returns a message about removed files when *remove_user_files* is set,
+    otherwise None. Raises DockerException if compose itself fails.
     """
     require_compose_file(directory)
+    _down_user_containers(directory)
     _client(directory).compose.down()
     if remove_user_files:
         return delete_user_files(directory)
     return None
+
+
+def installation_present(directory):
+    """True if any deployment or user-added containers exist for *directory*.
+
+    Lets a repeated uninstall report that nothing is installed instead of
+    claiming a successful teardown. Containers in any state count, since a
+    stopped container is still part of an installation.
+    """
+    if not (Path(directory) / COMPOSE_FILE).is_file():
+        return False
+    if _client(directory).compose.ps(all=True):
+        return True
+    client = _users_client(directory)
+    return client is not None and bool(client.compose.ps(all=True))
 
 
 def restart_service(directory, service):

--- a/cli/src/pkg/deploy.py
+++ b/cli/src/pkg/deploy.py
@@ -104,6 +104,17 @@ def _user_files_dir(directory):
     return files_dir
 
 
+def _is_generated_user_dir(child):
+    """True if *child* is a generated per-user directory safe to delete.
+
+    Excludes the 'common' and 'template' scaffolding, any non-directory entry,
+    and symlinks (which could point outside the installation).
+    """
+    if child.name in SCAFFOLDING_ENTRIES:
+        return False
+    return child.is_dir() and not child.is_symlink()
+
+
 def _remove_user_dirs(files_dir):
     """Delete generated per-user directories, keeping template scaffolding.
 
@@ -113,9 +124,7 @@ def _remove_user_dirs(files_dir):
     """
     removed = []
     for child in files_dir.iterdir():
-        if child.name in SCAFFOLDING_ENTRIES or not child.is_dir():
-            continue
-        if child.is_symlink():
+        if not _is_generated_user_dir(child):
             continue
         shutil.rmtree(child)
         removed.append(child.name)

--- a/cli/src/pkg/deploy.py
+++ b/cli/src/pkg/deploy.py
@@ -1,11 +1,4 @@
-"""Handlers for the 'dtaas admin install and uninstall' commands.
-
-Installation brings the generated deployment up with 'docker compose'.
-Uninstallation tears it down and can optionally remove per-user workspace
-files. Compose is driven through python-on-whales, which wraps the docker
-CLI and raises python_on_whales.exceptions.DockerException carrying the real
-command output (return code and stderr) when a compose operation fails.
-"""
+"""Handlers for the 'dtaas admin install and uninstall' commands."""
 
 import shutil
 from pathlib import Path
@@ -25,7 +18,7 @@ def _toml_present(directory):
     return (Path(directory) / "dtaas.toml").is_file() or Path("dtaas.toml").is_file()
 
 
-def _require_compose_file(directory):
+def require_compose_file(directory):
     """Raise OSError if the generated compose file is missing from *directory*."""
     if not (Path(directory) / COMPOSE_FILE).is_file():
         raise OSError(
@@ -41,7 +34,7 @@ def _require_deployment(directory):
     *directory* or in the current working directory, matching the lookup used
     by generate-deployment.
     """
-    _require_compose_file(directory)
+    require_compose_file(directory)
     if not _toml_present(directory):
         raise OSError(
             f"No 'dtaas.toml' found in '{directory}' or the current "
@@ -98,8 +91,18 @@ def uninstall(directory=".", remove_user_files=False):
     removed files when *remove_user_files* is set, otherwise None. Raises
     DockerException if compose itself fails.
     """
-    _require_compose_file(directory)
+    require_compose_file(directory)
     _client(directory).compose.down()
     if remove_user_files:
         return delete_user_files(directory)
     return None
+
+
+def restart_service(directory, service):
+    """Recreate one compose service so it picks up new certificates or config.
+
+    Mirrors 'docker compose up -d --force-recreate <service>'. Raises OSError
+    if the deployment is missing, or DockerException if compose itself fails.
+    """
+    require_compose_file(directory)
+    _client(directory).compose.up(services=[service], force_recreate=True, detach=True)

--- a/cli/src/pkg/deploy.py
+++ b/cli/src/pkg/deploy.py
@@ -3,14 +3,27 @@
 import shutil
 from pathlib import Path
 from python_on_whales import DockerClient
+from python_on_whales.utils import ValidPath
 
 COMPOSE_FILE = "docker-compose.yml"
 USER_FILES_DIR = "files"
+ENV_FILE = Path("config") / ".env"
+
+
+def _env_files(directory) -> list[ValidPath]:
+    """Return the deployment's env file for compose, or an empty list."""
+    env_file = Path(directory) / ENV_FILE
+    if env_file.is_file():
+        return [str(env_file)]
+    return []
 
 
 def _client(directory):
     """Return a DockerClient bound to the deployment's compose file."""
-    return DockerClient(compose_files=[str(Path(directory) / COMPOSE_FILE)])
+    return DockerClient(
+        compose_files=[str(Path(directory) / COMPOSE_FILE)],
+        compose_env_files=_env_files(directory),
+    )
 
 
 def _toml_present(directory):

--- a/cli/src/pkg/deploy_config.py
+++ b/cli/src/pkg/deploy_config.py
@@ -88,11 +88,16 @@ def _read_file_text(path):
 
 
 def _missing_placeholder_warnings(text, rel_path):
-    """Return warning strings for any secret placeholders found in text."""
+    """Return warning strings for any secret placeholders found in text.
+
+    Placeholders are matched on whole-word boundaries so that a real value
+    which merely contains a placeholder as a substring (for example
+    ``changemed`` containing ``changeme``) is not flagged as un-substituted.
+    """
     return [
         f"Warning: '{p}' not substituted in {rel_path}"
         for p in _SECRET_PLACEHOLDERS
-        if p in text
+        if re.search(rf"\b{re.escape(p)}\b", text)
     ]
 
 

--- a/cli/src/pkg/project.py
+++ b/cli/src/pkg/project.py
@@ -191,11 +191,15 @@ def create_user_dirs(dest_dir, usernames):
 
 
 def set_files_permissions(dest_dir):
-    """Grant read/write/execute on files/."""
+    """Set ownership to 1000:100 and grant read/write/execute on files/."""
     files_dir = Path(dest_dir) / "files"
     if not files_dir.is_dir():
         return
     try:
+        subprocess.run(
+            ["sudo", "chown", "-R", "1000:100", str(files_dir)],
+            check=True,
+        )
         subprocess.run(
             ["sudo", "chmod", "-R", "u+rwX,go+rwX", str(files_dir)],
             check=True,

--- a/cli/src/pkg/users.py
+++ b/cli/src/pkg/users.py
@@ -190,7 +190,9 @@ def add_users(config_obj):
         config = {"server": server, "path": path, "resources": resources, "tls": tls}
         err = add_users_to_compose(user_list, compose, config)
         utils.check_error(err)
-        _finalize_compose(compose)
+        # Authorise each user in the forward-auth config before starting their
+        # container. Writing conf.server first means a later 'compose up'
+        # failure cannot leave the forward-auth rules stale.
         for username in user_list:
             section = (users_section or {}).get(username, {})
             email = str(
@@ -203,6 +205,7 @@ def add_users(config_obj):
                     f"Invalid user config for '{username}': username/email must not contain newlines"
                 )
             add_conf_server_entry(username, email)
+        _finalize_compose(compose)
     except Exception as e:
         return e
 

--- a/cli/src/pkg/users_utils.py
+++ b/cli/src/pkg/users_utils.py
@@ -22,14 +22,27 @@ def _conf_server_block(username, email, rule_num):
     )
 
 
+def _has_user_rule(text, username):
+    """True if conf.server already has a routing rule for username."""
+    return bool(
+        re.search(
+            rf"rule\.onlyu\d+\.rule=PathPrefix\(`/{re.escape(username)}`\)", text
+        )
+    )
+
+
 def add_conf_server_entry(username, email):
     """Append routing and whitelist rules for username to config/conf.server.
 
-    Skipped silently when conf.server does not exist or email is empty.
+    Skipped silently when conf.server does not exist, email is empty, or a rule
+    for username is already present, so re-adding a user (or adding one whose
+    rule was generated at deployment time) does not create duplicate rules.
     """
     if not CONF_SERVER_PATH.is_file() or not email:
         return
     text = CONF_SERVER_PATH.read_text(encoding="utf-8")
+    if _has_user_rule(text, username):
+        return
     rule_num = _next_rule_num(text)
     CONF_SERVER_PATH.write_text(
         text + _conf_server_block(username, email, rule_num), encoding="utf-8"

--- a/cli/src/pkg/users_utils.py
+++ b/cli/src/pkg/users_utils.py
@@ -25,9 +25,7 @@ def _conf_server_block(username, email, rule_num):
 def _has_user_rule(text, username):
     """True if conf.server already has a routing rule for username."""
     return bool(
-        re.search(
-            rf"rule\.onlyu\d+\.rule=PathPrefix\(`/{re.escape(username)}`\)", text
-        )
+        re.search(rf"rule\.onlyu\d+\.rule=PathPrefix\(`/{re.escape(username)}`\)", text)
     )
 
 

--- a/cli/src/pkg/utils.py
+++ b/cli/src/pkg/utils.py
@@ -1,9 +1,31 @@
 "This file has generic helper functions and variables for dtaas cli"
 
+from pathlib import Path
 import yaml
 import tomlkit
 
 LOCALHOST_SERVER = "localhost"
+
+
+def find_toml(output_dir):
+    """Return path to dtaas.toml, checking output_dir first then cwd, or None."""
+    for candidate in [Path(output_dir) / "dtaas.toml", Path("dtaas.toml")]:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _nested_dict(data, key):
+    """Return data[key] when it is a dict, otherwise an empty dict."""
+    value = data.get(key, {}) if isinstance(data, dict) else {}
+    return value if isinstance(value, dict) else {}
+
+
+def resolve_certs_src(toml_data):
+    """Resolve [common.security].certs-src from dtaas.toml, or '' if unset."""
+    security = _nested_dict(_nested_dict(toml_data, "common"), "security")
+    certs_src = security.get("certs-src", "")
+    return certs_src.strip() if isinstance(certs_src, str) else ""
 
 
 def import_yaml(filename):

--- a/cli/src/templates/dtaas.toml
+++ b/cli/src/templates/dtaas.toml
@@ -1,7 +1,7 @@
 # This is the config for DTaaS CLI
 
 name="Digital Twin as a Service (DTaaS)"
-version="0.7.0"
+version="0.8.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 

--- a/cli/tests/dtaas.test.toml
+++ b/cli/tests/dtaas.test.toml
@@ -1,7 +1,7 @@
 # This is the config for DTaaS CLI
 
 name="Digital Twin as a Service (DTaaS)"
-version="0.7.0"
+version="0.8.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 

--- a/cli/tests/test_cert_update.py
+++ b/cli/tests/test_cert_update.py
@@ -6,12 +6,24 @@ The real validation logic is covered by test_cert_validate.py.
 """
 
 import os
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
 from src.pkg import cert_update
 from src.pkg.cert_validate import CertValidationError
 # pylint: disable=protected-access
+
+
+@contextmanager
+def _mock_docker():
+    """Patch the Traefik stop/restart/liveness calls used while activating certs."""
+    with patch("src.pkg.cert_update.deploy.stop_service") as stop, patch(
+        "src.pkg.cert_update.deploy.restart_service"
+    ) as restart, patch(
+        "src.pkg.cert_update.deploy.service_running", return_value=True
+    ) as running:
+        yield {"stop": stop, "restart": restart, "running": running}
 
 
 def _make_source(src):
@@ -51,24 +63,22 @@ def _seed_live_certs(out):
 def test_update_certs_success(tmp_path):
     """The newest pair is copied in, traefik reloaded, and no staging is left."""
     out, _ = _setup(tmp_path)
-    with patch("src.pkg.cert_update.validate_cert_pair"), patch(
-        "src.pkg.cert_update.deploy.restart_service"
-    ) as mock_restart:
+    with patch("src.pkg.cert_update.validate_cert_pair"), _mock_docker() as docker:
         message = cert_update.update_certs(str(out))
 
     assert (out / "certs" / "fullchain.pem").read_text() == "fc"
     assert (out / "certs" / "privkey.pem").read_text() == "pk"
     assert not list((out / "certs").glob("*.new"))
+    assert not list((out / "certs").glob("*.bak"))
     assert "updated" in message
-    mock_restart.assert_called_once_with(str(out), "traefik")
+    docker["stop"].assert_called_once_with(str(out), "traefik")
+    docker["restart"].assert_called_once_with(str(out), "traefik")
 
 
 def test_update_certs_sets_key_permissions(tmp_path):
     """The activated private key is restricted to 0600 (POSIX only)."""
     out, _ = _setup(tmp_path)
-    with patch("src.pkg.cert_update.validate_cert_pair"), patch(
-        "src.pkg.cert_update.deploy.restart_service"
-    ):
+    with patch("src.pkg.cert_update.validate_cert_pair"), _mock_docker():
         cert_update.update_certs(str(out))
 
     key = out / "certs" / "privkey.pem"
@@ -79,9 +89,7 @@ def test_update_certs_sets_key_permissions(tmp_path):
 def test_update_certs_is_repeatable(tmp_path):
     """Running the update twice is safe and leaves the newest certs in place."""
     out, _ = _setup(tmp_path)
-    with patch("src.pkg.cert_update.validate_cert_pair"), patch(
-        "src.pkg.cert_update.deploy.restart_service"
-    ):
+    with patch("src.pkg.cert_update.validate_cert_pair"), _mock_docker():
         cert_update.update_certs(str(out))
         cert_update.update_certs(str(out))
 
@@ -155,3 +163,41 @@ def test_stage_pair_discards_partial_on_missing(tmp_path):
         cert_update._stage_pair(src, certs_dir)
 
     assert not list(certs_dir.glob("*.new"))
+
+
+def test_update_certs_raises_when_traefik_stays_down(tmp_path):
+    """If traefik never reports running, the update raises instead of succeeding."""
+    out, _ = _setup(tmp_path)
+    with patch("src.pkg.cert_update.validate_cert_pair"), patch(
+        "src.pkg.cert_update.deploy.stop_service"
+    ), patch("src.pkg.cert_update.deploy.restart_service"), patch(
+        "src.pkg.cert_update.deploy.service_running", return_value=False
+    ), patch("src.pkg.cert_update.time.sleep"):
+        with pytest.raises(RuntimeError, match="not running"):
+            cert_update.update_certs(str(out))
+
+
+def test_update_certs_rolls_back_on_partial_swap(tmp_path):
+    """A failed second replace restores the old pair and still restarts traefik."""
+    out, _ = _setup(tmp_path)
+    live = _seed_live_certs(out)
+    real_replace = os.replace
+
+    def flaky_replace(src, dst):
+        if str(src).endswith("privkey.pem" + cert_update.STAGE_SUFFIX):
+            raise PermissionError("file is locked")
+        return real_replace(src, dst)
+
+    with patch(
+        "src.pkg.cert_update.validate_cert_pair"
+    ), _mock_docker() as docker, patch(
+        "src.pkg.cert_update.os.replace", side_effect=flaky_replace
+    ):
+        with pytest.raises(PermissionError):
+            cert_update.update_certs(str(out))
+
+    assert (live / "fullchain.pem").read_text() == "OLD"
+    assert (live / "privkey.pem").read_text() == "OLDKEY"
+    assert not list(live.glob("*.new"))
+    assert not list(live.glob("*.bak"))
+    docker["restart"].assert_called_once_with(str(out), "traefik")

--- a/cli/tests/test_cert_update.py
+++ b/cli/tests/test_cert_update.py
@@ -201,3 +201,47 @@ def test_update_certs_rolls_back_on_partial_swap(tmp_path):
     assert not list(live.glob("*.new"))
     assert not list(live.glob("*.bak"))
     docker["restart"].assert_called_once_with(str(out), "traefik")
+
+
+def test_update_certs_first_time_partial_swap_leaves_no_mismatch(tmp_path):
+    """A failed second replace on a first-time install leaves no half-written pair."""
+    out, _ = _setup(tmp_path)  # no live certs seeded: first-time install
+    certs = out / "certs"
+    real_replace = os.replace
+
+    def flaky_replace(src, dst):
+        if str(src).endswith("privkey.pem" + cert_update.STAGE_SUFFIX):
+            raise PermissionError("file is locked")
+        return real_replace(src, dst)
+
+    with patch("src.pkg.cert_update.validate_cert_pair"), _mock_docker(), patch(
+        "src.pkg.cert_update.os.replace", side_effect=flaky_replace
+    ):
+        with pytest.raises(PermissionError):
+            cert_update.update_certs(str(out))
+
+    # The first file must be rolled back too: neither cert is left in place.
+    assert not (certs / "fullchain.pem").exists()
+    assert not (certs / "privkey.pem").exists()
+    assert not list(certs.glob("*.new"))
+    assert not list(certs.glob("*.bak"))
+
+
+def test_update_certs_rolls_back_when_traefik_rejects_new_certs(tmp_path):
+    """If Traefik fails liveness on the new pair, the old pair is restored."""
+    out, _ = _setup(tmp_path)
+    live = _seed_live_certs(out)
+    with patch("src.pkg.cert_update.validate_cert_pair"), patch(
+        "src.pkg.cert_update.deploy.stop_service"
+    ), patch("src.pkg.cert_update.deploy.restart_service") as restart, patch(
+        "src.pkg.cert_update.deploy.service_running", return_value=False
+    ), patch("src.pkg.cert_update.time.sleep"):
+        with pytest.raises(RuntimeError, match="not running"):
+            cert_update.update_certs(str(out))
+
+    assert (live / "fullchain.pem").read_text() == "OLD"
+    assert (live / "privkey.pem").read_text() == "OLDKEY"
+    assert not list(live.glob("*.new"))
+    assert not list(live.glob("*.bak"))
+    # Restarted once for the new pair, then again after rolling the old pair back.
+    assert restart.call_count == 2

--- a/cli/tests/test_cert_update.py
+++ b/cli/tests/test_cert_update.py
@@ -1,0 +1,157 @@
+"""Tests for cert_update ('dtaas admin update --certs' orchestration).
+
+Certificate validation and the Traefik reload are mocked here so these tests
+focus on staging, the atomic swap, permissions, and the fail-safe behaviour.
+The real validation logic is covered by test_cert_validate.py.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from src.pkg import cert_update
+from src.pkg.cert_validate import CertValidationError
+# pylint: disable=protected-access
+
+
+def _make_source(src):
+    """Create a certs-src directory holding a dummy fullchain/privkey pair."""
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "fullchain.pem").write_text("fc")
+    (src / "privkey.pem").write_text("pk")
+
+
+def _write_toml(out_dir, certs_src):
+    """Write a dtaas.toml in *out_dir* whose certs-src points at *certs_src*."""
+    (out_dir / "dtaas.toml").write_text(
+        f"[common.security]\ncerts-src = '{certs_src}'\n"
+    )
+
+
+def _setup(tmp_path):
+    """Build an installed deployment plus a populated certs-src; return both."""
+    out = tmp_path / "install"
+    out.mkdir()
+    (out / "docker-compose.yml").write_text("services: {}")
+    src = tmp_path / "src"
+    _make_source(src)
+    _write_toml(out, str(src))
+    return out, src
+
+
+def _seed_live_certs(out):
+    """Place existing (old) certificates in the deployment's certs/ directory."""
+    live = out / "certs"
+    live.mkdir(parents=True, exist_ok=True)
+    (live / "fullchain.pem").write_text("OLD")
+    (live / "privkey.pem").write_text("OLDKEY")
+    return live
+
+
+def test_update_certs_success(tmp_path):
+    """The newest pair is copied in, traefik reloaded, and no staging is left."""
+    out, _ = _setup(tmp_path)
+    with patch("src.pkg.cert_update.validate_cert_pair"), patch(
+        "src.pkg.cert_update.deploy.restart_service"
+    ) as mock_restart:
+        message = cert_update.update_certs(str(out))
+
+    assert (out / "certs" / "fullchain.pem").read_text() == "fc"
+    assert (out / "certs" / "privkey.pem").read_text() == "pk"
+    assert not list((out / "certs").glob("*.new"))
+    assert "updated" in message
+    mock_restart.assert_called_once_with(str(out), "traefik")
+
+
+def test_update_certs_sets_key_permissions(tmp_path):
+    """The activated private key is restricted to 0600 (POSIX only)."""
+    out, _ = _setup(tmp_path)
+    with patch("src.pkg.cert_update.validate_cert_pair"), patch(
+        "src.pkg.cert_update.deploy.restart_service"
+    ):
+        cert_update.update_certs(str(out))
+
+    key = out / "certs" / "privkey.pem"
+    if os.name == "posix":
+        assert (key.stat().st_mode & 0o777) == 0o600
+
+
+def test_update_certs_is_repeatable(tmp_path):
+    """Running the update twice is safe and leaves the newest certs in place."""
+    out, _ = _setup(tmp_path)
+    with patch("src.pkg.cert_update.validate_cert_pair"), patch(
+        "src.pkg.cert_update.deploy.restart_service"
+    ):
+        cert_update.update_certs(str(out))
+        cert_update.update_certs(str(out))
+
+    assert (out / "certs" / "fullchain.pem").read_text() == "fc"
+
+
+def test_update_certs_requires_compose_file(tmp_path):
+    """Without a generated deployment the update fails before touching certs."""
+    out = tmp_path / "install"
+    out.mkdir()
+    _write_toml(out, str(tmp_path / "src"))
+    with patch("src.pkg.cert_update.deploy.restart_service") as mock_restart:
+        with pytest.raises(OSError, match="docker-compose.yml"):
+            cert_update.update_certs(str(out))
+        mock_restart.assert_not_called()
+
+
+def test_update_certs_requires_certs_src(tmp_path):
+    """A dtaas.toml without certs-src yields a clear error and no reload."""
+    out = tmp_path / "install"
+    out.mkdir()
+    (out / "docker-compose.yml").write_text("services: {}")
+    (out / "dtaas.toml").write_text("[common]\nserver-dns = 'localhost'\n")
+    with patch("src.pkg.cert_update.deploy.restart_service") as mock_restart:
+        with pytest.raises(OSError, match="certs-src"):
+            cert_update.update_certs(str(out))
+        mock_restart.assert_not_called()
+
+
+def test_update_certs_missing_source_file_leaves_live_certs(tmp_path):
+    """A certs-src missing privkey.pem leaves the live pair untouched."""
+    out, src = _setup(tmp_path)
+    (src / "privkey.pem").unlink()
+    live = _seed_live_certs(out)
+    with patch("src.pkg.cert_update.deploy.restart_service") as mock_restart:
+        with pytest.raises(OSError, match="privkey.pem"):
+            cert_update.update_certs(str(out))
+        mock_restart.assert_not_called()
+
+    assert (live / "fullchain.pem").read_text() == "OLD"
+    assert (live / "privkey.pem").read_text() == "OLDKEY"
+    assert not list(live.glob("*.new"))
+
+
+def test_update_certs_invalid_pair_leaves_live_certs(tmp_path):
+    """A pair that fails validation never replaces the live certificates."""
+    out, _ = _setup(tmp_path)
+    live = _seed_live_certs(out)
+    with patch(
+        "src.pkg.cert_update.validate_cert_pair",
+        side_effect=CertValidationError("expired"),
+    ), patch("src.pkg.cert_update.deploy.restart_service") as mock_restart:
+        with pytest.raises(CertValidationError, match="expired"):
+            cert_update.update_certs(str(out))
+        mock_restart.assert_not_called()
+
+    assert (live / "fullchain.pem").read_text() == "OLD"
+    assert (live / "privkey.pem").read_text() == "OLDKEY"
+    assert not list(live.glob("*.new"))
+
+
+def test_stage_pair_discards_partial_on_missing(tmp_path):
+    """_stage_pair removes an already-staged file when its partner is absent."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "fullchain.pem").write_text("fc")  # privkey.pem absent
+    certs_dir = tmp_path / "certs"
+    certs_dir.mkdir()
+
+    with pytest.raises(OSError, match="privkey.pem"):
+        cert_update._stage_pair(src, certs_dir)
+
+    assert not list(certs_dir.glob("*.new"))

--- a/cli/tests/test_cert_update.py
+++ b/cli/tests/test_cert_update.py
@@ -165,6 +165,31 @@ def test_stage_pair_discards_partial_on_missing(tmp_path):
     assert not list(certs_dir.glob("*.new"))
 
 
+def test_stage_one_copies_latest(tmp_path):
+    """_stage_one stages a present certificate into a .new file."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "fullchain.pem").write_text("fc")
+    certs_dir = tmp_path / "certs"
+    certs_dir.mkdir()
+
+    dest = cert_update._stage_one("fullchain.pem", src, certs_dir)
+
+    assert dest == certs_dir / ("fullchain.pem" + cert_update.STAGE_SUFFIX)
+    assert dest.read_text() == "fc"
+
+
+def test_stage_one_raises_when_missing(tmp_path):
+    """_stage_one raises OSError when the certificate is absent from source."""
+    src = tmp_path / "src"
+    src.mkdir()
+    certs_dir = tmp_path / "certs"
+    certs_dir.mkdir()
+
+    with pytest.raises(OSError, match="fullchain.pem"):
+        cert_update._stage_one("fullchain.pem", src, certs_dir)
+
+
 def test_update_certs_raises_when_traefik_stays_down(tmp_path):
     """If traefik never reports running, the update raises instead of succeeding."""
     out, _ = _setup(tmp_path)

--- a/cli/tests/test_cert_validate.py
+++ b/cli/tests/test_cert_validate.py
@@ -26,11 +26,9 @@ def _self_signed(key, not_after):
     )
 
 
-def _write_pair(directory, cert, key):
-    """Write *cert* and *key* as fullchain.pem/privkey.pem, returning their paths."""
-    cert_path = directory / "fullchain.pem"
+def _write_key(directory, key):
+    """Write *key* as privkey.pem, returning its path."""
     key_path = directory / "privkey.pem"
-    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
     key_path.write_bytes(
         key.private_bytes(
             serialization.Encoding.PEM,
@@ -38,7 +36,23 @@ def _write_pair(directory, cert, key):
             serialization.NoEncryption(),
         )
     )
-    return cert_path, key_path
+    return key_path
+
+
+def _write_pair(directory, cert, key):
+    """Write *cert* and *key* as fullchain.pem/privkey.pem, returning their paths."""
+    cert_path = directory / "fullchain.pem"
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    return cert_path, _write_key(directory, key)
+
+
+def _write_chain(directory, certs, key):
+    """Write *certs* (leaf first) as one fullchain.pem bundle plus the key."""
+    cert_path = directory / "fullchain.pem"
+    cert_path.write_bytes(
+        b"".join(c.public_bytes(serialization.Encoding.PEM) for c in certs)
+    )
+    return cert_path, _write_key(directory, key)
 
 
 def _valid_until(days):
@@ -99,3 +113,28 @@ def test_validate_rejects_unparseable_key(tmp_path):
 
     with pytest.raises(CertValidationError, match="parse private key"):
         validate_cert_pair(cert_path, bad_key)
+
+
+def test_validate_accepts_full_chain(tmp_path):
+    """A leaf plus a valid intermediate validates against the leaf's key."""
+    leaf_key = ec.generate_private_key(ec.SECP256R1())
+    leaf = _self_signed(leaf_key, _valid_until(30))
+    intermediate = _self_signed(
+        ec.generate_private_key(ec.SECP256R1()), _valid_until(60)
+    )
+    cert_path, key_path = _write_chain(tmp_path, [leaf, intermediate], leaf_key)
+
+    validate_cert_pair(cert_path, key_path)  # must not raise
+
+
+def test_validate_rejects_expired_intermediate(tmp_path):
+    """An expired intermediate is rejected even when the leaf is still valid."""
+    leaf_key = ec.generate_private_key(ec.SECP256R1())
+    leaf = _self_signed(leaf_key, _valid_until(30))
+    intermediate = _self_signed(
+        ec.generate_private_key(ec.SECP256R1()), _valid_until(-1)
+    )
+    cert_path, key_path = _write_chain(tmp_path, [leaf, intermediate], leaf_key)
+
+    with pytest.raises(CertValidationError, match="expired"):
+        validate_cert_pair(cert_path, key_path)

--- a/cli/tests/test_cert_validate.py
+++ b/cli/tests/test_cert_validate.py
@@ -1,0 +1,101 @@
+"""Tests for cert_validate (TLS certificate/key pair validation)."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from src.pkg.cert_validate import validate_cert_pair, CertValidationError
+
+
+def _self_signed(key, not_after):
+    """Build a self-signed certificate for *key* expiring at *not_after*."""
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    return (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime(2020, 1, 1, tzinfo=timezone.utc))
+        .not_valid_after(not_after)
+        .sign(key, hashes.SHA256())
+    )
+
+
+def _write_pair(directory, cert, key):
+    """Write *cert* and *key* as fullchain.pem/privkey.pem, returning their paths."""
+    cert_path = directory / "fullchain.pem"
+    key_path = directory / "privkey.pem"
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+    )
+    return cert_path, key_path
+
+
+def _valid_until(days):
+    """Return a UTC datetime *days* from now."""
+    return datetime.now(timezone.utc) + timedelta(days=days)
+
+
+def test_validate_accepts_matching_unexpired_pair(tmp_path):
+    """A matching, unexpired cert/key pair validates without raising."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    cert_path, key_path = _write_pair(
+        tmp_path, _self_signed(key, _valid_until(30)), key
+    )
+
+    validate_cert_pair(cert_path, key_path)  # must not raise
+
+
+def test_validate_rejects_mismatched_key(tmp_path):
+    """A private key that does not belong to the certificate is rejected."""
+    cert_key = ec.generate_private_key(ec.SECP256R1())
+    other_key = ec.generate_private_key(ec.SECP256R1())
+    cert_path, key_path = _write_pair(
+        tmp_path, _self_signed(cert_key, _valid_until(30)), other_key
+    )
+
+    with pytest.raises(CertValidationError, match="does not match"):
+        validate_cert_pair(cert_path, key_path)
+
+
+def test_validate_rejects_expired_cert(tmp_path):
+    """An already-expired certificate is rejected."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    cert_path, key_path = _write_pair(
+        tmp_path, _self_signed(key, _valid_until(-1)), key
+    )
+
+    with pytest.raises(CertValidationError, match="expired"):
+        validate_cert_pair(cert_path, key_path)
+
+
+def test_validate_rejects_unparseable_cert(tmp_path):
+    """A certificate file that is not valid PEM is rejected."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    _, key_path = _write_pair(tmp_path, _self_signed(key, _valid_until(30)), key)
+    bad_cert = tmp_path / "fullchain.pem"
+    bad_cert.write_text("not a certificate")
+
+    with pytest.raises(CertValidationError, match="parse certificate"):
+        validate_cert_pair(bad_cert, key_path)
+
+
+def test_validate_rejects_unparseable_key(tmp_path):
+    """A private-key file that is not valid PEM is rejected."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    cert_path, _ = _write_pair(tmp_path, _self_signed(key, _valid_until(30)), key)
+    bad_key = tmp_path / "privkey.pem"
+    bad_key.write_text("not a key")
+
+    with pytest.raises(CertValidationError, match="parse private key"):
+        validate_cert_pair(cert_path, bad_key)

--- a/cli/tests/test_certs.py
+++ b/cli/tests/test_certs.py
@@ -2,7 +2,7 @@
 
 import os
 from unittest.mock import patch
-from src.pkg.certs import copy_certs, _find_latest_cert, _secure_private_key
+from src.pkg.certs import copy_certs, find_latest_cert, secure_private_key
 
 
 def _make_cert_src(src, files):
@@ -13,13 +13,13 @@ def _make_cert_src(src, files):
 
 
 def test_find_latest_cert_picks_newest_numbered(tmp_path):
-    """_find_latest_cert returns the newest fullchain<N>.pem by mtime."""
+    """find_latest_cert returns the newest fullchain<N>.pem by mtime."""
     src = tmp_path / "archive"
     _make_cert_src(src, {"fullchain1.pem": "old", "fullchain2.pem": "new"})
     os.utime(src / "fullchain1.pem", (1, 1))
     os.utime(src / "fullchain2.pem", (2, 2))
 
-    latest = _find_latest_cert(src, "fullchain")
+    latest = find_latest_cert(src, "fullchain")
 
     assert latest == src / "fullchain2.pem"
 
@@ -29,7 +29,7 @@ def test_find_latest_cert_ignores_unrelated_names(tmp_path):
     src = tmp_path / "archive"
     _make_cert_src(src, {"fullchain-service.pem": "x"})
 
-    assert _find_latest_cert(src, "fullchain") is None
+    assert find_latest_cert(src, "fullchain") is None
 
 
 def test_copy_certs_skips_non_tls_deploy(tmp_path):
@@ -120,16 +120,16 @@ def test_copy_certs_overwrites_with_force(tmp_path):
 
 
 def test_secure_private_key_skips_missing_file(tmp_path):
-    """_secure_private_key is a no-op when the key file does not exist."""
-    _secure_private_key(tmp_path / "privkey.pem")  # must not raise
+    """secure_private_key is a no-op when the key file does not exist."""
+    secure_private_key(tmp_path / "privkey.pem")  # must not raise
 
 
 def test_secure_private_key_swallows_oserror(tmp_path):
-    """_secure_private_key silently ignores a chmod OSError."""
+    """secure_private_key silently ignores a chmod OSError."""
     key = tmp_path / "privkey.pem"
     key.write_text("pk")
     with patch.object(type(key), "chmod", side_effect=OSError("permission denied")):
-        _secure_private_key(key)  # must not raise
+        secure_private_key(key)  # must not raise
 
 
 def test_copy_certs_notes_partial_source(tmp_path):

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -6,6 +6,7 @@ import pytest
 from click.testing import CliRunner
 from python_on_whales.exceptions import DockerException
 from src.cmd import dtaas
+from src.pkg.cert_validate import CertValidationError
 # pylint: disable=redefined-outer-name
 
 
@@ -311,3 +312,47 @@ def test_admin_uninstall_error(runner, mock_deploy_pkg):
 
     assert result.exit_code != 0
     assert "daemon down" in result.output
+
+
+def test_admin_update_certs_success(runner):
+    """update --certs forwards the output dir and echoes the result message."""
+    with patch(
+        "src.cmd.certUpdatePkg.update_certs", return_value="certs updated"
+    ) as mock_update:
+        result = runner.invoke(dtaas, ["admin", "update", "--certs"])
+
+    assert result.exit_code == 0
+    assert "certs updated" in result.output
+    mock_update.assert_called_once_with(".")
+
+
+def test_admin_update_requires_a_target(runner):
+    """update without a target flag fails with a helpful message."""
+    result = runner.invoke(dtaas, ["admin", "update"])
+
+    assert result.exit_code != 0
+    assert "Nothing to update" in result.output
+
+
+def test_admin_update_validation_error(runner):
+    """A CertValidationError surfaces as a ClickException with its message."""
+    with patch(
+        "src.cmd.certUpdatePkg.update_certs",
+        side_effect=CertValidationError("Certificate expired on 2024-01-01."),
+    ):
+        result = runner.invoke(dtaas, ["admin", "update", "--certs"])
+
+    assert result.exit_code != 0
+    assert "expired" in result.output
+
+
+def test_admin_update_os_error(runner):
+    """An OSError (e.g. missing certs-src) surfaces as a ClickException."""
+    with patch(
+        "src.cmd.certUpdatePkg.update_certs",
+        side_effect=OSError("certs-src directory not found"),
+    ):
+        result = runner.invoke(dtaas, ["admin", "update", "--certs"])
+
+    assert result.exit_code != 0
+    assert "certs-src" in result.output

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -235,8 +235,17 @@ def mock_deploy_pkg():
     """Mock the deploy package handlers used by install/uninstall."""
     with patch("src.cmd.deployPkg.install") as mock_install, patch(
         "src.cmd.deployPkg.uninstall"
-    ) as mock_uninstall:
-        yield {"install": mock_install, "uninstall": mock_uninstall}
+    ) as mock_uninstall, patch(
+        "src.cmd.deployPkg.installation_present", return_value=True
+    ) as mock_present, patch(
+        "src.cmd.provision_user_files"
+    ) as mock_provision:
+        yield {
+            "install": mock_install,
+            "uninstall": mock_uninstall,
+            "present": mock_present,
+            "provision": mock_provision,
+        }
 
 
 def test_admin_install_success(runner, mock_deploy_pkg):
@@ -246,6 +255,7 @@ def test_admin_install_success(runner, mock_deploy_pkg):
     assert result.exit_code == 0
     assert "Deployment installed successfully" in result.output
     mock_deploy_pkg["install"].assert_called_once_with(".")
+    mock_deploy_pkg["provision"].assert_called_once_with(".")
 
 
 def test_admin_install_error(runner, mock_deploy_pkg):
@@ -312,6 +322,18 @@ def test_admin_uninstall_error(runner, mock_deploy_pkg):
 
     assert result.exit_code != 0
     assert "daemon down" in result.output
+
+
+def test_admin_uninstall_no_existing_installation(runner, mock_deploy_pkg):
+    """A repeated uninstall reports there is nothing installed, not success."""
+    mock_deploy_pkg["present"].return_value = False
+
+    result = runner.invoke(dtaas, ["admin", "uninstall"])
+
+    assert result.exit_code == 0
+    assert "no existing DTaaS / Workspace installation" in result.output
+    assert "uninstalled successfully" not in result.output
+    mock_deploy_pkg["uninstall"].assert_not_called()
 
 
 def test_admin_update_certs_success(runner):

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -237,9 +237,7 @@ def mock_deploy_pkg():
         "src.cmd.deployPkg.uninstall"
     ) as mock_uninstall, patch(
         "src.cmd.deployPkg.installation_present", return_value=True
-    ) as mock_present, patch(
-        "src.cmd.provision_user_files"
-    ) as mock_provision:
+    ) as mock_present, patch("src.cmd.provision_user_files") as mock_provision:
         yield {
             "install": mock_install,
             "uninstall": mock_uninstall,

--- a/cli/tests/test_cmd_utils.py
+++ b/cli/tests/test_cmd_utils.py
@@ -1,7 +1,12 @@
 """Tests for the CLI helper functions in cmd_utils.py."""
 
-from unittest.mock import MagicMock
-from src.cmd_utils import VerticalChoicesCommand, _find_toml, _certs_src
+from unittest.mock import MagicMock, patch
+from src.cmd_utils import (
+    VerticalChoicesCommand,
+    _find_toml,
+    _certs_src,
+    provision_user_files,
+)
 
 
 def test_param_rows_skips_hidden_param():
@@ -35,3 +40,29 @@ def test_certs_src_handles_missing_section():
     assert _certs_src({}) == ""
     assert _certs_src({"common": {"security": "oops"}}) == ""
     assert _certs_src({"common": {"security": {"certs-src": " /x "}}}) == "/x"
+
+
+def test_provision_user_files_creates_dirs_and_sets_permissions(tmp_path):
+    """provision_user_files recreates per-user dirs from toml and fixes ownership."""
+    (tmp_path / "dtaas.toml").write_text(
+        '[users]\nadd = ["alice"]\n'
+    )
+    with patch("src.cmd_utils.projectPkg.create_user_dirs") as mock_create, patch(
+        "src.cmd_utils.projectPkg.set_files_permissions"
+    ) as mock_perms:
+        provision_user_files(str(tmp_path))
+
+    mock_create.assert_called_once_with(str(tmp_path), ["alice"])
+    mock_perms.assert_called_once_with(str(tmp_path))
+
+
+def test_provision_user_files_noop_without_toml(tmp_path, monkeypatch):
+    """provision_user_files does nothing when no dtaas.toml is present."""
+    monkeypatch.chdir(tmp_path)  # no dtaas.toml in output dir or cwd
+    with patch("src.cmd_utils.projectPkg.create_user_dirs") as mock_create, patch(
+        "src.cmd_utils.projectPkg.set_files_permissions"
+    ) as mock_perms:
+        provision_user_files(str(tmp_path))
+
+    mock_create.assert_not_called()
+    mock_perms.assert_not_called()

--- a/cli/tests/test_cmd_utils.py
+++ b/cli/tests/test_cmd_utils.py
@@ -44,9 +44,7 @@ def test_certs_src_handles_missing_section():
 
 def test_provision_user_files_creates_dirs_and_sets_permissions(tmp_path):
     """provision_user_files recreates per-user dirs from toml and fixes ownership."""
-    (tmp_path / "dtaas.toml").write_text(
-        '[users]\nadd = ["alice"]\n'
-    )
+    (tmp_path / "dtaas.toml").write_text('[users]\nadd = ["alice"]\n')
     with patch("src.cmd_utils.projectPkg.create_user_dirs") as mock_create, patch(
         "src.cmd_utils.projectPkg.set_files_permissions"
     ) as mock_perms:

--- a/cli/tests/test_deploy.py
+++ b/cli/tests/test_deploy.py
@@ -107,16 +107,39 @@ def test_user_files_dir_absent(tmp_path):
     assert deploy._user_files_dir(str(tmp_path)) is None
 
 
-def test_delete_user_files_removes_dir(tmp_path):
-    """delete_user_files removes the files/ directory and reports it."""
+def test_delete_user_files_removes_per_user_dir(tmp_path):
+    """delete_user_files removes a per-user directory and reports it."""
     (tmp_path / "files" / "alice").mkdir(parents=True)
     message = deploy.delete_user_files(str(tmp_path))
     assert "Removed user files" in message
-    assert not (tmp_path / "files").exists()
+    assert not (tmp_path / "files" / "alice").exists()
+    assert (tmp_path / "files").is_dir()
+
+
+def test_delete_user_files_keeps_scaffolding(tmp_path):
+    """delete_user_files keeps files/common and files/template for reinstall."""
+    files = tmp_path / "files"
+    (files / "alice").mkdir(parents=True)
+    (files / "common").mkdir()
+    (files / "template").mkdir()
+
+    deploy.delete_user_files(str(tmp_path))
+
+    assert not (files / "alice").exists()
+    assert (files / "common").is_dir()
+    assert (files / "template").is_dir()
+
+
+def test_delete_user_files_reports_when_only_scaffolding(tmp_path):
+    """With only scaffolding present there are no per-user dirs to remove."""
+    (tmp_path / "files" / "common").mkdir(parents=True)
+    (tmp_path / "files" / "template").mkdir()
+
+    assert "nothing to remove" in deploy.delete_user_files(str(tmp_path))
 
 
 def test_delete_user_files_absent(tmp_path):
-    """delete_user_files reports when there is nothing to remove."""
+    """delete_user_files reports when there is no files/ directory at all."""
     assert "nothing to remove" in deploy.delete_user_files(str(tmp_path))
 
 
@@ -137,14 +160,62 @@ def test_uninstall_requires_compose_file(tmp_path):
 
 
 def test_uninstall_removes_user_files(tmp_path):
-    """uninstall with remove_user_files deletes the files/ directory."""
+    """uninstall with remove_user_files deletes per-user directories."""
     (tmp_path / "docker-compose.yml").write_text("services: {}")
     (tmp_path / "files" / "bob").mkdir(parents=True)
     with patch("src.pkg.deploy._client"):
         message = deploy.uninstall(str(tmp_path), remove_user_files=True)
         assert message is not None
         assert "Removed user files" in message
-        assert not (tmp_path / "files").exists()
+        assert not (tmp_path / "files" / "bob").exists()
+        assert (tmp_path / "files").is_dir()
+
+
+def test_uninstall_downs_user_containers_then_main(tmp_path):
+    """uninstall tears down user-added containers before the main project."""
+    (tmp_path / "docker-compose.yml").write_text("services: {}")
+    with patch("src.pkg.deploy._down_user_containers") as mock_down_users, patch(
+        "src.pkg.deploy._client"
+    ) as mock_client:
+        deploy.uninstall(str(tmp_path))
+    mock_down_users.assert_called_once_with(str(tmp_path))
+    mock_client.return_value.compose.down.assert_called_once_with()
+
+
+def test_down_user_containers_tears_down_user_compose(tmp_path):
+    """_down_user_containers downs compose.users.yml with --remove-orphans."""
+    (tmp_path / "compose.users.yml").write_text("services: {}")
+    with patch("src.pkg.deploy.DockerClient") as mock_docker:
+        deploy._down_user_containers(str(tmp_path))
+    mock_docker.return_value.compose.down.assert_called_once_with(remove_orphans=True)
+
+
+def test_down_user_containers_noop_without_user_compose(tmp_path):
+    """_down_user_containers does nothing when no user compose file exists."""
+    with patch("src.pkg.deploy.DockerClient") as mock_docker:
+        deploy._down_user_containers(str(tmp_path))
+    mock_docker.assert_not_called()
+
+
+def test_installation_present_true_when_main_has_containers(tmp_path):
+    """installation_present is True when the main project has any container."""
+    (tmp_path / "docker-compose.yml").write_text("services: {}")
+    with patch("src.pkg.deploy._client") as mock_client:
+        mock_client.return_value.compose.ps.return_value = [MagicMock()]
+        assert deploy.installation_present(str(tmp_path)) is True
+
+
+def test_installation_present_false_when_nothing_exists(tmp_path):
+    """installation_present is False when neither main nor user containers exist."""
+    (tmp_path / "docker-compose.yml").write_text("services: {}")
+    with patch("src.pkg.deploy._client") as mock_client:
+        mock_client.return_value.compose.ps.return_value = []
+        assert deploy.installation_present(str(tmp_path)) is False
+
+
+def test_installation_present_false_without_compose_file(tmp_path):
+    """installation_present is False when no deployment has been generated."""
+    assert deploy.installation_present(str(tmp_path)) is False
 
 
 def test_restart_service_force_recreates(tmp_path):

--- a/cli/tests/test_deploy.py
+++ b/cli/tests/test_deploy.py
@@ -1,6 +1,6 @@
 """Tests for the deploy module (admin install / uninstall handlers)."""
 
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 import pytest
 from python_on_whales.exceptions import DockerException
 from src.pkg import deploy
@@ -140,3 +140,42 @@ def test_restart_service_requires_compose_file(tmp_path):
         with pytest.raises(OSError, match="docker-compose.yml"):
             deploy.restart_service(str(tmp_path), "traefik")
         mock_client.assert_not_called()
+
+
+def test_stop_service_stops_named_service(tmp_path):
+    """stop_service stops only the named compose service."""
+    (tmp_path / "docker-compose.yml").write_text("services: {}")
+    with patch("src.pkg.deploy._client") as mock_client:
+        deploy.stop_service(str(tmp_path), "traefik")
+        mock_client.return_value.compose.stop.assert_called_once_with(
+            services=["traefik"]
+        )
+
+
+def test_stop_service_requires_compose_file(tmp_path):
+    """stop_service refuses to act without a generated deployment."""
+    with patch("src.pkg.deploy._client") as mock_client:
+        with pytest.raises(OSError, match="docker-compose.yml"):
+            deploy.stop_service(str(tmp_path), "traefik")
+        mock_client.assert_not_called()
+
+
+def test_service_running_true_when_container_up(tmp_path):
+    """service_running returns True when the service's container is running."""
+    (tmp_path / "docker-compose.yml").write_text("services: {}")
+    container = MagicMock()
+    container.state.running = True
+    with patch("src.pkg.deploy._client") as mock_client:
+        mock_client.return_value.compose.ps.return_value = [container]
+        assert deploy.service_running(str(tmp_path), "traefik") is True
+        mock_client.return_value.compose.ps.assert_called_once_with(
+            services=["traefik"]
+        )
+
+
+def test_service_running_false_when_no_container(tmp_path):
+    """service_running returns False when no running container is listed."""
+    (tmp_path / "docker-compose.yml").write_text("services: {}")
+    with patch("src.pkg.deploy._client") as mock_client:
+        mock_client.return_value.compose.ps.return_value = []
+        assert deploy.service_running(str(tmp_path), "traefik") is False

--- a/cli/tests/test_deploy.py
+++ b/cli/tests/test_deploy.py
@@ -33,6 +33,29 @@ def test_require_deployment_toml_falls_back_to_cwd(tmp_path, monkeypatch):
     deploy._require_deployment(str(outdir))  # does not raise
 
 
+def test_env_files_returns_config_env_when_present(tmp_path):
+    """_env_files returns config/.env so compose loads it explicitly."""
+    (tmp_path / "config").mkdir()
+    env_file = tmp_path / "config" / ".env"
+    env_file.write_text("OAUTH_URL=https://gitlab.com\n")
+    assert deploy._env_files(str(tmp_path)) == [str(env_file)]
+
+
+def test_env_files_empty_when_no_config_env(tmp_path):
+    """_env_files is empty for deploy types that keep .env at the root."""
+    assert deploy._env_files(str(tmp_path)) == []
+
+
+def test_client_passes_env_files(tmp_path):
+    """_client forwards config/.env to the DockerClient as an env file."""
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / ".env").write_text("OAUTH_URL=https://gitlab.com\n")
+    with patch("src.pkg.deploy.DockerClient") as mock_docker:
+        deploy._client(str(tmp_path))
+    _, kwargs = mock_docker.call_args
+    assert kwargs["compose_env_files"] == [str(tmp_path / "config" / ".env")]
+
+
 def test_install_runs_compose_up(tmp_path):
     """install validates inputs and runs 'docker compose up' detached."""
     (tmp_path / "docker-compose.yml").write_text("services: {}")

--- a/cli/tests/test_deploy.py
+++ b/cli/tests/test_deploy.py
@@ -122,3 +122,21 @@ def test_uninstall_removes_user_files(tmp_path):
         assert message is not None
         assert "Removed user files" in message
         assert not (tmp_path / "files").exists()
+
+
+def test_restart_service_force_recreates(tmp_path):
+    """restart_service force-recreates only the named service, detached."""
+    (tmp_path / "docker-compose.yml").write_text("services: {}")
+    with patch("src.pkg.deploy._client") as mock_client:
+        deploy.restart_service(str(tmp_path), "traefik")
+        mock_client.return_value.compose.up.assert_called_once_with(
+            services=["traefik"], force_recreate=True, detach=True
+        )
+
+
+def test_restart_service_requires_compose_file(tmp_path):
+    """restart_service refuses to act without a generated deployment."""
+    with patch("src.pkg.deploy._client") as mock_client:
+        with pytest.raises(OSError, match="docker-compose.yml"):
+            deploy.restart_service(str(tmp_path), "traefik")
+        mock_client.assert_not_called()

--- a/cli/tests/test_deploy.py
+++ b/cli/tests/test_deploy.py
@@ -130,6 +130,26 @@ def test_delete_user_files_keeps_scaffolding(tmp_path):
     assert (files / "template").is_dir()
 
 
+def test_remove_user_dirs_skips_symlinks_and_files(tmp_path):
+    """_remove_user_dirs leaves symlinked dirs and plain files untouched."""
+    files = tmp_path / "files"
+    (files / "alice").mkdir(parents=True)
+    (files / "loose.txt").write_text("x")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    try:
+        (files / "link").symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation is not permitted on this platform")
+
+    removed = deploy._remove_user_dirs(files)
+
+    assert removed == ["alice"]
+    assert (files / "link").exists()
+    assert (files / "loose.txt").exists()
+    assert outside.is_dir()
+
+
 def test_delete_user_files_reports_when_only_scaffolding(tmp_path):
     """With only scaffolding present there are no per-user dirs to remove."""
     (tmp_path / "files" / "common").mkdir(parents=True)

--- a/cli/tests/test_deploy_config.py
+++ b/cli/tests/test_deploy_config.py
@@ -164,6 +164,19 @@ def test_check_placeholders_returns_warning_for_unresolved(tmp_path):
     assert any("your_client_id_here" in w for w in warnings)
 
 
+def test_check_placeholders_ignores_placeholder_substring(tmp_path):
+    """A real value that merely contains a placeholder substring is not flagged."""
+    env = tmp_path / "config" / ".env"
+    env.parent.mkdir()
+    env.write_text("KEYCLOAK_ADMIN_PASSWORD=changemed\n")
+
+    warnings = check_placeholders(
+        str(tmp_path),
+        [("config/.env", "env", {"KEYCLOAK_ADMIN_PASSWORD": "changemed"})],
+    )
+    assert not warnings
+
+
 def test_check_placeholders_skips_missing_files(tmp_path):
     """check_placeholders ignores files that don't exist in dest_dir"""
     warnings = check_placeholders(

--- a/cli/tests/test_deploy_config.py
+++ b/cli/tests/test_deploy_config.py
@@ -168,11 +168,11 @@ def test_check_placeholders_ignores_placeholder_substring(tmp_path):
     """A real value that merely contains a placeholder substring is not flagged."""
     env = tmp_path / "config" / ".env"
     env.parent.mkdir()
-    env.write_text("KEYCLOAK_ADMIN_PASSWORD=changemed\n")
+    env.write_text("KEYCLOAK_ADMIN_PASSWORD=changemed\n")  # NOSONAR
 
     warnings = check_placeholders(
         str(tmp_path),
-        [("config/.env", "env", {"KEYCLOAK_ADMIN_PASSWORD": "changemed"})],
+        [("config/.env", "env", {"KEYCLOAK_ADMIN_PASSWORD": "changemed"})],  # NOSONAR
     )
     assert not warnings
 

--- a/cli/tests/test_project.py
+++ b/cli/tests/test_project.py
@@ -202,6 +202,21 @@ def test_copy_example_files_raises_on_copy_failure(tmp_path):
             _copy_example_files(tmp_path)
 
 
+def test_set_files_permissions_chowns_and_chmods_files_dir(tmp_path):
+    """set_files_permissions sets ownership to 1000:100 then grants rwX on files/."""
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+
+    with patch("src.pkg.project.subprocess.run") as mock_run:
+        set_files_permissions(str(tmp_path))
+
+    commands = [call.args[0] for call in mock_run.call_args_list]
+    assert commands == [
+        ["sudo", "chown", "-R", "1000:100", str(files_dir)],
+        ["sudo", "chmod", "-R", "u+rwX,go+rwX", str(files_dir)],
+    ]
+
+
 def test_set_files_permissions_ignores_missing_sudo(tmp_path):
     """set_files_permissions swallows FileNotFoundError when sudo is unavailable."""
     (tmp_path / "files").mkdir()

--- a/cli/tests/test_project.py
+++ b/cli/tests/test_project.py
@@ -15,6 +15,7 @@ from src.pkg.project import (
     _validate_deploy_inputs,
     DEPLOY_TYPES,
 )
+# pylint: disable=protected-access
 
 
 def test_generate_project_skips_existing_file(tmp_path, capsys):
@@ -33,13 +34,6 @@ def test_generate_project_raises_on_copy_failure(tmp_path):
     with patch("src.pkg.project.shutil.copy2", side_effect=OSError("disk full")):
         with pytest.raises(OSError, match="disk full"):
             generate_project(str(tmp_path))
-
-
-def test_generate_project_creates_missing_dest(tmp_path):
-    """generate_project creates the destination directory if it does not exist."""
-    new_dir = tmp_path / "new_output"
-    generate_project(str(new_dir))
-    assert new_dir.is_dir()
 
 
 def test_copy_file_skips_existing(tmp_path, capsys):
@@ -74,17 +68,6 @@ def test_check_no_symlinks_raises_on_symlink(tmp_path):
         _check_no_symlinks(src, [real, link])
 
 
-def test_check_no_symlinks_passes_for_regular_files(tmp_path):
-    """No exception is raised when all entries are regular files."""
-    src = tmp_path / "src"
-    src.mkdir()
-    entries = [src / "a.txt", src / "b.txt"]
-    for e in entries:
-        e.write_text("x")
-
-    _check_no_symlinks(src, entries)  # must not raise
-
-
 def test_copy_tree_collects_errors(tmp_path):
     """All files are attempted even when copies fail; errors are raised together."""
     src = tmp_path / "src"
@@ -99,22 +82,6 @@ def test_copy_tree_collects_errors(tmp_path):
             _copy_tree(src, dest, force=False)
 
 
-def test_copy_tree_delegates_to_helpers(tmp_path):
-    """_copy_tree successfully copies a plain directory tree end-to-end."""
-    src = tmp_path / "src"
-    src.mkdir()
-    (src / "a.txt").write_text("a")
-    (src / "sub").mkdir()
-    (src / "sub" / "b.txt").write_text("b")
-    dest = tmp_path / "dest"
-    dest.mkdir()
-
-    _copy_tree(src, dest)
-
-    assert (dest / "a.txt").read_text() == "a"
-    assert (dest / "sub" / "b.txt").read_text() == "b"
-
-
 def test_validate_deploy_inputs_raises_for_unknown_type(tmp_path):
     """ValueError for an unrecognised deploy type."""
     with pytest.raises(ValueError, match="Unknown deploy type"):
@@ -125,15 +92,6 @@ def test_validate_deploy_inputs_raises_if_src_missing(tmp_path):
     """RuntimeError when the template directory is absent."""
     with pytest.raises(RuntimeError, match="Template directory not found"):
         _validate_deploy_inputs("localhost", tmp_path / "missing", tmp_path)
-
-
-def test_validate_deploy_inputs_creates_missing_dest(tmp_path):
-    """Missing destination directory is created instead of raising."""
-    src = tmp_path / "localhost"
-    src.mkdir()
-    missing = tmp_path / "missing"
-    _validate_deploy_inputs("localhost", src, missing)
-    assert missing.is_dir()
 
 
 REQUIRED_FILES = {
@@ -210,52 +168,12 @@ def test_create_user_dirs_skips_when_no_template(tmp_path):
     assert not (tmp_path / "files" / "alice").exists()
 
 
-def test_set_files_permissions_chmods_files_dir(tmp_path):
-    """set_files_permissions runs sudo chmod -R on the files/ directory."""
-    files_dir = tmp_path / "files"
-    files_dir.mkdir(parents=True)
-
-    with patch("src.pkg.project.subprocess.run") as mock_run:
-        set_files_permissions(str(tmp_path))
-
-    mock_run.assert_called_once_with(
-        ["sudo", "chmod", "-R", "u+rwX,go+rwX", str(files_dir)],
-        check=True,
-    )
-
-
 def test_set_files_permissions_skips_when_no_files_dir(tmp_path):
     """set_files_permissions is a no-op when files/ does not exist."""
     with patch("src.pkg.project.subprocess.run") as mock_run:
         set_files_permissions(str(tmp_path))
 
     mock_run.assert_not_called()
-
-
-def test_create_user_dirs_skips_existing_user_dir(tmp_path):
-    """create_user_dirs does not overwrite an existing user directory."""
-    template = tmp_path / "files" / "template"
-    template.mkdir(parents=True)
-    (template / "readme.txt").write_text("new")
-    user_dir = tmp_path / "files" / "alice"
-    user_dir.mkdir(parents=True)
-    (user_dir / "readme.txt").write_text("old")
-
-    create_user_dirs(str(tmp_path), ["alice"])
-
-    assert (user_dir / "readme.txt").read_text() == "old"
-
-
-def test_copy_example_files_creates_actual_files(tmp_path):
-    """_copy_example_files creates non-example copies of all .example files."""
-    (tmp_path / "config").mkdir()
-    (tmp_path / "config" / ".env.example").write_text("KEY=value")
-    (tmp_path / "config" / "app.js.example").write_text("var x = 1;")
-
-    _copy_example_files(tmp_path)
-
-    assert (tmp_path / "config" / ".env").read_text() == "KEY=value"
-    assert (tmp_path / "config" / "app.js").read_text() == "var x = 1;"
 
 
 def test_copy_example_files_skips_existing_without_force(tmp_path):
@@ -268,11 +186,38 @@ def test_copy_example_files_skips_existing_without_force(tmp_path):
     assert (tmp_path / "a").read_text() == "old"
 
 
-def test_copy_example_files_overwrites_with_force(tmp_path):
-    """_copy_example_files overwrites existing files when force=True."""
-    (tmp_path / "a.example").write_text("new")
-    (tmp_path / "a").write_text("old")
+def test_generate_project_raises_when_templates_dir_missing(tmp_path):
+    """generate_project raises RuntimeError when the bundled templates are absent."""
+    with patch("src.pkg.project.TEMPLATES_DIR", tmp_path / "no-templates"):
+        with pytest.raises(RuntimeError, match="templates directory not found"):
+            generate_project(str(tmp_path / "out"))
 
-    _copy_example_files(tmp_path, force=True)
 
-    assert (tmp_path / "a").read_text() == "new"
+def test_copy_example_files_raises_on_copy_failure(tmp_path):
+    """A failing .example copy is collected and surfaced as an OSError."""
+    (tmp_path / "a.example").write_text("x")
+
+    with patch("src.pkg.project.shutil.copy2", side_effect=OSError("disk full")):
+        with pytest.raises(OSError, match="disk full"):
+            _copy_example_files(tmp_path)
+
+
+def test_set_files_permissions_ignores_missing_sudo(tmp_path):
+    """set_files_permissions swallows FileNotFoundError when sudo is unavailable."""
+    (tmp_path / "files").mkdir()
+
+    with patch(
+        "src.pkg.project.subprocess.run", side_effect=FileNotFoundError("no sudo")
+    ):
+        set_files_permissions(str(tmp_path))  # must not raise
+
+
+def test_generate_deploy_project_warns_when_no_templates(tmp_path, capsys):
+    """generate_deploy_project warns and returns early when no templates exist."""
+    with patch("src.pkg.project._validate_deploy_inputs"), patch(
+        "src.pkg.project._has_template_files", return_value=False
+    ), patch("src.pkg.project._copy_tree") as mock_copy:
+        generate_deploy_project("localhost", str(tmp_path))
+
+    assert "no deployment templates found" in capsys.readouterr().out
+    mock_copy.assert_not_called()

--- a/cli/tests/test_users.py
+++ b/cli/tests/test_users.py
@@ -4,8 +4,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch, MagicMock
 import pytest
-from src.pkg import users, users_utils
-from tests.conftest import CONF_SERVER_CONTENT
+from src.pkg import users
 # pylint: disable=redefined-outer-name,unused-argument
 
 

--- a/cli/tests/test_users.py
+++ b/cli/tests/test_users.py
@@ -66,10 +66,14 @@ def test_create_user_files(temp_dir_with_template, usernames):
     assert all(Path(temp_dir_with_template, u).exists() for u in usernames)
 
 
-def test_create_user_files_already_exists(temp_dir_with_template):
-    """Test create_user_files when directory already exists"""
-    Path(temp_dir_with_template, "testuser").mkdir(parents=True)
-    assert users.create_user_files(["testuser"], temp_dir_with_template) is None
+def test_create_user_files_chowns_nested_items(temp_dir_with_template):
+    """When chown succeeds, ownership is applied to the dir and every nested item."""
+    with patch("src.pkg.users.shutil.chown") as mock_chown:
+        assert users.create_user_files(["alice"], temp_dir_with_template) is None
+
+    chowned = [call.args[0] for call in mock_chown.call_args_list]
+    assert Path(temp_dir_with_template, "alice") in chowned
+    assert Path(temp_dir_with_template, "alice", "test.txt") in chowned
 
 
 def test_add_users_to_compose(mock_utils):
@@ -157,13 +161,26 @@ def test_add_users_missing_fields(
     assert users.add_users(mock_config) is None and field in compose
 
 
-def test_add_users_export_error(mock_config, mock_utils, mock_user_operations):
-    """Test add_users handles export errors"""
-    mock_utils["export"].return_value = Exception("Export failed")
-    assert users.add_users(mock_config) is not None
+def test_add_users_returns_config_error(mock_config, mock_utils):
+    """add_users returns the exception when config retrieval fails."""
+    mock_config.get_add_users_list.return_value = (None, Exception("missing add list"))
+
+    err = users.add_users(mock_config)
+
+    assert err is not None and "missing add list" in str(err)
 
 
-# deleteUser tests
+def test_add_users_rejects_newline_in_email(
+    mock_config, mock_utils, mock_user_operations
+):
+    """A newline in a user's email aborts add_users without writing the rule."""
+    mock_config.get_users.return_value = ({"user1": {"email": "bad\n@x.com"}}, None)
+
+    err = users.add_users(mock_config)
+
+    assert err is not None and "newlines" in str(err)
+
+
 @pytest.mark.parametrize("export_error", [False, True])
 def test_delete_user(mock_config, mock_utils, mock_user_operations, export_error):
     """Test delete_user removes users from compose"""
@@ -176,41 +193,12 @@ def test_delete_user(mock_config, mock_utils, mock_user_operations, export_error
     assert (err is not None) if export_error else err is None
 
 
-def test_delete_user_skips_nonexistent(
-    mock_config, mock_utils, mock_user_operations, capsys
+def test_delete_user_handles_none_compose(
+    mock_config, mock_utils, mock_user_operations
 ):
-    """Test delete_user skips users not present in compose services"""
-    compose = {"version": "3", "services": {"user1": {}}}
-    mock_config.get_delete_users_list.return_value = (["user1", "ghost"], None)
-    mock_utils["import"].return_value = (compose, None)
-    mock_utils["export"].return_value = None
+    """delete_user returns an error when the compose file loads as None."""
+    mock_utils["import"].return_value = (None, None)
 
     err = users.delete_user(mock_config)
 
-    assert err is None
-    captured = capsys.readouterr()
-    assert "'ghost' does not exist, skipping deletion" in captured.out
-    mock_user_operations["stop"].assert_called_once_with(["user1"])
-
-
-def test_delete_user_removes_conf_server_rules(
-    mock_config, mock_utils, mock_user_operations, tmp_path, monkeypatch
-):
-    """delete_user removes conf.server rules for each deleted user"""
-    conf = tmp_path / "config" / "conf.server"
-    conf.parent.mkdir()
-    conf.write_text(CONF_SERVER_CONTENT, encoding="utf-8")
-    monkeypatch.setattr(users_utils, "CONF_SERVER_PATH", conf)
-
-    compose = {"version": "3", "services": {"user1": {}, "user2": {}}}
-    mock_config.get_delete_users_list.return_value = (["user1"], None)
-    mock_utils["import"].return_value = (compose, None)
-    mock_utils["export"].return_value = None
-
-    err = users.delete_user(mock_config)
-
-    assert err is None
-    result = conf.read_text(encoding="utf-8")
-    assert "rule.onlyu1" not in result
-    assert "user1@example.com" not in result
-    assert "rule.onlyu2.action=auth" in result
+    assert err is not None and "Failed to load compose" in str(err)

--- a/cli/tests/test_users.py
+++ b/cli/tests/test_users.py
@@ -5,6 +5,8 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch, MagicMock
 import pytest
 from src.pkg import users
+from src.pkg import users_utils
+from tests.conftest import CONF_SERVER_CONTENT
 # pylint: disable=redefined-outer-name,unused-argument
 
 
@@ -180,6 +182,30 @@ def test_add_users_rejects_newline_in_email(
     assert err is not None and "newlines" in str(err)
 
 
+def test_add_users_writes_conf_server_before_starting_containers(
+    mock_config, mock_utils, mock_user_operations, tmp_path, monkeypatch
+):
+    """Forward-auth rules are written even when 'docker compose up' fails."""
+    conf = tmp_path / "config" / "conf.server"
+    conf.parent.mkdir()
+    conf.write_text(CONF_SERVER_CONTENT, encoding="utf-8")
+    monkeypatch.setattr(users_utils, "CONF_SERVER_PATH", conf)
+
+    mock_config.get_add_users_list.return_value = (["user3"], None)
+    mock_config.get_users.return_value = (
+        {"add": ["user3"], "user3": {"email": "user3@example.com"}},
+        None,
+    )
+    mock_user_operations["start"].return_value = Exception("compose up failed")
+
+    err = users.add_users(mock_config)
+
+    assert err is not None and "compose up failed" in str(err)
+    text = conf.read_text(encoding="utf-8")
+    assert "rule.onlyu3.rule=PathPrefix(`/user3`)" in text
+    assert "rule.onlyu3.whitelist=user3@example.com" in text
+
+
 @pytest.mark.parametrize("export_error", [False, True])
 def test_delete_user(mock_config, mock_utils, mock_user_operations, export_error):
     """Test delete_user removes users from compose"""
@@ -190,6 +216,21 @@ def test_delete_user(mock_config, mock_utils, mock_user_operations, export_error
 
     err = users.delete_user(mock_config)
     assert (err is not None) if export_error else err is None
+
+
+def test_delete_user_removes_conf_server_rules(
+    mock_config, mock_utils, mock_user_operations
+):
+    """delete_user removes each deleted user's forward-auth rule from conf.server."""
+    compose = {"version": "3", "services": {"user1": {}, "user2": {}}}
+    mock_config.get_delete_users_list.return_value = (["user1"], None)
+    mock_utils["import"].return_value = (compose, None)
+
+    with patch("src.pkg.users.remove_conf_server_entry") as mock_remove:
+        err = users.delete_user(mock_config)
+
+    assert err is None
+    mock_remove.assert_called_once_with("user1")
 
 
 def test_delete_user_handles_none_compose(

--- a/cli/tests/test_users_utils.py
+++ b/cli/tests/test_users_utils.py
@@ -43,6 +43,18 @@ def test_add_conf_server_entry_appends_block(tmp_path, monkeypatch):
     assert "rule.onlyu3.whitelist=alice@example.com" in result
 
 
+def test_add_conf_server_entry_skips_existing_user(tmp_path, monkeypatch):
+    """add_conf_server_entry does not duplicate a rule for a user already present"""
+    conf = tmp_path / "config" / "conf.server"
+    conf.parent.mkdir()
+    conf.write_text(CONF_SERVER_CONTENT, encoding="utf-8")
+    monkeypatch.setattr(users_utils, "CONF_SERVER_PATH", conf)
+
+    add_conf_server_entry("user1", "user1@example.com")
+
+    assert conf.read_text(encoding="utf-8") == CONF_SERVER_CONTENT
+
+
 def test_add_conf_server_entry_skips_when_no_email(tmp_path, monkeypatch):
     """add_conf_server_entry does nothing when email is empty"""
     conf = tmp_path / "config" / "conf.server"

--- a/cli/tests/test_utils.py
+++ b/cli/tests/test_utils.py
@@ -27,7 +27,7 @@ def test_import_toml():
 
     expected = {
         "name": "Digital Twin as a Service (DTaaS)",
-        "version": "0.7.0",
+        "version": "0.8.0",
         "owner": "The INTO-CPS-Association",
         "git-repo": "https://github.com/into-cps-association/DTaaS.git",
         "common": {

--- a/deploy/services/cli/poetry.lock
+++ b/deploy/services/cli/poetry.lock
@@ -200,14 +200,14 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.4.1"
+version = "8.4.2"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2"},
-    {file = "click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96"},
+    {file = "click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"},
+    {file = "click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"},
 ]
 
 [package.dependencies]
@@ -444,14 +444,14 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3"},
-    {file = "idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242"},
+    {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
+    {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
 ]
 
 [package.extras]
@@ -847,14 +847,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylint"
-version = "4.0.5"
+version = "4.0.6"
 description = "python code static checker"
 optional = false
 python-versions = ">=3.10.0"
 groups = ["dev"]
 files = [
-    {file = "pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2"},
-    {file = "pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c"},
+    {file = "pylint-4.0.6-py3-none-any.whl", hash = "sha256:d11a0e1fdb7b1cd46ec5d6fc78fee8b95f28695b2d6140e5809925f61e32ea54"},
+    {file = "pylint-4.0.6.tar.gz", hash = "sha256:52f19191bee08bf103f9705ad1a0ece4aa5a0a4ef2bdcbd969375a1e6f6579d5"},
 ]
 
 [package.dependencies]
@@ -877,14 +877,14 @@ testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pyright"
-version = "1.1.409"
+version = "1.1.411"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3"},
-    {file = "pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93"},
+    {file = "pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9"},
+    {file = "pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998"},
 ]
 
 [package.dependencies]
@@ -898,14 +898,14 @@ nodejs = ["nodejs-wheel-binaries"]
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
-    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
+    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
+    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
 ]
 
 [package.dependencies]
@@ -1178,14 +1178,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]
@@ -1197,4 +1197,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "7f2e3fb31ce75ecf08e6fc25c7d2ebd601404a55496f75e158b88a3597871158"
+content-hash = "849d1093d8e8950fa7b15d3a386f5dd5cbc547e74b267b39cb3fb7ecbe923c63"

--- a/deploy/services/cli/pyproject.toml
+++ b/deploy/services/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dtaas-services"
-version = "0.4.1"
+version = "0.4.2"
 description = "DTaaS Platform Services Management CLI"
 authors = ["Mohamed Abdulkarim"]
 license = "INTO-CPS-Association"
@@ -12,7 +12,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-click = "^8.4.1"
+click = "^8.4.2"
 python-dotenv = "^1.2.2"
 python-on-whales = "^0.81.0"
 rich = "^15.0.0"
@@ -21,11 +21,11 @@ python-gitlab = "^8.3.0"
 psycopg = {version = "^3.3", extras = ["binary"]}
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^9.0.3"
+pytest = "^9.1.1"
 pytest-cov = "^7.1.0"
 pytest-mock = "^3.15.1"
-pylint = "^4.0.5"
-pyright = "^1.1.409"
+pylint = "^4.0.6"
+pyright = "^1.1.411"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/docs/admin/guides/renew_certs.md
+++ b/docs/admin/guides/renew_certs.md
@@ -28,11 +28,14 @@ restart below with a single command:
 dtaas admin update --certs --output-dir /path/to/deployment
 ```
 
-It validates the renewed pair (parseable, key matches certificate, not
-expired), atomically swaps it into the deployment's `certs/` directory,
-restores `0600` on the private key, and reloads `traefik`. If validation
-fails, the live certificates are left untouched. See the DTaaS CLI `README`
-(`cli/README.md`) for details.
+It validates the renewed pair (parseable, key matches the certificate, and
+neither the leaf nor any intermediate has expired), stops `traefik`, swaps the
+new files into the deployment's `certs/` directory (restoring the previous pair
+if anything goes wrong), then restarts `traefik` and waits for it to come back
+up. On POSIX hosts it also restores `0600` on the private key; on Windows it
+prints a warning, because file permissions cannot be enforced there. If
+validation fails, the live certificates are left untouched. See the DTaaS CLI
+`README` (`cli/README.md`) for details.
 
 The manual steps below remain the reference for the
 `deploy/dtaas/docker/*` package layouts and the services project.

--- a/docs/admin/guides/renew_certs.md
+++ b/docs/admin/guides/renew_certs.md
@@ -16,6 +16,27 @@ sudo certbot renew --dry-run
 sudo certbot renew
 ```
 
+## CLI shortcut for generated deployments
+
+If the deployment was created with the DTaaS CLI (`dtaas generate-deployment`)
+and `[common.security].certs-src` in `dtaas.toml` points at the directory
+holding the renewed `fullchain.pem` / `privkey.pem` (e.g.
+`/etc/letsencrypt/live/your-domain.com`), you can replace the manual copy and
+restart below with a single command:
+
+```bash
+dtaas admin update --certs --output-dir /path/to/deployment
+```
+
+It validates the renewed pair (parseable, key matches certificate, not
+expired), atomically swaps it into the deployment's `certs/` directory,
+restores `0600` on the private key, and reloads `traefik`. If validation
+fails, the live certificates are left untouched. See the DTaaS CLI `README`
+(`cli/README.md`) for details.
+
+The manual steps below remain the reference for the
+`deploy/dtaas/docker/*` package layouts and the services project.
+
 ## Step 2: Deploy to DTaaS server package
 
 For the secure server package (`deploy/dtaas/docker/secure-server`):


### PR DESCRIPTION
# Add dtaas admin update --certs command

## Type of Change

- [X] New feature
- [X] Documentation update

## Description
Adds a CLI command to refresh TLS certificates in a running DTaaS deployment without regenerating the whole project or restarting all containers.

### New command
`dtaas admin update --certs [--output-dir DIR]`
Reads the certificate source from [common.security].certs-src in dtaas.toml, copies the newest fullchain.pem/privkey.pem into the deployment's certs/ directory, and reloads only the traefik container

### Safety guarantees

- New certificates are staged as .new files first, live certs are never touched until validation passes.
- Validation checks: PEM is parseable, private key matches the certificate's public key, certificate is not expired.
- On any failure, staged files are discarded and a ClickException is raised with a clear message.
- Private key permissions are restored to 0600 after the swap.
