### PR TITLE
Better management of DTaaS CLI configuration

### DIFF
--- a/cli/DEVELOPER.md
+++ b/cli/DEVELOPER.md
@@ -74,13 +74,12 @@ existing substitution engine rather than duplicating it:
 (read-only, so it also powers `--dry-run`), and `deploy_config.apply_config`
 writes them (idempotently — only changed files are touched). The deployment
 type is detected from the compose service names via `deploy.compose_services`
-(more robust than inspecting config-file names). A small `_FILE_SERVICES` map
-says which services consume each config file; the services to restart are that
-mapping for the changed files, intersected with the services actually present,
-then recreated through `deploy.restart_service`. `cmd_utils.run_config_update`
-adapts it to the CLI (mapping `OSError`/`ValueError`/`DockerException` to a
-`ClickException`), alongside `run_cert_update` and `require_update_flag` for
-the `update` group.
+(more robust than inspecting config-file names). When any file changed, the
+whole stack is recreated through `deploy.restart_all`
+(`docker compose up -d --force-recreate`), since a config change can affect any
+service. `cmd_utils.run_config_update` adapts it to the CLI (mapping
+`OSError`/`ValueError`/`DockerException` to a `ClickException`), alongside
+`run_cert_update` and `require_update_flag` for the `update` group.
 
 ### TOML File
 

--- a/cli/DEVELOPER.md
+++ b/cli/DEVELOPER.md
@@ -65,6 +65,23 @@ checks are syntactic, but `path` and `certs-src` are verified against the local
 filesystem (the directory must exist), so `validate` is expected to run on the
 deployment host.
 
+`admin update --config` is backed by _src/pkg/config_update.py_, which
+re-applies `dtaas.toml` to an installed deployment in place. It reuses the
+existing substitution engine rather than duplicating it:
+`config_validate.collect_errors` gates the run,
+`deploy_config.build_file_specs` produces the per-file specs,
+`deploy_config.diff_specs` previews which files a spec would change
+(read-only, so it also powers `--dry-run`), and `deploy_config.apply_config`
+writes them (idempotently — only changed files are touched). The deployment
+type is detected from the compose service names via `deploy.compose_services`
+(more robust than inspecting config-file names). A small `_FILE_SERVICES` map
+says which services consume each config file; the services to restart are that
+mapping for the changed files, intersected with the services actually present,
+then recreated through `deploy.restart_service`. `cmd_utils.run_config_update`
+adapts it to the CLI (mapping `OSError`/`ValueError`/`DockerException` to a
+`ClickException`), alongside `run_cert_update` and `require_update_flag` for
+the `update` group.
+
 ### TOML File
 
 The base configuration file used by the CLI is the _dtaas.toml_ file.

--- a/cli/DEVELOPER.md
+++ b/cli/DEVELOPER.md
@@ -55,6 +55,16 @@ The CLI has two layers of code:
   is responsible for. It also
   has helper functions that can be used across the CLI.
 
+The `admin config` commands are backed here: `generate_config` in
+_src/pkg/project.py_ copies just the `dtaas.toml` template (reusing the same
+helpers as `generate-project`), and _src/pkg/config_validate.py_ checks the
+values in an existing `dtaas.toml`. Each check in `config_validate.py` returns
+a list of human-readable problems (empty when the value is acceptable) and
+`validate_config` aggregates them so the user sees every issue at once. Most
+checks are syntactic, but `path` and `certs-src` are verified against the local
+filesystem (the directory must exist), so `validate` is expected to run on the
+deployment host.
+
 ### TOML File
 
 The base configuration file used by the CLI is the _dtaas.toml_ file.
@@ -64,7 +74,7 @@ It has the following sections:
 
 ```toml
 name="Digital Twin as a Service (DTaaS)"
-version="0.8.1"
+version="0.9.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -485,8 +485,8 @@ is strict, so unreplaced placeholders such as `https://your_server_dns/...`
 **Options (both commands):**
 
 - `--output-dir` (default: `.`): for `generate`, the target directory for the
-  new `dtaas.toml` (it must already exist); for `validate`, the directory to
-  look in first.
+  new `dtaas.toml` (it is created if it does not exist); for `validate`, the
+  directory to look in first.
 - `--force` (`generate` only): overwrite an existing `dtaas.toml`. Without it,
   an existing file is left untouched and a message is printed.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -381,6 +381,59 @@ docker compose -f compose.server.yml --env-file .env up -d --force-recreate trae
   '.'s in them cannot be added properly through the CLI.
   This is an active issue that will be resolved in future releases.
 
+### 🛠️ Configuration File
+
+`dtaas.toml` can be generated and checked on its own, without the other project
+files produced by `generate-project`.
+
+To write a fresh `dtaas.toml` template to fill in:
+
+```bash
+dtaas admin config generate
+```
+
+Then, after editing it with your own values, check those values:
+
+```bash
+dtaas admin config validate
+```
+
+`validate` reads `dtaas.toml` (from `--output-dir` first, then the current
+directory) and reports every problem it finds at once. It checks:
+
+| Value | Rule |
+| --- | --- |
+| `git-repo` | must be an `http(s)` URL |
+| `[common].server-dns` | must be `localhost`, an IP, or a dotted (fully qualified) hostname |
+| `[common].path` | must be an absolute path to a directory that exists |
+| `[common.security].certs-src` | when present, must be an absolute path to a directory that exists |
+| `[common.resources].cpus`, `pids_limit` | must be integers |
+| `[common.resources].mem_limit`, `shm_size` | must be size strings (e.g. `4G`, `512m`) |
+| `[users].add`, `[users].delete` | when present, must be lists of strings |
+| `[users.<name>].email` | must be a valid email address |
+| deployment-section URLs | when present, must be `http(s)` URLs |
+| deployment-section `default-user` | when present, must be a valid username |
+
+The deployment-section URLs are `react-app-oauth-url`, `oauth-url`,
+`auth-authority`, and `keycloak-issuer-url` across the `[frontend]`,
+`[localhost]`, `[insecure-server]`, `[secure-server]`, `[workspace-localhost]`,
+and `[workspace-secure-server]` sections; each is checked only when its section
+is present.
+
+`path` and `certs-src` are checked against the local filesystem, so run
+`validate` on the deployment host. A bare single-label `server-dns` (e.g.
+`myhost`) is rejected; use `localhost` or a fully qualified name. URL checking
+is strict, so unreplaced placeholders such as `https://your_server_dns/...`
+(an underscore is not a valid hostname) are reported until you fill them in.
+
+**Options (both commands):**
+
+- `--output-dir` (default: `.`): for `generate`, the target directory for the
+  new `dtaas.toml` (it must already exist); for `validate`, the directory to
+  look in first.
+- `--force` (`generate` only): overwrite an existing `dtaas.toml`. Without it,
+  an existing file is left untouched and a message is printed.
+
 ## ⚙️ Configure
 
 After running `dtaas generate-project`, open `dtaas.toml` and fill in the

--- a/cli/README.md
+++ b/cli/README.md
@@ -272,8 +272,8 @@ error is raised. The command is safe to run repeatedly.
 
 **Options:**
 
-- `--certs`: Refresh the deployment's TLS certificates. Required; it is the
-  only update target today, and the `update` group leaves room for future ones.
+- `--certs`: Refresh the deployment's TLS certificates. Pass at least one of
+  `--certs` or `--config` (see below).
 - `--output-dir` (default: `.`): Installation directory containing the
   generated deployment (the `docker-compose.yml` and `certs/`). The CLI looks
   for `dtaas.toml` here first, then in the current directory. Keep
@@ -285,6 +285,61 @@ The command fails with a clear error if the deployment has not been generated
 (`docker-compose.yml` missing), if `certs-src` is unset or missing, if either
 certificate is absent from `certs-src`, if the Docker daemon is not reachable,
 or if `traefik` does not come back up after the swap.
+
+### 🧩 Update Service Configuration
+
+To re-apply the values in `dtaas.toml` to an already-installed deployment's
+service config files — without regenerating the project — use:
+
+```bash
+dtaas admin update --config
+```
+
+This treats `dtaas.toml` as the single source of truth, re-runs the same
+substitution as `generate-deployment` against the installed config files, and
+then restarts only the services whose config actually changed. The deployment
+type is **auto-detected** from the services in `docker-compose.yml`, so you do
+not pass `--type`.
+
+The config that backs each service:
+
+| Service | Backing config | Re-applied keys |
+| --- | --- | --- |
+| `client` | `config/client.js` (or `config/env.local.js`) + `SERVER_DNS` in `.env` | `REACT_APP_*` client id / authority / URLs |
+| `traefik-forward-auth` | `config/conf.server` + `OAUTH_*` in `.env` | per-user path rules and whitelists, OAuth provider |
+| `libms` | `SERVER_DNS` in `.env` (routing only; no own config file) | server hostname used in its route |
+| `traefik` | `SERVER_DNS` in `.env` (routing host; `tls.yml` is static) | server hostname used in routes |
+
+Because `libms` and `traefik` have no dedicated config file, they are restarted
+only when the shared `.env` changes; the restart set is intersected with the
+services that actually exist, so a deployment without (say) `libms` is
+unaffected. Examples:
+
+```bash
+# Preview what would change and which services would restart:
+dtaas admin update --config --dry-run
+
+# Apply the changes and restart the affected services:
+dtaas admin update --config
+
+# Update a deployment generated elsewhere:
+dtaas admin update --config --output-dir ./my-server
+```
+
+`--config` first **validates** `dtaas.toml` with the same checks as
+`dtaas admin config validate` and refuses to apply anything if it finds
+problems, reporting each field-level issue. It is **idempotent**: a second run
+with no `dtaas.toml` changes reports `No configuration changes` and restarts
+nothing. It fails with a clear error if the deployment has not been generated,
+if `dtaas.toml` is missing or invalid, or if a service restart fails.
+
+**Options:**
+
+- `--config`: Re-apply `dtaas.toml` to the installed services' config files.
+- `--dry-run`: With `--config`, report what would change and which services
+  would restart, without writing files or restarting anything.
+
+`--certs` and `--config` may be combined in a single invocation.
 
 ### 📁 Select Template
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -297,29 +297,18 @@ dtaas admin update --config
 
 This treats `dtaas.toml` as the single source of truth, re-runs the same
 substitution as `generate-deployment` against the installed config files, and
-then restarts only the services whose config actually changed. The deployment
+if anything changed, recreates **all** the deployment's services with
+`docker compose up -d --force-recreate`. Because a config change can affect any
+service (the shared `.env`, routing, or a mounted config file), the whole stack
+is restarted rather than guessing which services are impacted. The deployment
 type is **auto-detected** from the services in `docker-compose.yml`, so you do
-not pass `--type`.
-
-The config that backs each service:
-
-| Service | Backing config | Re-applied keys |
-| --- | --- | --- |
-| `client` | `config/client.js` (or `config/env.local.js`) + `SERVER_DNS` in `.env` | `REACT_APP_*` client id / authority / URLs |
-| `traefik-forward-auth` | `config/conf.server` + `OAUTH_*` in `.env` | per-user path rules and whitelists, OAuth provider |
-| `libms` | `SERVER_DNS` in `.env` (routing only; no own config file) | server hostname used in its route |
-| `traefik` | `SERVER_DNS` in `.env` (routing host; `tls.yml` is static) | server hostname used in routes |
-
-Because `libms` and `traefik` have no dedicated config file, they are restarted
-only when the shared `.env` changes; the restart set is intersected with the
-services that actually exist, so a deployment without (say) `libms` is
-unaffected. Examples:
+not pass `--type`. Examples:
 
 ```bash
-# Preview what would change and which services would restart:
+# Preview what would change (no writes, no restart):
 dtaas admin update --config --dry-run
 
-# Apply the changes and restart the affected services:
+# Apply the changes and restart all services:
 dtaas admin update --config
 
 # Update a deployment generated elsewhere:
@@ -331,13 +320,13 @@ dtaas admin update --config --output-dir ./my-server
 problems, reporting each field-level issue. It is **idempotent**: a second run
 with no `dtaas.toml` changes reports `No configuration changes` and restarts
 nothing. It fails with a clear error if the deployment has not been generated,
-if `dtaas.toml` is missing or invalid, or if a service restart fails.
+if `dtaas.toml` is missing or invalid, or if the restart fails.
 
 **Options:**
 
 - `--config`: Re-apply `dtaas.toml` to the installed services' config files.
-- `--dry-run`: With `--config`, report what would change and which services
-  would restart, without writing files or restarting anything.
+- `--dry-run`: With `--config`, report what would change without writing files
+  or restarting anything.
 
 `--certs` and `--config` may be combined in a single invocation.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -411,7 +411,7 @@ directory) and reports every problem it finds at once. It checks:
 | `[common.resources].pids_limit` | must be an integer |
 | `[common.resources].mem_limit`, `shm_size` | must be a byte size with a required unit (e.g. `4G`, `512m`) |
 | `[users].add`, `[users].delete` | when present, must be lists of strings |
-| `[users.<name>].email` | must be a valid email address |
+| `[users.<name>].email` | must be a valid email address (RFC 5321/5322, no DNS lookup) |
 | deployment-section URLs | when present, must be `http(s)` URLs |
 | deployment-section `default-user` | when present, must be a valid username |
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -407,8 +407,9 @@ directory) and reports every problem it finds at once. It checks:
 | `[common].server-dns` | must be `localhost`, an IP, or a dotted (fully qualified) hostname |
 | `[common].path` | must be an absolute path to a directory that exists |
 | `[common.security].certs-src` | when present, must be an absolute path to a directory that exists |
-| `[common.resources].cpus`, `pids_limit` | must be integers |
-| `[common.resources].mem_limit`, `shm_size` | must be size strings (e.g. `4G`, `512m`) |
+| `[common.resources].cpus` | must be a positive number of CPU cores (e.g. `4` or `0.5`) |
+| `[common.resources].pids_limit` | must be an integer |
+| `[common.resources].mem_limit`, `shm_size` | must be a byte size with a required unit (e.g. `4G`, `512m`) |
 | `[users].add`, `[users].delete` | when present, must be lists of strings |
 | `[users.<name>].email` | must be a valid email address |
 | deployment-section URLs | when present, must be `http(s)` URLs |
@@ -453,10 +454,10 @@ Adjust `[common.resources]` to match your hardware:
 
 | Key | Default | Description |
 | --- | --- | --- |
-| `cpus` | `4` | Virtual CPUs per user container |
-| `mem_limit` | `"4G"` | Memory limit per container |
-| `pids_limit` | `4960` | Process limit per container |
-| `shm_size` | `"512m"` | Shared memory per container |
+| `cpus` | `4` | CPU cores per user container; may be fractional (e.g. `0.5`) |
+| `mem_limit` | `"4G"` | Memory limit per container; a byte size with a required unit |
+| `pids_limit` | `4960` | Process limit per container (integer) |
+| `shm_size` | `"512m"` | Shared memory per container; a byte size with a required unit |
 
 ### Deployment-specific credentials
 

--- a/cli/poetry.lock
+++ b/cli/poetry.lock
@@ -458,6 +458,27 @@ graph = ["objgraph (>=1.7.2)"]
 profile = ["gprof2dot (>=2022.7.29)"]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+description = "DNS toolkit"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af"},
+    {file = "dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f"},
+]
+
+[package.extras]
+dev = ["black (>=25.1.0)", "coverage (>=7.0)", "flake8 (>=7)", "hypercorn (>=0.17.0)", "mypy (>=1.17)", "pylint (>=3)", "pytest (>=8.4)", "pytest-cov (>=6.2.0)", "quart-trio (>=0.12.0)", "sphinx (>=8.2.0)", "sphinx-rtd-theme (>=3.0.0)", "twine (>=6.1.0)", "wheel (>=0.45.0)"]
+dnssec = ["cryptography (>=45)"]
+doh = ["h2 (>=4.2.0)", "httpcore (>=1.0.0)", "httpx (>=0.28.0)"]
+doq = ["aioquic (>=1.2.0)"]
+idna = ["idna (>=3.10)"]
+trio = ["trio (>=0.30)"]
+wmi = ["wmi (>=1.5.1) ; platform_system == \"Windows\""]
+
+[[package]]
 name = "dparse"
 version = "0.6.4"
 description = "A parser for Python dependency files"
@@ -478,6 +499,22 @@ all = ["pipenv", "poetry", "pyyaml"]
 conda = ["pyyaml"]
 pipenv = ["pipenv"]
 poetry = ["poetry"]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+description = "A robust email address syntax and deliverability validation library."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4"},
+    {file = "email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426"},
+]
+
+[package.dependencies]
+dnspython = ">=2.0.0"
+idna = ">=2.0.0"
 
 [[package]]
 name = "exceptiongroup"
@@ -508,6 +545,18 @@ groups = ["dev"]
 files = [
     {file = "filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767"},
     {file = "filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a"},
+]
+
+[[package]]
+name = "fqdn"
+version = "1.5.1"
+description = "Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers"
+optional = false
+python-versions = ">=2.7, !=3.0, !=3.1, !=3.2, !=3.3, !=3.4, <4"
+groups = ["main"]
+files = [
+    {file = "fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014"},
+    {file = "fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f"},
 ]
 
 [[package]]
@@ -575,7 +624,7 @@ version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
     {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
@@ -1715,4 +1764,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "caf7ca8f589feb3b7511641b0847381988ae70d8368fe43962912b23279b0893"
+content-hash = "3b2b1a15e2bdee8d2dcb9551daa872c93d84c1c90f20a450db6c28ca927b32af"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -18,6 +18,8 @@ click = "^8.4.2"
 tomlkit = "^0.15.0"
 python-on-whales = "^0.81.0"
 cryptography = "^49.0.0"
+email-validator = "^2.2.0"
+fqdn = "^1.5.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.1.1"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dtaas"
-version = "0.8.1"
+version = "0.9.0"
 description = "DTaaS CLI"
 authors = ["Astitva Sehgal"]
 license = "INTO-CPS-Association"

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -58,7 +58,6 @@ def admin():
 @admin.group(name="config")
 def config():
     """configuration file commands"""
-    return
 
 
 @config.command(name="generate")

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -5,9 +5,7 @@ from python_on_whales.exceptions import DockerException
 from .pkg import users as userPkg
 from .pkg import project as projectPkg
 from .pkg import deploy as deployPkg
-from .pkg import cert_update as certUpdatePkg
 from .pkg import config_validate as configValidatePkg
-from .pkg.cert_validate import CertValidationError
 from .pkg.project import DEPLOY_TYPES
 from .cmd_utils import (
     VerticalChoicesCommand,
@@ -15,6 +13,9 @@ from .cmd_utils import (
     provision_user_files,
     run_user_command,
     confirm_remove_user_files,
+    run_config_update,
+    run_cert_update,
+    require_update_flag,
 )
 
 NO_INSTALLATION_MESSAGE = "There is no existing DTaaS / Workspace installation"
@@ -216,21 +217,32 @@ def uninstall(output_dir, remove_user_files, yes):
     help="Refresh the deployment's TLS certificates in place.",
 )
 @click.option(
+    "--config",
+    "config_",
+    is_flag=True,
+    help="Re-apply dtaas.toml config to all services in place.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="With --config, report what would change without applying it.",
+)
+@click.option(
     "--output-dir",
     default=".",
     show_default=True,
     help="Installation directory containing the generated deployment.",
 )
-def update(certs, output_dir):
+def update(certs, config_, dry_run, output_dir):
     """Update deployment assets in place.
 
-    Currently supports --certs, which validates the newest certificate pair
-    from certs-src and swaps it in before reloading traefik.
+    --certs validates the newest certificate pair from certs-src and swaps it
+    in before reloading traefik. --config re-applies dtaas.toml to every
+    service's config file and restarts the services whose files changed; add
+    --dry-run to preview the changes first.
     """
-    if not certs:
-        raise click.ClickException("Nothing to update; pass --certs.")
-    try:
-        message = certUpdatePkg.update_certs(output_dir)
-    except (CertValidationError, OSError, DockerException, RuntimeError) as exc:
-        raise click.ClickException(str(exc)) from exc
-    click.echo(message)
+    require_update_flag(certs, config_)
+    if certs:
+        run_cert_update(output_dir)
+    if config_:
+        run_config_update(output_dir, dry_run)

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -6,6 +6,7 @@ from .pkg import users as userPkg
 from .pkg import project as projectPkg
 from .pkg import deploy as deployPkg
 from .pkg import cert_update as certUpdatePkg
+from .pkg import config_validate as configValidatePkg
 from .pkg.cert_validate import CertValidationError
 from .pkg.project import DEPLOY_TYPES
 from .cmd_utils import (
@@ -52,6 +53,48 @@ def generate_project(output_dir, force):
 def admin():
     """administration commands"""
     return
+
+
+@admin.group(name="config")
+def config():
+    """configuration file commands"""
+    return
+
+
+@config.command(name="generate")
+@click.option(
+    "--output-dir",
+    default=".",
+    show_default=True,
+    help="Target directory for the generated dtaas.toml.",
+)
+@click.option("--force", is_flag=True, help="Overwrite an existing dtaas.toml.")
+def config_generate(output_dir, force):
+    """Generate a dtaas.toml configuration template to fill in."""
+    try:
+        projectPkg.generate_config(output_dir, force)
+    except OSError as exc:
+        raise click.ClickException(f"Error while generating config: {exc}") from exc
+    click.echo("Configuration file generated successfully")
+
+
+@config.command(name="validate")
+@click.option(
+    "--output-dir",
+    default=".",
+    show_default=True,
+    help="Directory containing the dtaas.toml to validate.",
+)
+def config_validate(output_dir):
+    """Validate the values in dtaas.toml."""
+    try:
+        errors = configValidatePkg.validate_config(output_dir)
+    except (OSError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    if errors:
+        listed = "\n".join(f"- {err}" for err in errors)
+        raise click.ClickException(f"Invalid dtaas.toml:\n{listed}")
+    click.echo("Configuration is valid")
 
 
 @dtaas.command(name="generate-deployment", cls=VerticalChoicesCommand)

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -72,10 +72,11 @@ def config():
 def config_generate(output_dir, force):
     """Generate a dtaas.toml configuration template to fill in."""
     try:
-        projectPkg.generate_config(output_dir, force)
+        skipped = projectPkg.generate_config(output_dir, force)
     except OSError as exc:
         raise click.ClickException(f"Error while generating config: {exc}") from exc
-    click.echo("Configuration file generated successfully")
+    if not skipped:
+        click.echo("Configuration file generated successfully")
 
 
 @config.command(name="validate")

--- a/cli/src/cmd_utils.py
+++ b/cli/src/cmd_utils.py
@@ -6,11 +6,15 @@ the user-command wrapper, and the destructive-action confirmation prompt.
 """
 
 import click
+from python_on_whales.exceptions import DockerException
 from .pkg import config as configPkg
 from .pkg import project as projectPkg
 from .pkg import certs as certsPkg
 from .pkg import deploy_config as deployConfigPkg
+from .pkg import config_update as configUpdatePkg
+from .pkg import cert_update as certUpdatePkg
 from .pkg import utils as utilsPkg
+from .pkg.cert_validate import CertValidationError
 
 
 class VerticalChoicesCommand(click.Command):
@@ -134,3 +138,27 @@ def confirm_remove_user_files(remove_user_files, yes):
             "This permanently deletes all per-user workspace files. Continue?",
             abort=True,
         )
+
+
+def run_config_update(output_dir, dry_run):
+    """Re-apply dtaas.toml config to the installed deployment and report changes."""
+    try:
+        message = configUpdatePkg.update_config(output_dir, dry_run)
+    except (OSError, ValueError, DockerException) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(message)
+
+
+def require_update_flag(certs, config_):
+    """Reject an 'admin update' invocation that selects no assets to update."""
+    if not (certs or config_):
+        raise click.ClickException("Nothing to update; pass --certs or --config.")
+
+
+def run_cert_update(output_dir):
+    """Refresh and reload the deployment's TLS certificates."""
+    try:
+        message = certUpdatePkg.update_certs(output_dir)
+    except (CertValidationError, OSError, DockerException, RuntimeError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(message)

--- a/cli/src/pkg/config_update.py
+++ b/cli/src/pkg/config_update.py
@@ -1,0 +1,104 @@
+"""Re-apply dtaas.toml configuration to an installed deployment in place."""
+
+from pathlib import Path
+from . import utils
+from . import deploy
+from . import deploy_config
+from . import config_validate
+
+
+_SERVICE_MARKERS = (
+    ("dex", "workspace-localhost"),
+    ("keycloak", "workspace-secure-server"),
+    ("gitlab", "secure-server-gitlab"),
+)
+
+
+_FILE_SERVICES = {
+    "config/.env": ("traefik", "client", "libms", "traefik-forward-auth"),
+    ".env": ("traefik", "client", "libms", "traefik-forward-auth", "dex"),
+    "config/client.js": ("client",),
+    "config/env.local.js": ("client",),
+    "config/conf.server": ("traefik-forward-auth",),
+    "config/dex-config.yaml": ("dex",),
+}
+
+
+def _server_variant(output_dir):
+    """secure-server when tls.yml is present, otherwise insecure-server."""
+    tls = Path(output_dir) / "config" / "tls.yml"
+    return "secure-server" if tls.is_file() else "insecure-server"
+
+
+def detect_deploy_type(output_dir):
+    """Infer the installed deployment type from its compose service names.
+
+    Raises OSError when no compose file is present.
+    """
+    services = deploy.compose_services(output_dir)
+    for marker, deploy_type in _SERVICE_MARKERS:
+        if marker in services:
+            return deploy_type
+    if "libms" in services:
+        return _server_variant(output_dir)
+    return "localhost"
+
+
+def _load_toml(output_dir):
+    """Load dtaas.toml near *output_dir*, raising on absence or parse error."""
+    toml_path = utils.find_toml(output_dir)
+    if toml_path is None:
+        raise FileNotFoundError(
+            f"dtaas.toml not found in '{output_dir}' or the current directory"
+        )
+    data, err = utils.import_toml(str(toml_path))
+    if err is not None:
+        raise ValueError(f"Error reading dtaas.toml: {err}")
+    return data
+
+
+def _validate(data):
+    """Raise ValueError listing every dtaas.toml problem, if any."""
+    errors = config_validate.collect_errors(data)
+    if errors:
+        listed = "\n".join(f"- {err}" for err in errors)
+        raise ValueError(f"Invalid dtaas.toml:\n{listed}")
+
+
+def _services_to_restart(output_dir, changed):
+    """Return the present services backed by any changed config file."""
+    wanted = set()
+    for rel_path in changed:
+        wanted.update(_FILE_SERVICES.get(rel_path, ()))
+    return sorted(wanted & deploy.compose_services(output_dir))
+
+
+def _summary(deploy_type, changed, services, head, tail):
+    """Build the human-readable result or dry-run preview line."""
+    if not changed:
+        return f"No configuration changes for '{deploy_type}'; nothing to update."
+    parts = [f"{head} {', '.join(changed)}"]
+    if services:
+        parts.append(f"{tail} {', '.join(services)}")
+    return "; ".join(parts) + "."
+
+
+def update_config(output_dir, dry_run=False):
+    """Re-apply dtaas.toml config in place and restart affected services.
+
+    Returns a status (or, with dry_run, a preview) message. Raises
+    FileNotFoundError/ValueError for missing or invalid configuration, OSError
+    for a missing deployment, and DockerException if a restart fails.
+    """
+    deploy_type = detect_deploy_type(output_dir)
+    data = _load_toml(output_dir)
+    _validate(data)
+    specs = deploy_config.build_file_specs(deploy_type, data)
+    changed = deploy_config.diff_specs(output_dir, specs)
+    services = _services_to_restart(output_dir, changed)
+    if dry_run:
+        return _summary(deploy_type, changed, services, "Would update", "would restart")
+    deploy_config.apply_config(output_dir, specs)
+    for service in services:
+        deploy.restart_service(output_dir, service)
+    return _summary(deploy_type, changed, services, "Updated", "restarted")

--- a/cli/src/pkg/config_update.py
+++ b/cli/src/pkg/config_update.py
@@ -14,16 +14,6 @@ _SERVICE_MARKERS = (
 )
 
 
-_FILE_SERVICES = {
-    "config/.env": ("traefik", "client", "libms", "traefik-forward-auth"),
-    ".env": ("traefik", "client", "libms", "traefik-forward-auth", "dex"),
-    "config/client.js": ("client",),
-    "config/env.local.js": ("client",),
-    "config/conf.server": ("traefik-forward-auth",),
-    "config/dex-config.yaml": ("dex",),
-}
-
-
 def _server_variant(output_dir):
     """secure-server when tls.yml is present, otherwise insecure-server."""
     tls = Path(output_dir) / "config" / "tls.yml"
@@ -65,40 +55,32 @@ def _validate(data):
         raise ValueError(f"Invalid dtaas.toml:\n{listed}")
 
 
-def _services_to_restart(output_dir, changed):
-    """Return the present services backed by any changed config file."""
-    wanted = set()
-    for rel_path in changed:
-        wanted.update(_FILE_SERVICES.get(rel_path, ()))
-    return sorted(wanted & deploy.compose_services(output_dir))
-
-
-def _summary(deploy_type, changed, services, head, tail):
+def _summary(deploy_type, changed, head, tail):
     """Build the human-readable result or dry-run preview line."""
     if not changed:
         return f"No configuration changes for '{deploy_type}'; nothing to update."
-    parts = [f"{head} {', '.join(changed)}"]
-    if services:
-        parts.append(f"{tail} {', '.join(services)}")
-    return "; ".join(parts) + "."
+    return f"{head} {', '.join(changed)}; {tail} all services."
 
 
 def update_config(output_dir, dry_run=False):
-    """Re-apply dtaas.toml config in place and restart affected services.
+    """Re-apply dtaas.toml config in place and restart the whole deployment.
+
+    A config change can affect any service (shared .env, routing, mounted
+    files), so when anything changes every compose service is recreated rather
+    than guessing which ones are affected.
 
     Returns a status (or, with dry_run, a preview) message. Raises
     FileNotFoundError/ValueError for missing or invalid configuration, OSError
-    for a missing deployment, and DockerException if a restart fails.
+    for a missing deployment, and DockerException if the restart fails.
     """
     deploy_type = detect_deploy_type(output_dir)
     data = _load_toml(output_dir)
     _validate(data)
     specs = deploy_config.build_file_specs(deploy_type, data)
     changed = deploy_config.diff_specs(output_dir, specs)
-    services = _services_to_restart(output_dir, changed)
     if dry_run:
-        return _summary(deploy_type, changed, services, "Would update", "would restart")
+        return _summary(deploy_type, changed, "Would update", "would restart")
     deploy_config.apply_config(output_dir, specs)
-    for service in services:
-        deploy.restart_service(output_dir, service)
-    return _summary(deploy_type, changed, services, "Updated", "restarted")
+    if changed:
+        deploy.restart_all(output_dir)
+    return _summary(deploy_type, changed, "Updated", "restarted")

--- a/cli/src/pkg/config_validate.py
+++ b/cli/src/pkg/config_validate.py
@@ -19,7 +19,8 @@ FQDN_RE = re.compile(
     r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)"
     r"(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$"
 )
-EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+# Domain labels exclude the dot separator, so matching is linear (no ReDoS).
+EMAIL_RE = re.compile(r"^[^@\s]+@[^\s@.]+(\.[^\s@.]+)+$")
 SIZE_RE = re.compile(r"^\d+(\.\d+)?\s*([kmgt]i?b?|b)?$", re.IGNORECASE)
 USERNAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
@@ -141,19 +142,11 @@ def _check_resources(data):
     """cpus/pids_limit must be integers; mem_limit/shm_size must be size strings."""
     errors = []
     for field in _INT_FIELDS:
-        errors += _required(
-            data,
-            ("common", "resources", field),
-            _is_int,
-            f"common.resources.{field} must be an integer",
-        )
+        message = f"common.resources.{field} must be an integer"
+        errors += _required(data, ("common", "resources", field), _is_int, message)
     for field, example in _SIZE_FIELDS:
-        errors += _required(
-            data,
-            ("common", "resources", field),
-            _is_size,
-            f"common.resources.{field} must be a size string like '{example}'",
-        )
+        message = f"common.resources.{field} must be a size string like '{example}'"
+        errors += _required(data, ("common", "resources", field), _is_size, message)
     return errors
 
 
@@ -166,12 +159,8 @@ def _check_user_lists(data):
     """users.add and users.delete, when present, must be lists of strings."""
     errors = []
     for field in _LIST_FIELDS:
-        errors += _optional(
-            data,
-            ("users", field),
-            _is_string_list,
-            f"users.{field} must be a list of strings",
-        )
+        message = f"users.{field} must be a list of strings"
+        errors += _optional(data, ("users", field), _is_string_list, message)
     return errors
 
 

--- a/cli/src/pkg/config_validate.py
+++ b/cli/src/pkg/config_validate.py
@@ -5,6 +5,7 @@ readable problems (empty when the value is acceptable); validate_config
 aggregates them so the user sees every issue at once rather than one at a time.
 """
 
+import ipaddress
 import re
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
@@ -23,6 +24,7 @@ FQDN_RE = re.compile(
 EMAIL_RE = re.compile(r"^[^@\s]+@[^\s@.]+(\.[^\s@.]+)+$")
 SIZE_RE = re.compile(r"^\d+(\.\d+)?\s*([kmgt]i?b?|b)$", re.IGNORECASE)
 USERNAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+NUMERIC_HOST_RE = re.compile(r"^[0-9.]+$")
 
 _SIZE_FIELDS = (("mem_limit", "4G"), ("shm_size", "512m"))
 _LIST_FIELDS = ("add", "delete")
@@ -41,17 +43,26 @@ def _is_url(value):
     return isinstance(value, str) and bool(URL_RE.match(value))
 
 
-def _is_host(value):
-    """True for 'localhost', an IP literal, or a dotted hostname (FQDN).
+def _is_ip(value):
+    """True when *value* is a valid IPv4 or IPv6 address."""
+    try:
+        ipaddress.ip_address(value)
+        return True
+    except ValueError:
+        return False
 
-    A bare single-label name such as 'lossscalhost' is rejected: a server DNS
-    must be localhost or fully qualified, which always contains a dot.
+
+def _is_host(value):
+    """True for 'localhost', a valid IP literal, or a dotted hostname (FQDN).
+
+    A dotted-numeric value (e.g. '999.999.999.999') is validated as an IP, not
+    a hostname, so a malformed IP is rejected rather than read as four labels.
     """
     if not isinstance(value, str):
         return False
-    if value == "localhost":
-        return True
-    return bool(FQDN_RE.match(value))
+    if NUMERIC_HOST_RE.match(value):
+        return _is_ip(value)
+    return value == "localhost" or bool(FQDN_RE.match(value))
 
 
 def _is_abs_path(value):
@@ -116,32 +127,21 @@ def _check_git_repo(data):
 
 def _check_server_dns(data):
     """common.server-dns must be a hostname or IP."""
-    return _required(
-        data,
-        ("common", "server-dns"),
-        _is_host,
-        "common.server-dns must be a valid hostname or IP address",
-    )
+    message = "common.server-dns must be a valid hostname or IP address"
+    return _required(data, ("common", "server-dns"), _is_host, message)
 
 
 def _check_path(data):
     """common.path must be an absolute path to an existing directory."""
-    return _required(
-        data,
-        ("common", "path"),
-        _is_existing_dir,
-        "common.path must be an absolute path to an existing directory",
-    )
+    message = "common.path must be an absolute path to an existing directory"
+    return _required(data, ("common", "path"), _is_existing_dir, message)
 
 
 def _check_certs_src(data):
     """common.security.certs-src, when present, must be an existing directory."""
-    return _optional(
-        data,
-        ("common", "security", "certs-src"),
-        _is_existing_dir,
-        "common.security.certs-src must be an absolute path to an existing directory",
-    )
+    keys = ("common", "security", "certs-src")
+    message = "common.security.certs-src must be an absolute path to an existing directory"
+    return _optional(data, keys, _is_existing_dir, message)
 
 
 def _check_resources(data):

--- a/cli/src/pkg/config_validate.py
+++ b/cli/src/pkg/config_validate.py
@@ -21,10 +21,9 @@ FQDN_RE = re.compile(
 )
 # Domain labels exclude the dot separator, so matching is linear (no ReDoS).
 EMAIL_RE = re.compile(r"^[^@\s]+@[^\s@.]+(\.[^\s@.]+)+$")
-SIZE_RE = re.compile(r"^\d+(\.\d+)?\s*([kmgt]i?b?|b)?$", re.IGNORECASE)
+SIZE_RE = re.compile(r"^\d+(\.\d+)?\s*([kmgt]i?b?|b)$", re.IGNORECASE)
 USERNAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
-_INT_FIELDS = ("cpus", "pids_limit")
 _SIZE_FIELDS = (("mem_limit", "4G"), ("shm_size", "512m"))
 _LIST_FIELDS = ("add", "delete")
 
@@ -72,8 +71,15 @@ def _is_int(value):
     return isinstance(value, int) and not isinstance(value, bool)
 
 
+def _is_number(value):
+    """True when *value* is a positive number of cores (int or float, not bool)."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    return value > 0
+
+
 def _is_size(value):
-    """True when *value* is a size string such as '4G' or '512m'."""
+    """True when *value* is a byte size with a required unit, e.g. '4G' or '512m'."""
     return isinstance(value, str) and bool(SIZE_RE.match(value))
 
 
@@ -139,13 +145,13 @@ def _check_certs_src(data):
 
 
 def _check_resources(data):
-    """cpus/pids_limit must be integers; mem_limit/shm_size must be size strings."""
-    errors = []
-    for field in _INT_FIELDS:
-        message = f"common.resources.{field} must be an integer"
-        errors += _required(data, ("common", "resources", field), _is_int, message)
+    """cpus is a positive number; pids_limit an integer; mem/shm are byte sizes."""
+    cpus_msg = "common.resources.cpus must be a positive number of CPU cores"
+    errors = _required(data, ("common", "resources", "cpus"), _is_number, cpus_msg)
+    pids_msg = "common.resources.pids_limit must be an integer"
+    errors += _required(data, ("common", "resources", "pids_limit"), _is_int, pids_msg)
     for field, example in _SIZE_FIELDS:
-        message = f"common.resources.{field} must be a size string like '{example}'"
+        message = f"common.resources.{field} must include a unit, e.g. '{example}'"
         errors += _required(data, ("common", "resources", field), _is_size, message)
     return errors
 

--- a/cli/src/pkg/config_validate.py
+++ b/cli/src/pkg/config_validate.py
@@ -140,7 +140,9 @@ def _check_path(data):
 def _check_certs_src(data):
     """common.security.certs-src, when present, must be an existing directory."""
     keys = ("common", "security", "certs-src")
-    message = "common.security.certs-src must be an absolute path to an existing directory"
+    message = (
+        "common.security.certs-src must be an absolute path to an existing directory"
+    )
     return _optional(data, keys, _is_existing_dir, message)
 
 

--- a/cli/src/pkg/config_validate.py
+++ b/cli/src/pkg/config_validate.py
@@ -10,7 +10,7 @@ import re
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from email_validator import EmailNotValidError, validate_email
 from fqdn import FQDN
-from . import utils
+from .import utils
 
 
 URL_RE = re.compile(r"^https?://[A-Za-z0-9.-]+(:\d+)?(/[A-Za-z0-9._~%/+-]*)?$")
@@ -31,8 +31,8 @@ def _get(data, *keys):
 
 
 def _is_url(value):
-    """True when *value* is an http(s) URL with a host and a simple path."""
-    return isinstance(value, str) and bool(URL_RE.match(value))
+    """True when *value* is an http(s) URL (case-insensitive) with a host/path."""
+    return isinstance(value, str) and bool(URL_RE.match(value.lower()))
 
 
 def _is_ip(value):
@@ -50,10 +50,7 @@ def _is_fqdn(value):
 
 
 def _is_host(value):
-    """True for 'localhost', a valid IP literal, or a dotted hostname (FQDN).
-
-    A dotted-numeric value is validated as an IP, not read as a hostname.
-    """
+    """True for 'localhost', an IP literal, or a dotted FQDN (numeric => IP)."""
     if not isinstance(value, str):
         return False
     if NUMERIC_HOST_RE.match(value):

--- a/cli/src/pkg/config_validate.py
+++ b/cli/src/pkg/config_validate.py
@@ -1,27 +1,19 @@
 """Validate the values in a dtaas.toml configuration file.
 
 Used by 'dtaas admin config validate'. Each check returns a list of human
-readable problems (empty when the value is acceptable); validate_config
-aggregates them so the user sees every issue at once rather than one at a time.
+readable problems (empty when acceptable); validate_config aggregates them so
+the user sees every issue at once rather than one at a time.
 """
 
 import ipaddress
 import re
 from pathlib import Path, PurePosixPath, PureWindowsPath
-
+from email_validator import EmailNotValidError, validate_email
+from fqdn import FQDN
 from . import utils
 
-# Reject odd URLs (e.g. stray '@@' in the path): require http(s), a host, an
-# optional port, and a simple path made of safe characters only.
+
 URL_RE = re.compile(r"^https?://[A-Za-z0-9.-]+(:\d+)?(/[A-Za-z0-9._~%/+-]*)?$")
-# A server DNS must be fully qualified, so require at least one dot. 'localhost'
-# is allowed separately; a bare single label (e.g. 'lossscalhost') is rejected.
-FQDN_RE = re.compile(
-    r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)"
-    r"(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$"
-)
-# Domain labels exclude the dot separator, so matching is linear (no ReDoS).
-EMAIL_RE = re.compile(r"^[^@\s]+@[^\s@.]+(\.[^\s@.]+)+$")
 SIZE_RE = re.compile(r"^\d+(\.\d+)?\s*([kmgt]i?b?|b)$", re.IGNORECASE)
 USERNAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 NUMERIC_HOST_RE = re.compile(r"^[0-9.]+$")
@@ -52,17 +44,21 @@ def _is_ip(value):
         return False
 
 
+def _is_fqdn(value):
+    """True when *value* is an RFC 1123 fully qualified domain name."""
+    return FQDN(value).is_valid
+
+
 def _is_host(value):
     """True for 'localhost', a valid IP literal, or a dotted hostname (FQDN).
 
-    A dotted-numeric value (e.g. '999.999.999.999') is validated as an IP, not
-    a hostname, so a malformed IP is rejected rather than read as four labels.
+    A dotted-numeric value is validated as an IP, not read as a hostname.
     """
     if not isinstance(value, str):
         return False
     if NUMERIC_HOST_RE.match(value):
         return _is_ip(value)
-    return value == "localhost" or bool(FQDN_RE.match(value))
+    return value == "localhost" or _is_fqdn(value)
 
 
 def _is_abs_path(value):
@@ -95,8 +91,12 @@ def _is_size(value):
 
 
 def _is_email(value):
-    """True when *value* looks like an email address."""
-    return isinstance(value, str) and bool(EMAIL_RE.match(value))
+    """True when *value* is a valid email address (no DNS lookup)."""
+    try:
+        validate_email(value, check_deliverability=False)
+        return True
+    except (EmailNotValidError, TypeError):  # TypeError: non-string value
+        return False
 
 
 def _is_username(value):

--- a/cli/src/pkg/config_validate.py
+++ b/cli/src/pkg/config_validate.py
@@ -10,7 +10,7 @@ import re
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from email_validator import EmailNotValidError, validate_email
 from fqdn import FQDN
-from .import utils
+from . import utils
 
 
 URL_RE = re.compile(r"^https?://[A-Za-z0-9.-]+(:\d+)?(/[A-Za-z0-9._~%/+-]*)?$")

--- a/cli/src/pkg/config_validate.py
+++ b/cli/src/pkg/config_validate.py
@@ -1,0 +1,255 @@
+"""Validate the values in a dtaas.toml configuration file.
+
+Used by 'dtaas admin config validate'. Each check returns a list of human
+readable problems (empty when the value is acceptable); validate_config
+aggregates them so the user sees every issue at once rather than one at a time.
+"""
+
+import re
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+from . import utils
+
+# Reject odd URLs (e.g. stray '@@' in the path): require http(s), a host, an
+# optional port, and a simple path made of safe characters only.
+URL_RE = re.compile(r"^https?://[A-Za-z0-9.-]+(:\d+)?(/[A-Za-z0-9._~%/+-]*)?$")
+# A server DNS must be fully qualified, so require at least one dot. 'localhost'
+# is allowed separately; a bare single label (e.g. 'lossscalhost') is rejected.
+FQDN_RE = re.compile(
+    r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)"
+    r"(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$"
+)
+EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+SIZE_RE = re.compile(r"^\d+(\.\d+)?\s*([kmgt]i?b?|b)?$", re.IGNORECASE)
+USERNAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+_INT_FIELDS = ("cpus", "pids_limit")
+_SIZE_FIELDS = (("mem_limit", "4G"), ("shm_size", "512m"))
+_LIST_FIELDS = ("add", "delete")
+
+
+def _get(data, *keys):
+    """Return the nested value at *keys*, or None if any step is missing."""
+    node = data
+    for key in keys:
+        node = node.get(key) if isinstance(node, dict) else None
+    return node
+
+
+def _is_url(value):
+    """True when *value* is an http(s) URL with a host and a simple path."""
+    return isinstance(value, str) and bool(URL_RE.match(value))
+
+
+def _is_host(value):
+    """True for 'localhost', an IP literal, or a dotted hostname (FQDN).
+
+    A bare single-label name such as 'lossscalhost' is rejected: a server DNS
+    must be localhost or fully qualified, which always contains a dot.
+    """
+    if not isinstance(value, str):
+        return False
+    if value == "localhost":
+        return True
+    return bool(FQDN_RE.match(value))
+
+
+def _is_abs_path(value):
+    """True when *value* is an absolute path in POSIX or Windows form."""
+    if not isinstance(value, str) or not value.strip():
+        return False
+    return PurePosixPath(value).is_absolute() or PureWindowsPath(value).is_absolute()
+
+
+def _is_existing_dir(value):
+    """True when *value* is an absolute path to a directory that exists."""
+    return _is_abs_path(value) and Path(value).is_dir()
+
+
+def _is_int(value):
+    """True when *value* is an integer (and not a bool, which subclasses int)."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_size(value):
+    """True when *value* is a size string such as '4G' or '512m'."""
+    return isinstance(value, str) and bool(SIZE_RE.match(value))
+
+
+def _is_email(value):
+    """True when *value* looks like an email address."""
+    return isinstance(value, str) and bool(EMAIL_RE.match(value))
+
+
+def _is_username(value):
+    """True when *value* is a non-empty username (alphanumeric plus . _ -)."""
+    return isinstance(value, str) and bool(USERNAME_RE.match(value))
+
+
+def _required(data, keys, predicate, message):
+    """Return [message] if the value at *keys* is missing or fails *predicate*."""
+    value = _get(data, *keys)
+    if value is None:
+        return [".".join(keys) + " is missing"]
+    return [] if predicate(value) else [message]
+
+
+def _optional(data, keys, predicate, message):
+    """Like _required, but a missing value is allowed (no error)."""
+    value = _get(data, *keys)
+    if value is None:
+        return []
+    return [] if predicate(value) else [message]
+
+
+def _check_git_repo(data):
+    """git-repo must be a URL."""
+    return _required(data, ("git-repo",), _is_url, "git-repo must be a valid URL")
+
+
+def _check_server_dns(data):
+    """common.server-dns must be a hostname or IP."""
+    return _required(
+        data,
+        ("common", "server-dns"),
+        _is_host,
+        "common.server-dns must be a valid hostname or IP address",
+    )
+
+
+def _check_path(data):
+    """common.path must be an absolute path to an existing directory."""
+    return _required(
+        data,
+        ("common", "path"),
+        _is_existing_dir,
+        "common.path must be an absolute path to an existing directory",
+    )
+
+
+def _check_certs_src(data):
+    """common.security.certs-src, when present, must be an existing directory."""
+    return _optional(
+        data,
+        ("common", "security", "certs-src"),
+        _is_existing_dir,
+        "common.security.certs-src must be an absolute path to an existing directory",
+    )
+
+
+def _check_resources(data):
+    """cpus/pids_limit must be integers; mem_limit/shm_size must be size strings."""
+    errors = []
+    for field in _INT_FIELDS:
+        errors += _required(
+            data,
+            ("common", "resources", field),
+            _is_int,
+            f"common.resources.{field} must be an integer",
+        )
+    for field, example in _SIZE_FIELDS:
+        errors += _required(
+            data,
+            ("common", "resources", field),
+            _is_size,
+            f"common.resources.{field} must be a size string like '{example}'",
+        )
+    return errors
+
+
+def _is_string_list(value):
+    """True when *value* is a list whose entries are all strings."""
+    return isinstance(value, list) and all(isinstance(x, str) for x in value)
+
+
+def _check_user_lists(data):
+    """users.add and users.delete, when present, must be lists of strings."""
+    errors = []
+    for field in _LIST_FIELDS:
+        errors += _optional(
+            data,
+            ("users", field),
+            _is_string_list,
+            f"users.{field} must be a list of strings",
+        )
+    return errors
+
+
+def _email_error(name, info):
+    """Return an error for a user sub-table whose email is missing or invalid."""
+    if not isinstance(info, dict):
+        return []
+    if _is_email(info.get("email", "")):
+        return []
+    return [f"users.{name}.email is not a valid email address"]
+
+
+def _check_emails(data):
+    """Every [users.<name>] sub-table must hold a valid email."""
+    users = _get(data, "users")
+    if not isinstance(users, dict):
+        return []
+    errors = []
+    for name, info in users.items():
+        errors += _email_error(name, info)
+    return errors
+
+
+# Deployment-section fields checked when present: (section, key, predicate, label).
+_DEPLOY_FIELDS = (
+    ("frontend", "react-app-oauth-url", _is_url, "URL"),
+    ("localhost", "auth-authority", _is_url, "URL"),
+    ("localhost", "default-user", _is_username, "username"),
+    ("insecure-server", "oauth-url", _is_url, "URL"),
+    ("secure-server", "oauth-url", _is_url, "URL"),
+    ("workspace-localhost", "auth-authority", _is_url, "URL"),
+    ("workspace-localhost", "default-user", _is_username, "username"),
+    ("workspace-secure-server", "keycloak-issuer-url", _is_url, "URL"),
+    ("workspace-secure-server", "auth-authority", _is_url, "URL"),
+)
+
+
+def _check_deploy_fields(data):
+    """Validate URL/username fields across deployment sections when present."""
+    errors = []
+    for section, key, predicate, label in _DEPLOY_FIELDS:
+        message = f"{section}.{key} must be a valid {label}"
+        errors += _optional(data, (section, key), predicate, message)
+    return errors
+
+
+_CHECKS = (
+    _check_git_repo,
+    _check_server_dns,
+    _check_path,
+    _check_certs_src,
+    _check_resources,
+    _check_user_lists,
+    _check_emails,
+    _check_deploy_fields,
+)
+
+
+def collect_errors(data):
+    """Run every check against *data* and return the combined list of problems."""
+    errors = []
+    for check in _CHECKS:
+        errors += check(data)
+    return errors
+
+
+def validate_config(output_dir):
+    """Validate dtaas.toml in *output_dir*, returning a list of problems.
+
+    The list is empty when the configuration is valid. Raises FileNotFoundError
+    when no dtaas.toml is found and ValueError when the file cannot be parsed.
+    """
+    toml_path = utils.find_toml(output_dir)
+    if toml_path is None:
+        raise FileNotFoundError(
+            f"dtaas.toml not found in '{output_dir}' or the current directory"
+        )
+    data, err = utils.import_toml(str(toml_path))
+    if err is not None:
+        raise ValueError(str(err))
+    return collect_errors(data)

--- a/cli/src/pkg/deploy.py
+++ b/cli/src/pkg/deploy.py
@@ -2,6 +2,7 @@
 
 import shutil
 from pathlib import Path
+import yaml
 from python_on_whales import DockerClient
 from python_on_whales.utils import ValidPath
 
@@ -219,3 +220,14 @@ def service_running(directory, service):
     require_compose_file(directory)
     containers = _client(directory).compose.ps(services=[service])
     return any(container.state.running for container in containers)
+
+
+def compose_services(directory):
+    """Return the set of service names defined in the deployment's compose file.
+
+    Raises OSError when the compose file is missing.
+    """
+    require_compose_file(directory)
+    data = yaml.safe_load((Path(directory) / COMPOSE_FILE).read_text(encoding="utf-8"))
+    services = data.get("services", {}) if isinstance(data, dict) else {}
+    return set(services)

--- a/cli/src/pkg/deploy.py
+++ b/cli/src/pkg/deploy.py
@@ -201,6 +201,16 @@ def restart_service(directory, service):
     _client(directory).compose.up(services=[service], force_recreate=True, detach=True)
 
 
+def restart_all(directory):
+    """Recreate every compose service so they pick up new configuration.
+
+    Mirrors 'docker compose up -d --force-recreate'. Raises OSError if the
+    deployment is missing, or DockerException if compose itself fails.
+    """
+    require_compose_file(directory)
+    _client(directory).compose.up(force_recreate=True, detach=True)
+
+
 def stop_service(directory, service):
     """Stop one compose service so its files can be safely replaced.
 

--- a/cli/src/pkg/deploy_config.py
+++ b/cli/src/pkg/deploy_config.py
@@ -114,19 +114,33 @@ def check_placeholders(dest_dir, specs):
     return warnings
 
 
+def _render(content, file_format, values):
+    """Return *content* with every key/value substitution for *file_format* applied."""
+    setter = _SETTERS[file_format]
+    for key, value in values.items():
+        content = setter(content, key, value)
+    return content
+
+
+def _decode_editable(raw):
+    """Return decoded text, or None when *raw* looks binary (has a NUL byte)."""
+    if b"\x00" in raw[:4096]:
+        return None
+    return raw.decode("utf-8")
+
+
+def _write_if_changed(path, old, new):
+    """Write *new* to *path* only when it differs from *old*."""
+    if new != old:
+        path.write_text(new, encoding="utf-8")
+
+
 def _apply_to_file(path, file_format, values):
     """Apply key/value substitutions to one config file. Returns error or None."""
-    setter = _SETTERS[file_format]
     try:
-        raw = path.read_bytes()
-        if b"\x00" in raw[:4096]:
-            return None
-        content = raw.decode("utf-8")
-        new_content = content
-        for key, value in values.items():
-            new_content = setter(new_content, key, value)
-        if new_content != content:
-            path.write_text(new_content, encoding="utf-8")
+        content = _decode_editable(path.read_bytes())
+        if content is not None:
+            _write_if_changed(path, content, _render(content, file_format, values))
     except (OSError, UnicodeDecodeError) as exc:
         return str(exc)
     return None
@@ -153,3 +167,17 @@ def apply_config(dest_dir, specs):
     errors = _collect_apply_errors(dest_dir, specs)
     if errors:
         raise OSError("\n".join(errors))
+
+
+def diff_specs(dest_dir, specs):
+    """Return the relative paths whose content *specs* would change.
+
+    Read-only preview used for dry runs and to decide which services need a
+    restart. Missing, binary, or unreadable files count as unchanged.
+    """
+    changed = []
+    for rel_path, file_format, values in specs:
+        text = _read_file_text(Path(dest_dir) / rel_path)
+        if text is not None and _render(text, file_format, values) != text:
+            changed.append(rel_path)
+    return changed

--- a/cli/src/pkg/project.py
+++ b/cli/src/pkg/project.py
@@ -79,11 +79,16 @@ def generate_project(dest_dir=".", force=False):
 
 
 def generate_config(dest_dir=".", force=False):
-    """Copy only the dtaas.toml template into dest_dir for the user to fill in."""
+    """Copy only the dtaas.toml template into dest_dir for the user to fill in.
+
+    Returns True if an existing dtaas.toml was kept (skipped), False if it was
+    written. Raises OSError on copy failure.
+    """
     _validate_project_inputs(dest_dir)
-    error = _try_copy_template("dtaas.toml", dest_dir, force)
-    if error:
-        raise OSError(error)
+    skipped = _copy_template("dtaas.toml", dest_dir, force)
+    if skipped:
+        click.echo("'dtaas.toml' already exists, skipping")
+    return skipped
 
 
 def _copy_file(item, target, force):

--- a/cli/src/pkg/project.py
+++ b/cli/src/pkg/project.py
@@ -78,6 +78,14 @@ def generate_project(dest_dir=".", force=False):
     _create_workspace_dirs(dest_dir)
 
 
+def generate_config(dest_dir=".", force=False):
+    """Copy only the dtaas.toml template into dest_dir for the user to fill in."""
+    _validate_project_inputs(dest_dir)
+    error = _try_copy_template("dtaas.toml", dest_dir, force)
+    if error:
+        raise OSError(error)
+
+
 def _copy_file(item, target, force):
     """Copy item to target, returning an error string or None."""
     if target.exists() and not force:

--- a/cli/src/templates/dtaas.toml
+++ b/cli/src/templates/dtaas.toml
@@ -1,7 +1,7 @@
 # This is the config for DTaaS CLI
 
 name="Digital Twin as a Service (DTaaS)"
-version="0.8.1"
+version="0.9.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 

--- a/cli/tests/dtaas.test.toml
+++ b/cli/tests/dtaas.test.toml
@@ -1,7 +1,7 @@
 # This is the config for DTaaS CLI
 
 name="Digital Twin as a Service (DTaaS)"
-version="0.8.1"
+version="0.9.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -36,14 +36,6 @@ def test_delete_user_success(runner, mock_user_pkg):
     mock_user_pkg["delete"].assert_called_once()
 
 
-def test_delete_user_error(runner, mock_user_pkg):
-    """Test user deletion with error"""
-    mock_user_pkg["delete"].return_value = Exception("Delete failed")
-
-    result = runner.invoke(dtaas, ["admin", "user", "delete"])
-    assert result.exit_code != 0
-    assert "Error while deleting users" in result.output
-
 
 def test_generate_project_success(runner):
     """Test successful project file generation with defaults"""
@@ -77,21 +69,6 @@ def test_generate_deployment_without_config_prints_note(runner):
     assert "Note:" in result.output
 
 
-def test_generate_deployment_malformed_toml_errors(runner):
-    """generate-deployment fails when dtaas.toml exists but cannot be parsed"""
-
-    with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
-        "src.cmd_utils._find_toml", return_value=Path("dtaas.toml")
-    ), patch(
-        "src.cmd_utils.utilsPkg.import_toml",
-        return_value=(None, Exception("parse error")),
-    ):
-        result = runner.invoke(dtaas, ["generate-deployment", "--type", "localhost"])
-
-    assert result.exit_code != 0
-    assert "Error reading dtaas.toml" in result.output
-
-
 def test_generate_deployment_error(runner):
     """generate-deployment converts known exceptions to ClickException"""
     with patch("src.cmd.projectPkg.generate_deploy_project") as mock_gen:
@@ -103,122 +80,6 @@ def test_generate_deployment_error(runner):
 
         assert result.exit_code != 0
         assert "template missing" in result.output
-
-
-def test_generate_deployment_help_lists_choices_vertically(runner):
-    """The custom help formatter renders --type choices as a vertical list."""
-    result = runner.invoke(dtaas, ["generate-deployment", "--help"])
-
-    assert result.exit_code == 0
-    assert "One of:" in result.output
-    # Each deploy type appears on its own line in the Options section.
-    for deploy_type in ["localhost", "secure-server", "workspace-localhost"]:
-        assert deploy_type in result.output
-
-
-def test_generate_deployment_prints_placeholder_warnings(runner):
-    """Warnings from check_placeholders are echoed to the user."""
-
-    with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
-        "src.cmd_utils._find_toml", return_value=Path("dtaas.toml")
-    ), patch(
-        "src.cmd_utils.utilsPkg.import_toml", return_value=({"localhost": {}}, None)
-    ), patch("src.cmd_utils.deployConfigPkg.build_file_specs", return_value=[]), patch(
-        "src.cmd_utils.deployConfigPkg.apply_config"
-    ), patch(
-        "src.cmd_utils.deployConfigPkg.check_placeholders",
-        return_value=["Warning: placeholder FOO left unset"],
-    ):
-        result = runner.invoke(dtaas, ["generate-deployment", "--type", "localhost"])
-
-    assert result.exit_code == 0
-    assert "placeholder FOO left unset" in result.output
-
-
-def test_generate_deployment_substitution_error(runner):
-    """A failure during config substitution is reported as a ClickException."""
-
-    with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
-        "src.cmd_utils._find_toml", return_value=Path("dtaas.toml")
-    ), patch(
-        "src.cmd_utils.utilsPkg.import_toml", return_value=({"localhost": {}}, None)
-    ), patch(
-        "src.cmd_utils.deployConfigPkg.build_file_specs",
-        side_effect=ValueError("bad spec"),
-    ):
-        result = runner.invoke(dtaas, ["generate-deployment", "--type", "localhost"])
-
-    assert result.exit_code != 0
-    assert "Error substituting config values" in result.output
-
-
-def test_generate_deployment_user_dir_error(runner):
-    """An OSError while creating user directories surfaces as a ClickException."""
-
-    with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
-        "src.cmd_utils._find_toml", return_value=Path("dtaas.toml")
-    ), patch(
-        "src.cmd_utils.utilsPkg.import_toml",
-        return_value=({"users": {"add": ["alice"]}, "localhost": {}}, None),
-    ), patch("src.cmd_utils.deployConfigPkg.build_file_specs", return_value=[]), patch(
-        "src.cmd_utils.deployConfigPkg.apply_config"
-    ), patch(
-        "src.cmd_utils.projectPkg.create_user_dirs", side_effect=OSError("disk full")
-    ):
-        result = runner.invoke(dtaas, ["generate-deployment", "--type", "localhost"])
-
-    assert result.exit_code != 0
-    assert "Error creating user directories" in result.output
-
-
-def test_generate_deployment_copies_certs(runner):
-    """The certs-src from dtaas.toml is forwarded to certsPkg.copy_certs."""
-
-    with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
-        "src.cmd.projectPkg.set_files_permissions"
-    ), patch("src.cmd_utils._find_toml", return_value=Path("dtaas.toml")), patch(
-        "src.cmd_utils.utilsPkg.import_toml",
-        return_value=(
-            {"common": {"security": {"certs-src": "/etc/certs"}}, "secure-server": {}},
-            None,
-        ),
-    ), patch("src.cmd_utils.deployConfigPkg.build_file_specs", return_value=[]), patch(
-        "src.cmd_utils.deployConfigPkg.apply_config"
-    ), patch(
-        "src.cmd_utils.deployConfigPkg.check_placeholders", return_value=[]
-    ), patch(
-        "src.cmd_utils.certsPkg.copy_certs", return_value="certs copied"
-    ) as mock_copy:
-        result = runner.invoke(
-            dtaas, ["generate-deployment", "--type", "secure-server"]
-        )
-
-    assert result.exit_code == 0
-    assert "certs copied" in result.output
-    mock_copy.assert_called_once_with("secure-server", ".", "/etc/certs", False)
-
-
-def test_generate_deployment_cert_copy_error(runner):
-    """An OSError while copying certificates surfaces as a ClickException."""
-
-    with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
-        "src.cmd_utils._find_toml", return_value=Path("dtaas.toml")
-    ), patch(
-        "src.cmd_utils.utilsPkg.import_toml",
-        return_value=({"common": {"security": {"certs-src": "/etc/certs"}}}, None),
-    ), patch("src.cmd_utils.deployConfigPkg.build_file_specs", return_value=[]), patch(
-        "src.cmd_utils.deployConfigPkg.apply_config"
-    ), patch(
-        "src.cmd_utils.deployConfigPkg.check_placeholders", return_value=[]
-    ), patch(
-        "src.cmd_utils.certsPkg.copy_certs", side_effect=OSError("permission denied")
-    ):
-        result = runner.invoke(
-            dtaas, ["generate-deployment", "--type", "secure-server"]
-        )
-
-    assert result.exit_code != 0
-    assert "Error copying certificates" in result.output
 
 
 def test_config_generate_success(runner):
@@ -320,28 +181,6 @@ def test_admin_install_error(runner, mock_deploy_pkg):
     assert "not generated" in result.output
 
 
-def test_admin_install_docker_error(runner, mock_deploy_pkg):
-    """A python-on-whales DockerException surfaces with its real message."""
-    mock_deploy_pkg["install"].side_effect = DockerException(
-        ["docker", "compose", "up", "-d"], 1, stderr=b"Cannot connect to the daemon"
-    )
-
-    result = runner.invoke(dtaas, ["admin", "install"])
-
-    assert result.exit_code != 0
-    assert "Cannot connect to the daemon" in result.output
-
-
-def test_admin_uninstall_success(runner, mock_deploy_pkg):
-    """uninstall reports success and preserves files by default."""
-    mock_deploy_pkg["uninstall"].return_value = None
-
-    result = runner.invoke(dtaas, ["admin", "uninstall"])
-
-    assert result.exit_code == 0
-    assert "Deployment uninstalled successfully" in result.output
-    mock_deploy_pkg["uninstall"].assert_called_once_with(".", False)
-
 
 def test_admin_uninstall_remove_user_files_with_yes(runner, mock_deploy_pkg):
     """--remove-user-files with --yes skips the prompt and reports removal."""
@@ -356,16 +195,6 @@ def test_admin_uninstall_remove_user_files_with_yes(runner, mock_deploy_pkg):
     mock_deploy_pkg["uninstall"].assert_called_once_with(".", True)
 
 
-def test_admin_uninstall_remove_user_files_aborts(runner, mock_deploy_pkg):
-    """Declining the confirmation prompt aborts before any teardown."""
-    result = runner.invoke(
-        dtaas, ["admin", "uninstall", "--remove-user-files"], input="n\n"
-    )
-
-    assert result.exit_code != 0
-    mock_deploy_pkg["uninstall"].assert_not_called()
-
-
 def test_admin_uninstall_error(runner, mock_deploy_pkg):
     """uninstall converts an OSError into a ClickException."""
     mock_deploy_pkg["uninstall"].side_effect = OSError("daemon down")
@@ -374,18 +203,6 @@ def test_admin_uninstall_error(runner, mock_deploy_pkg):
 
     assert result.exit_code != 0
     assert "daemon down" in result.output
-
-
-def test_admin_uninstall_no_existing_installation(runner, mock_deploy_pkg):
-    """A repeated uninstall reports there is nothing installed, not success."""
-    mock_deploy_pkg["present"].return_value = False
-
-    result = runner.invoke(dtaas, ["admin", "uninstall"])
-
-    assert result.exit_code == 0
-    assert "no existing DTaaS / Workspace installation" in result.output
-    assert "uninstalled successfully" not in result.output
-    mock_deploy_pkg["uninstall"].assert_not_called()
 
 
 def test_admin_uninstall_removes_files_when_nothing_running(runner, mock_deploy_pkg):
@@ -411,7 +228,7 @@ def test_admin_uninstall_removes_files_when_nothing_running(runner, mock_deploy_
 def test_admin_update_certs_success(runner):
     """update --certs forwards the output dir and echoes the result message."""
     with patch(
-        "src.cmd.certUpdatePkg.update_certs", return_value="certs updated"
+        "src.cmd_utils.certUpdatePkg.update_certs", return_value="certs updated"
     ) as mock_update:
         result = runner.invoke(dtaas, ["admin", "update", "--certs"])
 
@@ -420,33 +237,13 @@ def test_admin_update_certs_success(runner):
     mock_update.assert_called_once_with(".")
 
 
-def test_admin_update_requires_a_target(runner):
-    """update without a target flag fails with a helpful message."""
-    result = runner.invoke(dtaas, ["admin", "update"])
-
-    assert result.exit_code != 0
-    assert "Nothing to update" in result.output
-
-
-def test_admin_update_validation_error(runner):
-    """A CertValidationError surfaces as a ClickException with its message."""
+def test_admin_update_config_success(runner):
+    """update --config forwards the output dir (not dry-run) and echoes the result."""
     with patch(
-        "src.cmd.certUpdatePkg.update_certs",
-        side_effect=CertValidationError("Certificate expired on 2024-01-01."),
-    ):
-        result = runner.invoke(dtaas, ["admin", "update", "--certs"])
+        "src.cmd_utils.configUpdatePkg.update_config", return_value="Updated config/.env."
+    ) as mock_update:
+        result = runner.invoke(dtaas, ["admin", "update", "--config"])
 
-    assert result.exit_code != 0
-    assert "expired" in result.output
-
-
-def test_admin_update_os_error(runner):
-    """An OSError (e.g. missing certs-src) surfaces as a ClickException."""
-    with patch(
-        "src.cmd.certUpdatePkg.update_certs",
-        side_effect=OSError("certs-src directory not found"),
-    ):
-        result = runner.invoke(dtaas, ["admin", "update", "--certs"])
-
-    assert result.exit_code != 0
-    assert "certs-src" in result.output
+    assert result.exit_code == 0
+    assert "Updated config/.env." in result.output
+    mock_update.assert_called_once_with(".", False)

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -36,7 +36,6 @@ def test_delete_user_success(runner, mock_user_pkg):
     mock_user_pkg["delete"].assert_called_once()
 
 
-
 def test_generate_project_success(runner):
     """Test successful project file generation with defaults"""
     with patch("src.cmd.projectPkg.generate_project") as mock_gen:
@@ -190,7 +189,6 @@ def test_admin_install_error(runner, mock_deploy_pkg):
     assert "not generated" in result.output
 
 
-
 def test_admin_uninstall_remove_user_files_with_yes(runner, mock_deploy_pkg):
     """--remove-user-files with --yes skips the prompt and reports removal."""
     mock_deploy_pkg["uninstall"].return_value = "Removed user files at '/x/files'."
@@ -249,7 +247,8 @@ def test_admin_update_certs_success(runner):
 def test_admin_update_config_success(runner):
     """update --config forwards the output dir (not dry-run) and echoes the result."""
     with patch(
-        "src.cmd_utils.configUpdatePkg.update_config", return_value="Updated config/.env."
+        "src.cmd_utils.configUpdatePkg.update_config",
+        return_value="Updated config/.env.",
     ) as mock_update:
         result = runner.invoke(dtaas, ["admin", "update", "--config"])
 

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -83,13 +83,22 @@ def test_generate_deployment_error(runner):
 
 
 def test_config_generate_success(runner):
-    """config generate forwards output-dir/force and reports success."""
-    with patch("src.cmd.projectPkg.generate_config") as mock_gen:
+    """config generate forwards output-dir/force and reports success when written."""
+    with patch("src.cmd.projectPkg.generate_config", return_value=False) as mock_gen:
         result = runner.invoke(dtaas, ["admin", "config", "generate"])
 
     assert result.exit_code == 0
     assert "Configuration file generated successfully" in result.output
     mock_gen.assert_called_once_with(".", False)
+
+
+def test_config_generate_skips_existing(runner):
+    """When the file already exists, no misleading success message is printed."""
+    with patch("src.cmd.projectPkg.generate_config", return_value=True):
+        result = runner.invoke(dtaas, ["admin", "config", "generate"])
+
+    assert result.exit_code == 0
+    assert "Configuration file generated successfully" not in result.output
 
 
 def test_config_generate_error(runner):

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -221,6 +221,60 @@ def test_generate_deployment_cert_copy_error(runner):
     assert "Error copying certificates" in result.output
 
 
+def test_config_generate_success(runner):
+    """config generate forwards output-dir/force and reports success."""
+    with patch("src.cmd.projectPkg.generate_config") as mock_gen:
+        result = runner.invoke(dtaas, ["admin", "config", "generate"])
+
+    assert result.exit_code == 0
+    assert "Configuration file generated successfully" in result.output
+    mock_gen.assert_called_once_with(".", False)
+
+
+def test_config_generate_error(runner):
+    """config generate converts an OSError into a ClickException."""
+    with patch("src.cmd.projectPkg.generate_config", side_effect=OSError("disk full")):
+        result = runner.invoke(dtaas, ["admin", "config", "generate"])
+
+    assert result.exit_code != 0
+    assert "Error while generating config" in result.output
+
+
+def test_config_validate_valid(runner):
+    """config validate reports success when no problems are found."""
+    with patch("src.cmd.configValidatePkg.validate_config", return_value=[]):
+        result = runner.invoke(dtaas, ["admin", "config", "validate"])
+
+    assert result.exit_code == 0
+    assert "Configuration is valid" in result.output
+
+
+def test_config_validate_reports_problems(runner):
+    """config validate lists every problem and exits non-zero."""
+    with patch(
+        "src.cmd.configValidatePkg.validate_config",
+        return_value=["git-repo must be a valid URL", "common.path is missing"],
+    ):
+        result = runner.invoke(dtaas, ["admin", "config", "validate"])
+
+    assert result.exit_code != 0
+    assert "Invalid dtaas.toml" in result.output
+    assert "- git-repo must be a valid URL" in result.output
+    assert "- common.path is missing" in result.output
+
+
+def test_config_validate_missing_file(runner):
+    """A FileNotFoundError from validate_config surfaces as a ClickException."""
+    with patch(
+        "src.cmd.configValidatePkg.validate_config",
+        side_effect=FileNotFoundError("dtaas.toml not found"),
+    ):
+        result = runner.invoke(dtaas, ["admin", "config", "validate"])
+
+    assert result.exit_code != 0
+    assert "dtaas.toml not found" in result.output
+
+
 def test_add_users_config_error(runner):
     """add command raises ClickException when Config() fails"""
     with patch("src.cmd_utils.configPkg.Config", side_effect=RuntimeError("no config")):

--- a/cli/tests/test_config_update.py
+++ b/cli/tests/test_config_update.py
@@ -73,42 +73,34 @@ def test_validate_raises_with_field_messages():
     assert "common.server-dns is missing" in message
 
 
-def test_services_to_restart_intersects_with_present(tmp_path):
-    """Only services that both back a changed file and exist are restarted."""
-    base = _write_deployment(tmp_path, ("traefik", "client", "dex"))  # no libms
-    services = config_update._services_to_restart(base, [".env"])
-    assert services == ["client", "dex", "traefik"]  # libms/forward-auth absent
-
-
 def test_update_config_dry_run_previews_without_writing(tmp_path):
-    """Dry run reports would-be changes and restarts but edits nothing."""
+    """Dry run reports would-be changes and restart but edits nothing."""
     base = _write_deployment(tmp_path, SERVER_SERVICES)
     env_before = (tmp_path / "config" / ".env").read_text()
-    with patch("src.pkg.config_update.deploy.restart_service") as mock_restart:
+    with patch("src.pkg.config_update.deploy.restart_all") as mock_restart:
         message = config_update.update_config(base, dry_run=True)
     assert "Would update config/.env" in message
-    assert "would restart" in message
+    assert "would restart all services" in message
     mock_restart.assert_not_called()
     assert (tmp_path / "config" / ".env").read_text() == env_before
 
 
-def test_update_config_applies_and_restarts(tmp_path):
-    """A real run rewrites the changed file and restarts its backing services."""
+def test_update_config_applies_and_restarts_all(tmp_path):
+    """A real run rewrites the changed file and recreates the whole deployment."""
     base = _write_deployment(tmp_path, SERVER_SERVICES)
-    with patch("src.pkg.config_update.deploy.restart_service") as mock_restart:
+    with patch("src.pkg.config_update.deploy.restart_all") as mock_restart:
         message = config_update.update_config(base, dry_run=False)
     assert "SERVER_DNS=example.org" in (tmp_path / "config" / ".env").read_text()
-    assert "Updated config/.env" in message
-    restarted = {call.args[1] for call in mock_restart.call_args_list}
-    assert restarted == {"traefik", "client", "libms", "traefik-forward-auth"}
+    assert "Updated config/.env; restarted all services." == message
+    mock_restart.assert_called_once_with(base)
 
 
 def test_update_config_idempotent_second_run(tmp_path):
     """Re-running after the values are applied reports no changes and no restart."""
     base = _write_deployment(tmp_path, SERVER_SERVICES)
-    with patch("src.pkg.config_update.deploy.restart_service"):
+    with patch("src.pkg.config_update.deploy.restart_all"):
         config_update.update_config(base, dry_run=False)
-    with patch("src.pkg.config_update.deploy.restart_service") as mock_restart:
+    with patch("src.pkg.config_update.deploy.restart_all") as mock_restart:
         message = config_update.update_config(base, dry_run=False)
     assert "No configuration changes" in message
     mock_restart.assert_not_called()

--- a/cli/tests/test_config_update.py
+++ b/cli/tests/test_config_update.py
@@ -1,0 +1,130 @@
+"""Tests for the config_update module (admin update --config)."""
+
+from unittest.mock import patch
+import pytest
+from src.pkg import config_update
+# pylint: disable=protected-access
+
+
+def _write_deployment(tmp_path, services, env_text="SERVER_DNS=localhost\n"):
+    """Create a minimal installed deployment: compose, dtaas.toml, config/.env."""
+    service_block = "".join(f"  {name}:\n    image: x\n" for name in services)
+    (tmp_path / "docker-compose.yml").write_text("services:\n" + service_block)
+    (tmp_path / "dtaas.toml").write_text(
+        'git-repo="https://github.com/into-cps-association/DTaaS.git"\n'
+        "[common]\n"
+        'server-dns="example.org"\n'
+        f'path="{str(tmp_path).replace(chr(92), "/")}"\n'
+        "[common.resources]\n"
+        "cpus=4\npids_limit=4960\n"
+        'mem_limit="4G"\nshm_size="512m"\n'
+    )
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / ".env").write_text(env_text)
+    return str(tmp_path)
+
+
+SERVER_SERVICES = ("traefik", "client", "libms", "traefik-forward-auth", "user1")
+
+
+def test_detect_deploy_type_by_service_markers(tmp_path):
+    """A unique service name (dex/keycloak/gitlab) pins the deployment type."""
+    base = _write_deployment(tmp_path, ("traefik", "client", "dex"))
+    assert config_update.detect_deploy_type(base) == "workspace-localhost"
+
+
+def test_detect_deploy_type_server_variant_uses_tls(tmp_path):
+    """A libms deployment is secure-server when tls.yml is present, else insecure."""
+    base = _write_deployment(tmp_path, SERVER_SERVICES)
+    assert config_update.detect_deploy_type(base) == "insecure-server"
+    (tmp_path / "config" / "tls.yml").write_text("tls: {}\n")
+    assert config_update.detect_deploy_type(base) == "secure-server"
+
+
+def test_detect_deploy_type_falls_back_to_localhost(tmp_path):
+    """Without any marker service the deployment is treated as localhost."""
+    base = _write_deployment(tmp_path, ("traefik", "client", "user"))
+    assert config_update.detect_deploy_type(base) == "localhost"
+
+
+def test_load_toml_missing_raises(tmp_path):
+    """_load_toml raises FileNotFoundError when no dtaas.toml is reachable."""
+    workdir = tmp_path / "empty"
+    workdir.mkdir()
+    with patch("src.pkg.config_update.utils.find_toml", return_value=None):
+        with pytest.raises(FileNotFoundError, match="dtaas.toml not found"):
+            config_update._load_toml(str(workdir))
+
+
+def test_load_toml_parse_error_raises(tmp_path):
+    """_load_toml raises ValueError when the file cannot be parsed."""
+    (tmp_path / "dtaas.toml").write_text("key = = =")
+    with pytest.raises(ValueError, match="Error reading dtaas.toml"):
+        config_update._load_toml(str(tmp_path))
+
+
+def test_validate_raises_with_field_messages():
+    """_validate surfaces every dtaas.toml problem as a field-level message."""
+    with pytest.raises(ValueError) as exc:
+        config_update._validate({"common": {}})
+    message = str(exc.value)
+    assert "git-repo is missing" in message
+    assert "common.server-dns is missing" in message
+
+
+def test_services_to_restart_intersects_with_present(tmp_path):
+    """Only services that both back a changed file and exist are restarted."""
+    base = _write_deployment(tmp_path, ("traefik", "client", "dex"))  # no libms
+    services = config_update._services_to_restart(base, [".env"])
+    assert services == ["client", "dex", "traefik"]  # libms/forward-auth absent
+
+
+def test_update_config_dry_run_previews_without_writing(tmp_path):
+    """Dry run reports would-be changes and restarts but edits nothing."""
+    base = _write_deployment(tmp_path, SERVER_SERVICES)
+    env_before = (tmp_path / "config" / ".env").read_text()
+    with patch("src.pkg.config_update.deploy.restart_service") as mock_restart:
+        message = config_update.update_config(base, dry_run=True)
+    assert "Would update config/.env" in message
+    assert "would restart" in message
+    mock_restart.assert_not_called()
+    assert (tmp_path / "config" / ".env").read_text() == env_before
+
+
+def test_update_config_applies_and_restarts(tmp_path):
+    """A real run rewrites the changed file and restarts its backing services."""
+    base = _write_deployment(tmp_path, SERVER_SERVICES)
+    with patch("src.pkg.config_update.deploy.restart_service") as mock_restart:
+        message = config_update.update_config(base, dry_run=False)
+    assert "SERVER_DNS=example.org" in (tmp_path / "config" / ".env").read_text()
+    assert "Updated config/.env" in message
+    restarted = {call.args[1] for call in mock_restart.call_args_list}
+    assert restarted == {"traefik", "client", "libms", "traefik-forward-auth"}
+
+
+def test_update_config_idempotent_second_run(tmp_path):
+    """Re-running after the values are applied reports no changes and no restart."""
+    base = _write_deployment(tmp_path, SERVER_SERVICES)
+    with patch("src.pkg.config_update.deploy.restart_service"):
+        config_update.update_config(base, dry_run=False)
+    with patch("src.pkg.config_update.deploy.restart_service") as mock_restart:
+        message = config_update.update_config(base, dry_run=False)
+    assert "No configuration changes" in message
+    mock_restart.assert_not_called()
+
+
+def test_update_config_rejects_invalid_toml(tmp_path):
+    """Invalid dtaas.toml is rejected before any file is touched."""
+    base = _write_deployment(tmp_path, SERVER_SERVICES)
+    (tmp_path / "dtaas.toml").write_text("[common]\nserver-dns=123\n")
+    env_before = (tmp_path / "config" / ".env").read_text()
+    with pytest.raises(ValueError, match="Invalid dtaas.toml"):
+        config_update.update_config(base, dry_run=False)
+    assert (tmp_path / "config" / ".env").read_text() == env_before
+
+
+def test_update_config_requires_deployment(tmp_path):
+    """Without a compose file the update fails with a deployment-missing error."""
+    with pytest.raises(OSError, match="docker-compose.yml"):
+        config_update.update_config(str(tmp_path), dry_run=False)

--- a/cli/tests/test_config_validate.py
+++ b/cli/tests/test_config_validate.py
@@ -68,7 +68,7 @@ def test_server_dns_validation(base):
     assert collect_errors(with_common(base, **{"server-dns": "999.999.999.999"})) == [msg]
     assert msg not in collect_errors(with_common(base, **{"server-dns": "localhost"}))
     assert msg not in collect_errors(with_common(base, **{"server-dns": "intocps.org"}))
-    assert msg not in collect_errors(with_common(base, **{"server-dns": "192.168.1.1"}))
+    assert msg not in collect_errors(with_common(base, **{"server-dns": "192.168.1.1"}))# NOSONAR
 
 
 def test_path_must_exist(base, tmp_path):

--- a/cli/tests/test_config_validate.py
+++ b/cli/tests/test_config_validate.py
@@ -1,0 +1,235 @@
+"""Tests for the config_validate module."""
+
+import copy
+import pytest
+from src.pkg.config_validate import collect_errors, validate_config
+from src.pkg.project import generate_config
+
+
+@pytest.fixture
+def base(tmp_path):
+    """A valid config whose path/certs-src point at an existing directory."""
+    existing = str(tmp_path)
+    return {
+        "git-repo": "https://github.com/into-cps-association/DTaaS.git",
+        "common": {
+            "server-dns": "localhost",
+            "path": existing,
+            "security": {"certs-src": existing},
+            "resources": {
+                "cpus": 4,
+                "pids_limit": 4960,
+                "mem_limit": "4G",
+                "shm_size": "512m",
+            },
+        },
+        "users": {
+            "add": ["u1", "u2"],
+            "delete": ["u2"],
+            "u1": {"email": "u1@intocps.org"},
+            "u2": {"email": "u2@intocps.org"},
+        },
+    }
+
+
+def with_common(base, **changes):
+    """Return a deep copy of *base* with common-section keys overridden."""
+    data = copy.deepcopy(base)
+    data["common"].update(changes)
+    return data
+
+
+def test_valid_config_has_no_errors(base):
+    """A fully populated, correct config produces no problems."""
+    assert collect_errors(base) == []
+
+
+def test_git_repo_missing_and_invalid(base):
+    """git-repo must be present and a clean URL (stray '@@' is rejected)."""
+    no_repo = copy.deepcopy(base)
+    del no_repo["git-repo"]
+    assert "git-repo is missing" in collect_errors(no_repo)
+
+    bad = copy.deepcopy(base)
+    bad["git-repo"] = "https://github.com/into-cps-association/DTaaS.git..cs@@"
+    assert "git-repo must be a valid URL" in collect_errors(bad)
+
+    bad["git-repo"] = 123  # non-string
+    assert "git-repo must be a valid URL" in collect_errors(bad)
+
+
+def test_server_dns_validation(base):
+    """localhost, IPs and FQDNs pass; a bare single-label name is rejected."""
+    msg = "common.server-dns must be a valid hostname or IP address"
+
+    assert collect_errors(with_common(base, **{"server-dns": "lossscalhost"})) == [msg]
+    assert collect_errors(with_common(base, **{"server-dns": 123})) == [msg]
+    assert msg not in collect_errors(with_common(base, **{"server-dns": "localhost"}))
+    assert msg not in collect_errors(with_common(base, **{"server-dns": "intocps.org"}))
+    assert msg not in collect_errors(with_common(base, **{"server-dns": "192.168.1.1"}))
+
+
+def test_path_must_exist(base, tmp_path):
+    """common.path must be an absolute path to a directory that exists."""
+    msg = "common.path must be an absolute path to an existing directory"
+
+    assert collect_errors(with_common(base, path="relative/dir")) == [msg]
+    assert collect_errors(with_common(base, path=str(tmp_path / "missing"))) == [msg]
+    assert collect_errors(with_common(base, path=123)) == [msg]
+    # The fixture's path (tmp_path) exists, so the valid config has no path error.
+    assert msg not in collect_errors(base)
+
+
+def test_certs_src_optional_but_must_exist_when_present(base, tmp_path):
+    """certs-src may be omitted, but when present must be an existing directory."""
+    msg = "common.security.certs-src must be an absolute path to an existing directory"
+
+    no_security = with_common(base, security={})
+    assert msg not in collect_errors(no_security)
+
+    missing_dir = with_common(base, security={"certs-src": str(tmp_path / "nope")})
+    assert msg in collect_errors(missing_dir)
+
+
+def test_resource_validation(base):
+    """cpus/pids_limit must be ints; mem_limit/shm_size carry the right example."""
+    broken = with_common(
+        base,
+        resources={
+            "cpus": "4",  # string, not int
+            "pids_limit": True,  # bool is rejected even though it subclasses int
+            "mem_limit": "abc",  # not a size string
+            # shm_size omitted -> missing
+        },
+    )
+    errors = collect_errors(broken)
+    assert "common.resources.cpus must be an integer" in errors
+    assert "common.resources.pids_limit must be an integer" in errors
+    assert "common.resources.mem_limit must be a size string like '4G'" in errors
+    assert "common.resources.shm_size is missing" in errors
+
+
+def test_shm_size_message_uses_its_own_example(base):
+    """The shm_size message references '512m', not '4G'."""
+    broken = with_common(
+        base,
+        resources={"cpus": 4, "pids_limit": 4960, "mem_limit": "4G", "shm_size": "bad"},
+    )
+    assert (
+        "common.resources.shm_size must be a size string like '512m'"
+        in collect_errors(broken)
+    )
+
+
+def test_user_lists_validation(base):
+    """users.add/delete are optional but must be lists of strings when present."""
+    data = copy.deepcopy(base)
+    data["users"] = {"add": "notalist", "delete": ["ok", 5]}
+    errors = collect_errors(data)
+    assert "users.add must be a list of strings" in errors
+    assert "users.delete must be a list of strings" in errors
+
+    data["users"] = {}  # absent lists are allowed
+    assert collect_errors(data) == []
+
+
+def test_email_validation(base):
+    """Each user sub-table must carry a valid email."""
+    data = copy.deepcopy(base)
+    data["users"] = {
+        "add": ["u1"],
+        "u1": {"email": "not-an-email"},
+        "u2": {},  # missing email
+    }
+    errors = collect_errors(data)
+    assert "users.u1.email is not a valid email address" in errors
+    assert "users.u2.email is not a valid email address" in errors
+
+
+def test_deploy_sections_are_optional(base):
+    """Deployment sections are validated only when present."""
+    assert collect_errors(base) == []  # base has no deployment sections
+
+
+def test_deploy_urls_validated(base):
+    """URL fields in deployment sections must be valid URLs."""
+    data = copy.deepcopy(base)
+    data["frontend"] = {"react-app-oauth-url": "https:s/£@/gitlab.com"}
+    data["workspace-localhost"] = {"auth-authority": "http://localhost:5556/dex"}
+    errors = collect_errors(data)
+    assert "frontend.react-app-oauth-url must be a valid URL" in errors
+    # An http localhost authority with a port is a valid URL.
+    assert "workspace-localhost.auth-authority must be a valid URL" not in errors
+
+
+def test_deploy_username_validated(base):
+    """default-user fields must be valid usernames."""
+    data = copy.deepcopy(base)
+    data["localhost"] = {
+        "default-user": "bad user",
+        "auth-authority": "https://gitlab.com/",
+    }
+    errors = collect_errors(data)
+    assert "localhost.default-user must be a valid username" in errors
+    assert "localhost.auth-authority must be a valid URL" not in errors
+
+
+def test_deploy_placeholder_host_with_underscore_flagged(base):
+    """Strict URL checking flags the template's your_server_dns placeholder."""
+    data = copy.deepcopy(base)
+    data["workspace-secure-server"] = {
+        "keycloak-issuer-url": "https://your_server_dns/auth/realms/dtaas"
+    }
+    assert (
+        "workspace-secure-server.keycloak-issuer-url must be a valid URL"
+        in collect_errors(data)
+    )
+
+
+def test_non_dict_sections_report_missing_keys():
+    """A malformed (non-dict) section is treated as having no keys."""
+    errors = collect_errors({"common": "oops", "users": "oops"})
+    assert "common.server-dns is missing" in errors
+    assert "common.path is missing" in errors
+
+
+def test_validate_config_missing_file(tmp_path, monkeypatch):
+    """validate_config raises FileNotFoundError when no dtaas.toml exists."""
+    monkeypatch.chdir(tmp_path)  # neither output_dir nor cwd has the file
+    with pytest.raises(FileNotFoundError, match="dtaas.toml not found"):
+        validate_config(str(tmp_path))
+
+
+def test_validate_config_parse_error(tmp_path):
+    """validate_config raises ValueError when the file cannot be parsed."""
+    (tmp_path / "dtaas.toml").write_text("key = = =")
+    with pytest.raises(ValueError):
+        validate_config(str(tmp_path))
+
+
+def test_validate_config_returns_empty_for_valid_file(tmp_path):
+    """A real dtaas.toml whose path/certs-src exist validates clean end to end."""
+    existing = str(tmp_path).replace("\\", "/")  # forward slashes are TOML-safe
+    (tmp_path / "dtaas.toml").write_text(
+        'git-repo="https://github.com/into-cps-association/DTaaS.git"\n'
+        "[common]\n"
+        'server-dns="localhost"\n'
+        f'path="{existing}"\n'
+        "[common.security]\n"
+        f"certs-src='{existing}'\n"
+        "[common.resources]\n"
+        "cpus=4\npids_limit=4960\n"
+        'mem_limit="4G"\nshm_size="512m"\n'
+        "[users]\n"
+        'add=["u1"]\n'
+        "[users.u1]\n"
+        'email="u1@intocps.org"\n'
+    )
+    assert validate_config(str(tmp_path)) == []
+
+
+def test_validate_config_flags_placeholder_path(tmp_path):
+    """The shipped template's placeholder path does not exist, so it is flagged."""
+    generate_config(str(tmp_path))
+    errors = validate_config(str(tmp_path))
+    assert any(e.startswith("common.path") for e in errors)

--- a/cli/tests/test_config_validate.py
+++ b/cli/tests/test_config_validate.py
@@ -154,6 +154,14 @@ def test_email_validation(base):
     assert "users.u2.email is not a valid email address" in errors
 
 
+def test_email_validation_rejects_malformed_addresses(base):
+    """email-validator catches cases a minimal regex would wrongly accept."""
+    for bad in ("foo@@bar.com", "foo@bar", "foo@.com", 123):
+        data = copy.deepcopy(base)
+        data["users"] = {"add": ["u1"], "u1": {"email": bad}}
+        assert "users.u1.email is not a valid email address" in collect_errors(data)
+
+
 def test_deploy_sections_are_optional(base):
     """Deployment sections are validated only when present."""
     assert collect_errors(base) == []  # base has no deployment sections

--- a/cli/tests/test_config_validate.py
+++ b/cli/tests/test_config_validate.py
@@ -58,6 +58,13 @@ def test_git_repo_missing_and_invalid(base):
     assert "git-repo must be a valid URL" in collect_errors(bad)
 
 
+def test_url_scheme_is_case_insensitive(base):
+    """An upper-case scheme (HTTPS://) is still accepted as a valid URL."""
+    ok = copy.deepcopy(base)
+    ok["git-repo"] = "HTTPS://github.com/into-cps-association/DTaaS.git"
+    assert "git-repo must be a valid URL" not in collect_errors(ok)
+
+
 def test_server_dns_validation(base):
     """localhost, IPs and FQDNs pass; a bare single-label name is rejected."""
     msg = "common.server-dns must be a valid hostname or IP address"

--- a/cli/tests/test_config_validate.py
+++ b/cli/tests/test_config_validate.py
@@ -72,10 +72,14 @@ def test_server_dns_validation(base):
     assert collect_errors(with_common(base, **{"server-dns": "lossscalhost"})) == [msg]
     assert collect_errors(with_common(base, **{"server-dns": 123})) == [msg]
     # A dotted-numeric value that is not a valid IP is rejected, not read as a host.
-    assert collect_errors(with_common(base, **{"server-dns": "999.999.999.999"})) == [msg]
+    assert collect_errors(with_common(base, **{"server-dns": "999.999.999.999"})) == [
+        msg
+    ]
     assert msg not in collect_errors(with_common(base, **{"server-dns": "localhost"}))
     assert msg not in collect_errors(with_common(base, **{"server-dns": "intocps.org"}))
-    assert msg not in collect_errors(with_common(base, **{"server-dns": "192.168.1.1"}))# NOSONAR
+    assert msg not in collect_errors(
+        with_common(base, **{"server-dns": "192.168.1.1"})
+    )  # NOSONAR
 
 
 def test_path_must_exist(base, tmp_path):

--- a/cli/tests/test_config_validate.py
+++ b/cli/tests/test_config_validate.py
@@ -64,6 +64,8 @@ def test_server_dns_validation(base):
 
     assert collect_errors(with_common(base, **{"server-dns": "lossscalhost"})) == [msg]
     assert collect_errors(with_common(base, **{"server-dns": 123})) == [msg]
+    # A dotted-numeric value that is not a valid IP is rejected, not read as a host.
+    assert collect_errors(with_common(base, **{"server-dns": "999.999.999.999"})) == [msg]
     assert msg not in collect_errors(with_common(base, **{"server-dns": "localhost"}))
     assert msg not in collect_errors(with_common(base, **{"server-dns": "intocps.org"}))
     assert msg not in collect_errors(with_common(base, **{"server-dns": "192.168.1.1"}))

--- a/cli/tests/test_config_validate.py
+++ b/cli/tests/test_config_validate.py
@@ -78,7 +78,7 @@ def test_server_dns_validation(base):
     assert msg not in collect_errors(with_common(base, **{"server-dns": "localhost"}))
     assert msg not in collect_errors(with_common(base, **{"server-dns": "intocps.org"}))
     assert msg not in collect_errors(
-        with_common(base, **{"server-dns": "192.168.1.1"})
+        with_common(base, **{"server-dns": "192.168.1.1"}) # NOSONAR
     )  # NOSONAR
 
 

--- a/cli/tests/test_config_validate.py
+++ b/cli/tests/test_config_validate.py
@@ -92,33 +92,39 @@ def test_certs_src_optional_but_must_exist_when_present(base, tmp_path):
 
 
 def test_resource_validation(base):
-    """cpus/pids_limit must be ints; mem_limit/shm_size carry the right example."""
+    """cpus must be a number; pids_limit an int; mem/shm need a unit; shm missing."""
     broken = with_common(
         base,
         resources={
-            "cpus": "4",  # string, not int
+            "cpus": "4",  # a string is not a number
             "pids_limit": True,  # bool is rejected even though it subclasses int
-            "mem_limit": "abc",  # not a size string
+            "mem_limit": "4096",  # missing a unit
             # shm_size omitted -> missing
         },
     )
     errors = collect_errors(broken)
-    assert "common.resources.cpus must be an integer" in errors
+    assert "common.resources.cpus must be a positive number of CPU cores" in errors
     assert "common.resources.pids_limit must be an integer" in errors
-    assert "common.resources.mem_limit must be a size string like '4G'" in errors
+    assert "common.resources.mem_limit must include a unit, e.g. '4G'" in errors
     assert "common.resources.shm_size is missing" in errors
 
 
-def test_shm_size_message_uses_its_own_example(base):
-    """The shm_size message references '512m', not '4G'."""
-    broken = with_common(
-        base,
-        resources={"cpus": 4, "pids_limit": 4960, "mem_limit": "4G", "shm_size": "bad"},
-    )
-    assert (
-        "common.resources.shm_size must be a size string like '512m'"
-        in collect_errors(broken)
-    )
+def test_cpus_must_be_positive_number(base):
+    """cpus accepts fractional cores but rejects 0, bools and strings."""
+    msg = "common.resources.cpus must be a positive number of CPU cores"
+    res = base["common"]["resources"]
+    assert msg not in collect_errors(with_common(base, resources={**res, "cpus": 0.5}))
+    assert msg in collect_errors(with_common(base, resources={**res, "cpus": 0}))
+    assert msg in collect_errors(with_common(base, resources={**res, "cpus": True}))
+
+
+def test_size_unit_is_required(base):
+    """mem_limit/shm_size require a unit; '42s' and bare numbers are rejected."""
+    res = base["common"]["resources"]
+    bad = with_common(base, resources={**res, "mem_limit": "42s", "shm_size": "256"})
+    errors = collect_errors(bad)
+    assert "common.resources.mem_limit must include a unit, e.g. '4G'" in errors
+    assert "common.resources.shm_size must include a unit, e.g. '512m'" in errors
 
 
 def test_user_lists_validation(base):

--- a/cli/tests/test_deploy.py
+++ b/cli/tests/test_deploy.py
@@ -7,12 +7,6 @@ from src.pkg import deploy
 # pylint: disable=protected-access
 
 
-def test_require_deployment_missing_compose(tmp_path):
-    """_require_deployment fails when the compose file is absent."""
-    with pytest.raises(OSError, match="docker-compose.yml"):
-        deploy._require_deployment(str(tmp_path))
-
-
 def test_require_deployment_missing_toml(tmp_path, monkeypatch):
     """_require_deployment fails when dtaas.toml is absent from dir and cwd."""
     (tmp_path / "docker-compose.yml").write_text("services: {}")
@@ -21,24 +15,6 @@ def test_require_deployment_missing_toml(tmp_path, monkeypatch):
     monkeypatch.chdir(workdir)  # no dtaas.toml in the cwd either
     with pytest.raises(OSError, match="dtaas.toml"):
         deploy._require_deployment(str(tmp_path))
-
-
-def test_require_deployment_toml_falls_back_to_cwd(tmp_path, monkeypatch):
-    """dtaas.toml in the cwd satisfies the check when absent from output dir."""
-    outdir = tmp_path / "insecure"
-    outdir.mkdir()
-    (outdir / "docker-compose.yml").write_text("services: {}")
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / "dtaas.toml").write_text("x = 1")  # toml only in the cwd
-    deploy._require_deployment(str(outdir))  # does not raise
-
-
-def test_env_files_returns_config_env_when_present(tmp_path):
-    """_env_files returns config/.env so compose loads it explicitly."""
-    (tmp_path / "config").mkdir()
-    env_file = tmp_path / "config" / ".env"
-    env_file.write_text("OAUTH_URL=https://gitlab.com\n")
-    assert deploy._env_files(str(tmp_path)) == [str(env_file)]
 
 
 def test_env_files_empty_when_no_config_env(tmp_path):
@@ -56,15 +32,6 @@ def test_client_passes_env_files(tmp_path):
     assert kwargs["compose_env_files"] == [str(tmp_path / "config" / ".env")]
 
 
-def test_install_runs_compose_up(tmp_path):
-    """install validates inputs and runs 'docker compose up' detached."""
-    (tmp_path / "docker-compose.yml").write_text("services: {}")
-    (tmp_path / "dtaas.toml").write_text("x = 1")
-    with patch("src.pkg.deploy._client") as mock_client:
-        deploy.install(str(tmp_path))
-        mock_client.return_value.compose.up.assert_called_once_with(detach=True)
-
-
 def test_install_propagates_docker_exception(tmp_path):
     """A compose failure surfaces as the real DockerException."""
     (tmp_path / "docker-compose.yml").write_text("services: {}")
@@ -75,16 +42,6 @@ def test_install_propagates_docker_exception(tmp_path):
         )
         with pytest.raises(DockerException):
             deploy.install(str(tmp_path))
-
-
-def test_check_within_base_rejects_escape(tmp_path):
-    """A files dir resolving outside the install dir is rejected."""
-    base = tmp_path / "install"
-    base.mkdir()
-    outside = tmp_path / "outside_files"
-    outside.mkdir()
-    with pytest.raises(OSError, match="resolves outside"):
-        deploy._check_within_base(outside, base)
 
 
 def test_check_within_base_rejects_symlink(tmp_path):
@@ -102,54 +59,6 @@ def test_check_within_base_rejects_symlink(tmp_path):
         deploy._check_within_base(link, base)
 
 
-def test_user_files_dir_absent(tmp_path):
-    """_user_files_dir returns None when files/ does not exist."""
-    assert deploy._user_files_dir(str(tmp_path)) is None
-
-
-def test_delete_user_files_removes_per_user_dir(tmp_path):
-    """delete_user_files removes a per-user directory and reports it."""
-    (tmp_path / "files" / "alice").mkdir(parents=True)
-    message = deploy.delete_user_files(str(tmp_path))
-    assert "Removed user files" in message
-    assert not (tmp_path / "files" / "alice").exists()
-    assert (tmp_path / "files").is_dir()
-
-
-def test_delete_user_files_keeps_scaffolding(tmp_path):
-    """delete_user_files keeps files/common and files/template for reinstall."""
-    files = tmp_path / "files"
-    (files / "alice").mkdir(parents=True)
-    (files / "common").mkdir()
-    (files / "template").mkdir()
-
-    deploy.delete_user_files(str(tmp_path))
-
-    assert not (files / "alice").exists()
-    assert (files / "common").is_dir()
-    assert (files / "template").is_dir()
-
-
-def test_remove_user_dirs_skips_symlinks_and_files(tmp_path):
-    """_remove_user_dirs leaves symlinked dirs and plain files untouched."""
-    files = tmp_path / "files"
-    (files / "alice").mkdir(parents=True)
-    (files / "loose.txt").write_text("x")
-    outside = tmp_path / "outside"
-    outside.mkdir()
-    try:
-        (files / "link").symlink_to(outside, target_is_directory=True)
-    except (OSError, NotImplementedError):
-        pytest.skip("symlink creation is not permitted on this platform")
-
-    removed = deploy._remove_user_dirs(files)
-
-    assert removed == ["alice"]
-    assert (files / "link").exists()
-    assert (files / "loose.txt").exists()
-    assert outside.is_dir()
-
-
 def test_delete_user_files_reports_when_only_scaffolding(tmp_path):
     """With only scaffolding present there are no per-user dirs to remove."""
     (tmp_path / "files" / "common").mkdir(parents=True)
@@ -161,22 +70,6 @@ def test_delete_user_files_reports_when_only_scaffolding(tmp_path):
 def test_delete_user_files_absent(tmp_path):
     """delete_user_files reports when there is no files/ directory at all."""
     assert "nothing to remove" in deploy.delete_user_files(str(tmp_path))
-
-
-def test_uninstall_runs_compose_down(tmp_path):
-    """uninstall runs 'docker compose down' and preserves files by default."""
-    (tmp_path / "docker-compose.yml").write_text("services: {}")
-    with patch("src.pkg.deploy._client") as mock_client:
-        assert deploy.uninstall(str(tmp_path)) is None
-        mock_client.return_value.compose.down.assert_called_once_with()
-
-
-def test_uninstall_requires_compose_file(tmp_path):
-    """uninstall refuses to act when no deployment exists in the directory."""
-    with patch("src.pkg.deploy._client") as mock_client:
-        with pytest.raises(OSError, match="docker-compose.yml"):
-            deploy.uninstall(str(tmp_path), remove_user_files=True)
-        mock_client.assert_not_called()
 
 
 def test_uninstall_removes_user_files(tmp_path):
@@ -210,12 +103,6 @@ def test_down_user_containers_tears_down_user_compose(tmp_path):
     mock_docker.return_value.compose.down.assert_called_once_with(remove_orphans=True)
 
 
-def test_down_user_containers_noop_without_user_compose(tmp_path):
-    """_down_user_containers does nothing when no user compose file exists."""
-    with patch("src.pkg.deploy.DockerClient") as mock_docker:
-        deploy._down_user_containers(str(tmp_path))
-    mock_docker.assert_not_called()
-
 
 def test_installation_present_true_when_main_has_containers(tmp_path):
     """installation_present is True when the main project has any container."""
@@ -248,14 +135,6 @@ def test_restart_service_force_recreates(tmp_path):
         )
 
 
-def test_restart_service_requires_compose_file(tmp_path):
-    """restart_service refuses to act without a generated deployment."""
-    with patch("src.pkg.deploy._client") as mock_client:
-        with pytest.raises(OSError, match="docker-compose.yml"):
-            deploy.restart_service(str(tmp_path), "traefik")
-        mock_client.assert_not_called()
-
-
 def test_stop_service_stops_named_service(tmp_path):
     """stop_service stops only the named compose service."""
     (tmp_path / "docker-compose.yml").write_text("services: {}")
@@ -266,30 +145,21 @@ def test_stop_service_stops_named_service(tmp_path):
         )
 
 
-def test_stop_service_requires_compose_file(tmp_path):
-    """stop_service refuses to act without a generated deployment."""
-    with patch("src.pkg.deploy._client") as mock_client:
-        with pytest.raises(OSError, match="docker-compose.yml"):
-            deploy.stop_service(str(tmp_path), "traefik")
-        mock_client.assert_not_called()
-
-
-def test_service_running_true_when_container_up(tmp_path):
-    """service_running returns True when the service's container is running."""
-    (tmp_path / "docker-compose.yml").write_text("services: {}")
-    container = MagicMock()
-    container.state.running = True
-    with patch("src.pkg.deploy._client") as mock_client:
-        mock_client.return_value.compose.ps.return_value = [container]
-        assert deploy.service_running(str(tmp_path), "traefik") is True
-        mock_client.return_value.compose.ps.assert_called_once_with(
-            services=["traefik"]
-        )
-
-
 def test_service_running_false_when_no_container(tmp_path):
     """service_running returns False when no running container is listed."""
     (tmp_path / "docker-compose.yml").write_text("services: {}")
     with patch("src.pkg.deploy._client") as mock_client:
         mock_client.return_value.compose.ps.return_value = []
         assert deploy.service_running(str(tmp_path), "traefik") is False
+
+
+def test_compose_services_empty_when_no_services_key(tmp_path):
+    """compose_services tolerates a compose file with no services mapping."""
+    (tmp_path / "docker-compose.yml").write_text("networks:\n  frontend: {}\n")
+    assert deploy.compose_services(str(tmp_path)) == set()
+
+
+def test_compose_services_requires_compose_file(tmp_path):
+    """compose_services refuses to act without a generated deployment."""
+    with pytest.raises(OSError, match="docker-compose.yml"):
+        deploy.compose_services(str(tmp_path))

--- a/cli/tests/test_deploy.py
+++ b/cli/tests/test_deploy.py
@@ -103,7 +103,6 @@ def test_down_user_containers_tears_down_user_compose(tmp_path):
     mock_docker.return_value.compose.down.assert_called_once_with(remove_orphans=True)
 
 
-
 def test_installation_present_true_when_main_has_containers(tmp_path):
     """installation_present is True when the main project has any container."""
     (tmp_path / "docker-compose.yml").write_text("services: {}")
@@ -133,6 +132,22 @@ def test_restart_service_force_recreates(tmp_path):
         mock_client.return_value.compose.up.assert_called_once_with(
             services=["traefik"], force_recreate=True, detach=True
         )
+
+
+def test_restart_all_force_recreates_whole_project(tmp_path):
+    """restart_all recreates every service (no services filter), detached."""
+    (tmp_path / "docker-compose.yml").write_text("services: {}")
+    with patch("src.pkg.deploy._client") as mock_client:
+        deploy.restart_all(str(tmp_path))
+        mock_client.return_value.compose.up.assert_called_once_with(
+            force_recreate=True, detach=True
+        )
+
+
+def test_restart_all_requires_compose_file(tmp_path):
+    """restart_all refuses to act without a generated deployment."""
+    with pytest.raises(OSError, match="docker-compose.yml"):
+        deploy.restart_all(str(tmp_path))
 
 
 def test_stop_service_stops_named_service(tmp_path):

--- a/cli/tests/test_deploy_config.py
+++ b/cli/tests/test_deploy_config.py
@@ -11,6 +11,7 @@ from src.pkg.deploy_config import (
     build_file_specs,
     apply_config,
     check_placeholders,
+    diff_specs,
 )
 
 
@@ -199,3 +200,34 @@ def test_toml_lookup_user_collision_reserved_key():
     """email lookup is safe when a username collides with the 'add' key"""
     toml = {"users": {"add": ["add"]}}
     assert _toml_lookup(toml, "users.email1") == ""
+
+
+def test_diff_specs_reports_only_changed_files(tmp_path):
+    """diff_specs lists files a spec would change and omits no-op specs."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / ".env").write_text(ENV_TEXT)
+    (config_dir / "client.js").write_text(JS_TEXT)
+
+    changed = diff_specs(
+        str(tmp_path),
+        [
+            ("config/.env", "env", {"SERVER_DNS": "myserver.com"}),  # changes
+            ("config/client.js", "js", {"REACT_APP_CLIENT_ID": "your_client_id_here"}),
+        ],
+    )
+    assert changed == ["config/.env"]
+
+
+def test_diff_specs_does_not_write(tmp_path):
+    """diff_specs is read-only: it never edits the file it inspects."""
+    env = tmp_path / ".env"
+    env.write_text("SERVER_DNS=localhost\n")
+    before = env.read_text()
+    diff_specs(str(tmp_path), [(".env", "env", {"SERVER_DNS": "changed.com"})])
+    assert env.read_text() == before
+
+
+def test_diff_specs_skips_missing_files(tmp_path):
+    """A spec for a file absent from dest_dir counts as unchanged."""
+    assert not diff_specs(str(tmp_path), [("config/.env", "env", {"K": "v"})])

--- a/cli/tests/test_project.py
+++ b/cli/tests/test_project.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 from src.pkg.project import (
     generate_project,
+    generate_config,
     generate_deploy_project,
     create_user_dirs,
     set_files_permissions,
@@ -16,6 +17,31 @@ from src.pkg.project import (
     DEPLOY_TYPES,
 )
 # pylint: disable=protected-access
+
+
+def test_generate_config_copies_only_toml(tmp_path):
+    """generate_config writes dtaas.toml and not the other project templates."""
+    generate_config(str(tmp_path))
+
+    assert (tmp_path / "dtaas.toml").is_file()
+    assert not (tmp_path / "users.server.yml").exists()
+
+
+def test_generate_config_skips_existing_without_force(tmp_path, capsys):
+    """An existing dtaas.toml is preserved and a skip message is printed."""
+    (tmp_path / "dtaas.toml").write_text("existing")
+
+    generate_config(str(tmp_path))
+
+    assert (tmp_path / "dtaas.toml").read_text() == "existing"
+    assert "'dtaas.toml' already exists, skipping" in capsys.readouterr().out
+
+
+def test_generate_config_raises_on_copy_failure(tmp_path):
+    """OSError is raised when the dtaas.toml copy fails."""
+    with patch("src.pkg.project.shutil.copy2", side_effect=OSError("disk full")):
+        with pytest.raises(OSError, match="disk full"):
+            generate_config(str(tmp_path))
 
 
 def test_generate_project_skips_existing_file(tmp_path, capsys):

--- a/cli/tests/test_project.py
+++ b/cli/tests/test_project.py
@@ -20,18 +20,18 @@ from src.pkg.project import (
 
 
 def test_generate_config_copies_only_toml(tmp_path):
-    """generate_config writes dtaas.toml and not the other project templates."""
-    generate_config(str(tmp_path))
+    """generate_config writes dtaas.toml (returning False) and no other templates."""
+    assert generate_config(str(tmp_path)) is False
 
     assert (tmp_path / "dtaas.toml").is_file()
     assert not (tmp_path / "users.server.yml").exists()
 
 
 def test_generate_config_skips_existing_without_force(tmp_path, capsys):
-    """An existing dtaas.toml is preserved and a skip message is printed."""
+    """An existing dtaas.toml is preserved, returns True, and prints a skip message."""
     (tmp_path / "dtaas.toml").write_text("existing")
 
-    generate_config(str(tmp_path))
+    assert generate_config(str(tmp_path)) is True
 
     assert (tmp_path / "dtaas.toml").read_text() == "existing"
     assert "'dtaas.toml' already exists, skipping" in capsys.readouterr().out

--- a/cli/tests/test_utils.py
+++ b/cli/tests/test_utils.py
@@ -27,7 +27,7 @@ def test_import_toml():
 
     expected = {
         "name": "Digital Twin as a Service (DTaaS)",
-        "version": "0.8.1",
+        "version": "0.9.0",
         "owner": "The INTO-CPS-Association",
         "git-repo": "https://github.com/into-cps-association/DTaaS.git",
         "common": {


### PR DESCRIPTION
# Better management of DTaaS CLI configuration

## Type of Change

- [X] New feature

## Description
Adds new commands:

`dtaas admin config generate` Writes a fresh `dtaas.toml` template into the
target directory for you to fill in. Only `dtaas.toml` is created, no other
project files.

`dtaas admin config validate` Reads `dtaas.toml` (from `--output-dir` first,
then the current directory) and reports every problem it finds at once, exiting
non-zero if the file is missing, unparseable, or any value below is invalid.

What it checks
- `git-repo` must be an `http(s)` URL
- `[common].server-dns`  must be `localhost`, an IP address, or a dotted fully
  qualified hostname
- `[common].path` must be an absolute path to a directory that exists
- `[common.security].certs-src`  when present, must be an absolute path to a
  directory that exists
- `[common.resources].cpus`  must be a positive number (e.g. `4` or `0.5`);
  `pids_limit` must be an integer
- `mem_limit`, `shm_size` must be size strings with a unit, e.g. `4G` or `512m`
- `[users].add`, `[users].delete`  when present, must be lists of strings
- `[users.<name>].email`  must be a valid email address
- Deployment-section URLs and `default-user`  when present, must be valid
  `http(s)` URLs / usernames

Each deployment section, including its `default-user` field, is checked only
when that section is present.

`dtaas admin update --config`  Re-applies `dtaas.toml` to an already-installed deployment's service config files and restarts only the services whose config changed. The deployment type is auto-detected, the config is validated first,
and the run is idempotent. Add `--dry-run` to preview the changes without writing or restarting anything.

## Options
- `--force` (`generate` only): overwrite an existing `dtaas.toml`. Without it,
  an existing file is left untouched and a message is printed.
- `--output-dir` (default: `.`): target directory for `dtaas.toml` (created if
  it does not exist), or the directory to read it from for `validate`/`update`.
- `--dry-run` (`update --config` only): show what would change without applying.
