### PR TITLE
## Support adding users with and without resource limits

### DIFF
--- a/cli/DEVELOPER.md
+++ b/cli/DEVELOPER.md
@@ -90,7 +90,7 @@ It has the following sections:
 
 ```toml
 name="Digital Twin as a Service (DTaaS)"
-version="0.9.1"
+version="0.10.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -119,6 +119,7 @@ directory) and reports all problems at once:
 | `[common].server-dns` | Must be `localhost`, an IP, or a fully qualified hostname |
 | `[common].path` | Must be an absolute path to an existing directory |
 | `[common.security].certs-src` | When present, must be an absolute path to an existing directory |
+| `[common.resources].set_limits` | When present, `true` or `false` (default `true`) |
 | `[common.resources].cpus` | Positive number (e.g. `4` or `0.5`) |
 | `[common.resources].pids_limit` | Integer |
 | `[common.resources].mem_limit`, `shm_size` | Byte size with required unit (e.g. `4G`, `512m`) |
@@ -135,6 +136,11 @@ present.
 
 `path` and `certs-src` are checked against the local filesystem, run
 `validate` on the deployment host.
+
+The `[common.resources]` limit fields (`cpus`, `pids_limit`, `mem_limit`,
+`shm_size`) are required only when `set_limits` is `true` (the default). With
+`set_limits = false` they are optional and ignored; any value still present is
+validated.
 
 **Options**
 
@@ -389,6 +395,7 @@ dtaas generate-project
 | `dtaas.toml` | Main CLI configuration |
 | `users.server.yml` | Docker Compose template for HTTP deployments |
 | `users.server.secure.yml` | Docker Compose template for HTTPS/TLS deployments |
+| `users.resources.yml` | Per-user resource-limit overlay, merged in when `set_limits` is true |
 | `files/template/` | Skeleton copied into each new user workspace |
 
 > **Tip: verify the Docker image tag**
@@ -428,6 +435,32 @@ the container for the change to take effect:
 ```bash
 docker compose -f compose.server.yml --env-file .env up -d --force-recreate traefik-forward-auth
 ```
+
+**Resource limits (optional)**
+
+By default each user container is created with the CPU, memory, process, and
+shared-memory caps from `[common.resources]`, merged in from the
+`users.resources.yml` overlay. To onboard users without any caps, set
+`set_limits = false` in that section:
+
+```toml
+# Constrained users (default): limits enforced
+[common.resources]
+set_limits = true
+cpus       = 4
+mem_limit  = "4G"
+pids_limit = 4960
+shm_size   = "512m"
+```
+
+```toml
+# Unconstrained users: no caps written, limit fields optional
+[common.resources]
+set_limits = false
+```
+
+The flag is read on every `user add`, so a deployment can host both constrained
+and unconstrained users by toggling `set_limits` between runs.
 
 > **Notes**
 > - `user add` starts a container for a new user or restarts a stopped one; it
@@ -536,6 +569,9 @@ certs-src = "/etc/letsencrypt/live/dtaas.example.com"
 
 # ── Per-user container resource limits (optional, all types) ──────────────────
 [common.resources]
+# Enforce the limits below. Set to false to add users without any caps.
+# The 4 fields are then optional and ignored. Defaults to true when omitted.
+set_limits = true
 cpus       = 4        # CPU cores; may be fractional, e.g. 0.5
 mem_limit  = "4G"     # memory limit — unit required: G, m, k …
 pids_limit = 4960     # maximum number of processes per container (integer)

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dtaas"
-version = "0.9.1"
+version = "0.10.0"
 description = "DTaaS CLI"
 authors = ["Astitva Sehgal"]
 license = "INTO-CPS-Association"

--- a/cli/src/pkg/config.py
+++ b/cli/src/pkg/config.py
@@ -100,6 +100,19 @@ class Config:
             return None, err
         return resources, None
 
+    def get_set_limits(self):
+        """Gets the set_limits flag from config.common.resources (default True).
+
+        When false, user containers are created without resource limits.
+        """
+        conf_common, err = self.get_common()
+        if err is not None or not isinstance(conf_common, dict):
+            return True, err
+        resources = conf_common.get("resources", {})
+        if not isinstance(resources, dict):
+            return True, Exception("Config file error: resources section is not a dict")
+        return bool(resources.get("set_limits", True)), None
+
     def get_tls(self):
         """Gets the TLS flag from config.common.security"""
         conf_common, err = self.get_common()

--- a/cli/src/pkg/config_validate.py
+++ b/cli/src/pkg/config_validate.py
@@ -144,14 +144,20 @@ def _check_certs_src(data):
 
 
 def _check_resources(data):
-    """cpus is a positive number; pids_limit an integer; mem/shm are byte sizes."""
+    """Resource limits, required unless common.resources.set_limits is false.
+
+    With set_limits = false the container runs uncapped, so the fields are
+    optional; any values that are present are still checked.
+    """
+    enabled = _get(data, "common", "resources", "set_limits") is not False
+    check = _required if enabled else _optional
     cpus_msg = "common.resources.cpus must be a positive number of CPU cores"
-    errors = _required(data, ("common", "resources", "cpus"), _is_number, cpus_msg)
+    errors = check(data, ("common", "resources", "cpus"), _is_number, cpus_msg)
     pids_msg = "common.resources.pids_limit must be an integer"
-    errors += _required(data, ("common", "resources", "pids_limit"), _is_int, pids_msg)
+    errors += check(data, ("common", "resources", "pids_limit"), _is_int, pids_msg)
     for field, example in _SIZE_FIELDS:
         message = f"common.resources.{field} must include a unit, e.g. '{example}'"
-        errors += _required(data, ("common", "resources", field), _is_size, message)
+        errors += check(data, ("common", "resources", field), _is_size, message)
     return errors
 
 

--- a/cli/src/pkg/project.py
+++ b/cli/src/pkg/project.py
@@ -13,6 +13,7 @@ TEMPLATE_FILES = [
     "dtaas.toml",
     "users.server.yml",
     "users.server.secure.yml",
+    "users.resources.yml",
 ]
 
 DEPLOY_TYPES = {

--- a/cli/src/pkg/users.py
+++ b/cli/src/pkg/users.py
@@ -11,30 +11,9 @@ from .users_utils import (
     categorize_users,
     report_missing_users,
     remove_users_from_compose,
+    build_base_mapping,
+    resource_mapping,
 )
-
-
-def _build_config_mapping(user_config, resources):
-    """Build the mapping for config substitution.
-
-    Args:
-        user_config: Dict with keys 'username', 'path', optionally 'server'
-        resources: Dict with resource limits
-
-    Returns:
-        Mapping dict for config substitution
-    """
-    mapping = {
-        "${DTAAS_DIR}": user_config["path"],
-        "${username}": user_config["username"],
-        "${shm_size}": str(resources["shm_size"]),
-        "${cpus}": str(resources["cpus"]),
-        "${mem_limit}": str(resources["mem_limit"]),
-        "${pids_limit}": str(resources["pids_limit"]),
-    }
-    if user_config.get("server") is not None:
-        mapping["${SERVER_DNS}"] = user_config["server"]
-    return mapping
 
 
 def _load_template(server, tls):
@@ -54,12 +33,29 @@ def _load_template(server, tls):
     return utils.import_yaml("users.server.yml")
 
 
+def _apply_resource_limits(service, config):
+    """Merge substituted resource limits into the service dict when enabled.
+
+    When set_limits is false the service is returned unchanged so the container
+    runs without CPU/memory/process caps. Raises on a template load or
+    substitution error.
+    """
+    if not config.get("set_limits", True):
+        return service
+    template, err = utils.import_yaml("users.resources.yml")
+    utils.check_error(err)
+    resources, err = utils.replace_all(template, resource_mapping(config["resources"]))
+    utils.check_error(err)
+    service.update(resources)
+    return service
+
+
 def get_compose_config(username, config):
     """Makes and returns the config for the user
 
     Args:
         username: Username for the config
-        config: Dict with 'server', 'path', 'resources', 'tls' keys
+        config: Dict with 'server', 'path', 'resources', 'tls', 'set_limits' keys
 
     Returns:
         Tuple of (user config dict, error if any)
@@ -67,16 +63,10 @@ def get_compose_config(username, config):
     try:
         template, err = _load_template(config["server"], config.get("tls"))
         utils.check_error(err)
-        user_config = {
-            "username": username,
-            "path": config["path"],
-            "server": config["server"]
-            if config["server"] != utils.LOCALHOST_SERVER
-            else None,
-        }
-        mapping = _build_config_mapping(user_config, config["resources"])
+        mapping = build_base_mapping(username, config)
         result, err = utils.replace_all(template, mapping)
         utils.check_error(err)
+        result = _apply_resource_limits(result, config)
     except Exception as e:
         return None, e
     return result, None
@@ -160,7 +150,9 @@ def _get_add_users_config(config_obj):
     utils.check_error(err)
     tls, err = config_obj.get_tls()
     utils.check_error(err)
-    return user_list, server, path, resources, tls
+    set_limits, err = config_obj.get_set_limits()
+    utils.check_error(err)
+    return user_list, server, path, resources, tls, set_limits
 
 
 def _finalize_compose(compose):
@@ -177,7 +169,9 @@ def add_users(config_obj):
     try:
         compose, err = utils.import_yaml(COMPOSE_USERS_YML)
         utils.check_error(err)
-        user_list, server, path, resources, tls = _get_add_users_config(config_obj)
+        user_list, server, path, resources, tls, set_limits = _get_add_users_config(
+            config_obj
+        )
         users_section, err = config_obj.get_users()
         utils.check_error(err)
     except Exception as e:
@@ -187,7 +181,13 @@ def add_users(config_obj):
 
     try:
         create_user_files(user_list, path + "/files")
-        config = {"server": server, "path": path, "resources": resources, "tls": tls}
+        config = {
+            "server": server,
+            "path": path,
+            "resources": resources,
+            "tls": tls,
+            "set_limits": set_limits,
+        }
         err = add_users_to_compose(user_list, compose, config)
         utils.check_error(err)
         # Authorise each user in the forward-auth config before starting their

--- a/cli/src/pkg/users_utils.py
+++ b/cli/src/pkg/users_utils.py
@@ -3,8 +3,34 @@
 import re
 import click
 from pathlib import Path
+from . import utils
 
 CONF_SERVER_PATH = Path("config") / "conf.server"
+
+
+def build_base_mapping(username, config):
+    """Build the non-resource placeholder mapping for a user service.
+
+    ${SERVER_DNS} is only added for non-localhost servers, mirroring the
+    previous behaviour where localhost installations carry no host label.
+    """
+    mapping = {
+        "${DTAAS_DIR}": config["path"],
+        "${username}": username,
+    }
+    if config["server"] != utils.LOCALHOST_SERVER:
+        mapping["${SERVER_DNS}"] = config["server"]
+    return mapping
+
+
+def resource_mapping(resources):
+    """Build the resource-limit placeholder mapping for users.resources.yml."""
+    return {
+        "${shm_size}": str(resources["shm_size"]),
+        "${cpus}": str(resources["cpus"]),
+        "${mem_limit}": str(resources["mem_limit"]),
+        "${pids_limit}": str(resources["pids_limit"]),
+    }
 
 
 def _next_rule_num(text):

--- a/cli/src/templates/dtaas.toml
+++ b/cli/src/templates/dtaas.toml
@@ -1,7 +1,7 @@
 # This is the config for DTaaS CLI
 
 name="Digital Twin as a Service (DTaaS)"
-version="0.9.1"
+version="0.10.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 
@@ -29,6 +29,9 @@ certs-src='/etc/letsencrypt/archive/intocps.org'
 #certs-src='C:/Certbot/archive/intocps.org'
 
 [common.resources]
+# Enforce the per-user container resource limits below. Set to false to create
+# users without any CPU/memory/process caps; the limit fields are then ignored.
+set_limits=true
 # These are the default resource limits for user containers.
 cpus=4 # Virtual CPU
 mem_limit="4G"

--- a/cli/src/templates/users.resources.yml
+++ b/cli/src/templates/users.resources.yml
@@ -1,0 +1,4 @@
+shm_size: ${shm_size}
+cpus: ${cpus}
+mem_limit: ${mem_limit}
+pids_limit: ${pids_limit}

--- a/cli/src/templates/users.server.secure.yml
+++ b/cli/src/templates/users.server.secure.yml
@@ -6,10 +6,6 @@ volumes:
   - "${DTAAS_DIR}/files/${username}:/workspace"
 environment:
   - MAIN_USER=${username}
-shm_size: ${shm_size}
-cpus: ${cpus}
-mem_limit: ${mem_limit}
-pids_limit: ${pids_limit}
 labels:
   - "traefik.enable=true"
   - "traefik.http.routers.${username}.entryPoints=web-secure"

--- a/cli/src/templates/users.server.yml
+++ b/cli/src/templates/users.server.yml
@@ -6,10 +6,6 @@ volumes:
   - "${DTAAS_DIR}/files/${username}:/workspace"
 environment:
   - MAIN_USER=${username}
-shm_size: ${shm_size}
-cpus: ${cpus}
-mem_limit: ${mem_limit}
-pids_limit: ${pids_limit}
 labels:
   - "traefik.enable=true"
   - "traefik.http.routers.${username}.entryPoints=web"

--- a/cli/tests/dtaas.test.toml
+++ b/cli/tests/dtaas.test.toml
@@ -1,7 +1,7 @@
 # This is the config for DTaaS CLI
 
 name="Digital Twin as a Service (DTaaS)"
-version="0.9.1"
+version="0.10.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -159,6 +159,48 @@ def test_get_tls_success_true():
         assert tls is True
 
 
+def test_get_set_limits_defaults_to_true():
+    """set_limits defaults to True when absent so limits stay enforced."""
+    with patch("src.pkg.config.utils.import_toml") as mock_import:
+        mock_import.return_value = ({"common": {"resources": {"cpus": 4}}}, None)
+        cfg = Config()
+        set_limits, err = cfg.get_set_limits()
+        assert err is None
+        assert set_limits is True
+
+
+def test_get_set_limits_reads_false():
+    """An explicit set_limits=false disables resource limits."""
+    with patch("src.pkg.config.utils.import_toml") as mock_import:
+        mock_import.return_value = (
+            {"common": {"resources": {"set_limits": False}}},
+            None,
+        )
+        cfg = Config()
+        set_limits, err = cfg.get_set_limits()
+        assert err is None
+        assert set_limits is False
+
+
+def test_get_set_limits_when_no_common_section(mock_utils):
+    """get_set_limits returns True with error when 'common' section is absent."""
+    mock_utils.return_value = ({"users": {}}, None)
+    cfg = config.Config()
+    set_limits, err = cfg.get_set_limits()
+    assert set_limits is True
+    assert err is not None
+
+
+def test_get_set_limits_resources_not_dict(mock_utils):
+    """get_set_limits returns True with error when resources is not a dict."""
+    mock_utils.return_value = ({"common": {"resources": "nope"}}, None)
+    cfg = config.Config()
+    set_limits, err = cfg.get_set_limits()
+    assert set_limits is True
+    assert err is not None
+    assert "resources section is not a dict" in str(err)
+
+
 def test_get_from_config_when_data_is_none():
     """get_from_config returns error when config is uninitialised."""
     cfg = Config.__new__(Config)

--- a/cli/tests/test_config_validate.py
+++ b/cli/tests/test_config_validate.py
@@ -140,6 +140,28 @@ def test_size_unit_is_required(base):
     assert "common.resources.shm_size must include a unit, e.g. '512m'" in errors
 
 
+def test_resources_optional_when_set_limits_false(base):
+    """With set_limits=false the cpus/mem/shm/pids fields may all be omitted."""
+    data = with_common(base, resources={"set_limits": False})
+    assert collect_errors(data) == []
+
+
+def test_resources_still_validated_when_set_limits_false(base):
+    """A bad value is reported even in unlimited mode, when one is supplied."""
+    data = with_common(base, resources={"set_limits": False, "cpus": "4"})
+    assert "common.resources.cpus must be a positive number of CPU cores" in (
+        collect_errors(data)
+    )
+
+
+def test_resources_required_when_set_limits_true(base):
+    """set_limits=true keeps every limit field mandatory."""
+    data = with_common(base, resources={"set_limits": True})
+    errors = collect_errors(data)
+    assert "common.resources.cpus is missing" in errors
+    assert "common.resources.shm_size is missing" in errors
+
+
 def test_user_lists_validation(base):
     """users.add/delete are optional but must be lists of strings when present."""
     data = copy.deepcopy(base)

--- a/cli/tests/test_project.py
+++ b/cli/tests/test_project.py
@@ -55,6 +55,13 @@ def test_generate_project_skips_existing_file(tmp_path, capsys):
     assert "'dtaas.toml' already exists, skipping" in captured.out
 
 
+def test_generate_project_copies_resources_overlay(tmp_path):
+    """generate_project ships the users.resources.yml limits overlay."""
+    generate_project(str(tmp_path))
+
+    assert (tmp_path / "users.resources.yml").is_file()
+
+
 def test_generate_project_raises_on_copy_failure(tmp_path):
     """OSError is raised when a file copy fails."""
     with patch("src.pkg.project.shutil.copy2", side_effect=OSError("disk full")):

--- a/cli/tests/test_users.py
+++ b/cli/tests/test_users.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 from src.pkg import users
 from src.pkg import users_utils
+from src.pkg.project import generate_project
 from tests.conftest import CONF_SERVER_CONTENT
 # pylint: disable=redefined-outer-name,unused-argument
 
@@ -23,6 +24,7 @@ def mock_config():
         None,
     )
     mock.get_tls.return_value = (False, None)
+    mock.get_set_limits.return_value = (True, None)
     mock.get_users.return_value = ({"add": ["user1"], "user1": {}}, None)
     return mock
 
@@ -85,6 +87,7 @@ def test_add_users_to_compose(mock_utils):
         "path": "/test",
         "resources": resources,
         "tls": False,
+        "set_limits": False,
     }
 
     users.add_users_to_compose(["user1", "user2", "user3"], {"services": {}}, config)
@@ -111,9 +114,15 @@ def test_add_users_to_compose_config_error():
     ],
 )
 def test_get_compose_config(mock_utils, server, tls, file):
-    """Test getComposeConfig with resources parameter and TLS flag"""
+    """Test getComposeConfig selects the template by server type and TLS flag"""
     resources = {"cpus": 4, "mem_limit": "4G", "pids_limit": 4960, "shm_size": "512m"}
-    config = {"server": server, "path": "/test", "resources": resources, "tls": tls}
+    config = {
+        "server": server,
+        "path": "/test",
+        "resources": resources,
+        "tls": tls,
+        "set_limits": False,
+    }
     _, _ = users.get_compose_config("testuser", config)
     assert mock_utils["import"].called
     mock_utils["import"].assert_called_with(file)
@@ -128,6 +137,42 @@ def test_get_compose_config_error():
     ):
         result, err = users.get_compose_config("testuser", config)
         assert (result, isinstance(err, Exception)) == (None, True)
+
+
+@pytest.fixture
+def project_templates(tmp_path, monkeypatch):
+    """Generate the real CLI templates into a temp dir and run the CLI from there."""
+    generate_project(str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _limits_config(set_limits):
+    """A non-localhost user config with the given set_limits flag."""
+    return {
+        "server": "example.com",
+        "path": "/opt/dtaas",
+        "resources": {
+            "cpus": 4,
+            "mem_limit": "4G",
+            "pids_limit": 4960,
+            "shm_size": "512m",
+        },
+        "tls": False,
+        "set_limits": set_limits,
+    }
+
+
+def test_get_compose_config_includes_limits_when_enabled(project_templates):
+    """With set_limits true the generated service carries all four limit keys."""
+    result, err = users.get_compose_config("alice", _limits_config(True))
+
+    assert err is None
+    assert result is not None
+    assert result["cpus"] == "4"
+    assert result["mem_limit"] == "4G"
+    assert result["pids_limit"] == "4960"
+    assert result["shm_size"] == "512m"
 
 
 @pytest.mark.parametrize(
@@ -182,30 +227,6 @@ def test_add_users_rejects_newline_in_email(
     assert err is not None and "newlines" in str(err)
 
 
-def test_add_users_writes_conf_server_before_starting_containers(
-    mock_config, mock_utils, mock_user_operations, tmp_path, monkeypatch
-):
-    """Forward-auth rules are written even when 'docker compose up' fails."""
-    conf = tmp_path / "config" / "conf.server"
-    conf.parent.mkdir()
-    conf.write_text(CONF_SERVER_CONTENT, encoding="utf-8")
-    monkeypatch.setattr(users_utils, "CONF_SERVER_PATH", conf)
-
-    mock_config.get_add_users_list.return_value = (["user3"], None)
-    mock_config.get_users.return_value = (
-        {"add": ["user3"], "user3": {"email": "user3@example.com"}},
-        None,
-    )
-    mock_user_operations["start"].return_value = Exception("compose up failed")
-
-    err = users.add_users(mock_config)
-
-    assert err is not None and "compose up failed" in str(err)
-    text = conf.read_text(encoding="utf-8")
-    assert "rule.onlyu3.rule=PathPrefix(`/user3`)" in text
-    assert "rule.onlyu3.whitelist=user3@example.com" in text
-
-
 @pytest.mark.parametrize("export_error", [False, True])
 def test_delete_user(mock_config, mock_utils, mock_user_operations, export_error):
     """Test delete_user removes users from compose"""
@@ -216,21 +237,6 @@ def test_delete_user(mock_config, mock_utils, mock_user_operations, export_error
 
     err = users.delete_user(mock_config)
     assert (err is not None) if export_error else err is None
-
-
-def test_delete_user_removes_conf_server_rules(
-    mock_config, mock_utils, mock_user_operations
-):
-    """delete_user removes each deleted user's forward-auth rule from conf.server."""
-    compose = {"version": "3", "services": {"user1": {}, "user2": {}}}
-    mock_config.get_delete_users_list.return_value = (["user1"], None)
-    mock_utils["import"].return_value = (compose, None)
-
-    with patch("src.pkg.users.remove_conf_server_entry") as mock_remove:
-        err = users.delete_user(mock_config)
-
-    assert err is None
-    mock_remove.assert_called_once_with("user1")
 
 
 def test_delete_user_handles_none_compose(

--- a/cli/tests/test_users_utils.py
+++ b/cli/tests/test_users_utils.py
@@ -6,8 +6,37 @@ from src.pkg.users_utils import (
     _conf_server_block,
     add_conf_server_entry,
     remove_conf_server_entry,
+    build_base_mapping,
+    resource_mapping,
 )
 from tests.conftest import CONF_SERVER_CONTENT
+
+
+def test_build_base_mapping_includes_server_dns_for_remote():
+    """A non-localhost server contributes a ${SERVER_DNS} placeholder."""
+    mapping = build_base_mapping("alice", {"path": "/opt/dtaas", "server": "x.org"})
+    assert mapping["${DTAAS_DIR}"] == "/opt/dtaas"
+    assert mapping["${username}"] == "alice"
+    assert mapping["${SERVER_DNS}"] == "x.org"
+
+
+def test_build_base_mapping_omits_server_dns_for_localhost():
+    """localhost installations carry no ${SERVER_DNS} label."""
+    mapping = build_base_mapping("alice", {"path": "/opt/dtaas", "server": "localhost"})
+    assert "${SERVER_DNS}" not in mapping
+
+
+def test_resource_mapping_stringifies_values():
+    """resource_mapping renders every limit as a string placeholder value."""
+    mapping = resource_mapping(
+        {"cpus": 4, "mem_limit": "4G", "pids_limit": 4960, "shm_size": "512m"}
+    )
+    assert mapping == {
+        "${shm_size}": "512m",
+        "${cpus}": "4",
+        "${mem_limit}": "4G",
+        "${pids_limit}": "4960",
+    }
 
 
 def test_next_rule_num_increments_max():

--- a/cli/tests/test_utils.py
+++ b/cli/tests/test_utils.py
@@ -27,7 +27,7 @@ def test_import_toml():
 
     expected = {
         "name": "Digital Twin as a Service (DTaaS)",
-        "version": "0.9.1",
+        "version": "0.10.0",
         "owner": "The INTO-CPS-Association",
         "git-repo": "https://github.com/into-cps-association/DTaaS.git",
         "common": {


### PR DESCRIPTION
# Support adding users with and without resource limits

## Type of Change

- [X] New feature
- [ ] Bug fix
- [x] Documentation update

## Description

Adds a `set_limits` flag to `[common.resources]` so users can be onboarded **with** the existing CPU/memory/process/shared-memory caps or **without any caps**, supporting heterogeneous deployments where constrained and unconstrained users coexist.

### Approach
Rather than duplicating the deployment templates into limited/unlimited pairs, the resource-limit keys are split into a single overlay file (`users.resources.yml`) that is merged into each user's compose service **only when `set_limits` is true**. With `set_limits = false`, no caps are written and Docker Compose treats the container as unlimited.

The flag is read on every `user add`, so a deployment can mix constrained and unconstrained users by toggling it between runs. It defaults to `true`, preserving current behavior.