### PR TITLE
Separate starting users from additional users to prevent duplicate containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,6 @@ deploy/dtaas/docker/secure-server_with_integrated-gitlab/certs/fullchain.pem
 deploy/dtaas/docker/secure-server_with_integrated-gitlab/certs/privkey.pem
 deploy/dtaas/docker/secure-server_with_integrated-gitlab/data
 !deploy/dtaas/docker/secure-server_with_integrated-gitlab/data/.gitkeep
+
+# dtaas CLI runtime state cache (machine-owned, never committed)
+.dtaas.state.json

--- a/cli/DEVELOPER.md
+++ b/cli/DEVELOPER.md
@@ -26,7 +26,9 @@ The CLI is written in Python and uses the following libraries:
   (_cli/src/pkg/deploy.py_) to drive `docker compose up`/`down`. It wraps the
   docker CLI (which must be installed on the host) and raises a
   `python_on_whales.exceptions.DockerException` carrying the real command
-  output (return code and stderr) when a compose operation fails.
+  output (return code and stderr) when a compose operation fails. It is also
+  used by _cli/src/pkg/state.py_ to read best-effort container id/status when
+  writing the `.dtaas.state.json` runtime cache.
 
 - [Poetry Package](https://python-poetry.org/docs/) to manage
   dependencies and build the CLI. The configuration file for this is
@@ -81,6 +83,26 @@ service. `cmd_utils.run_config_update` adapts it to the CLI (mapping
 `OSError`/`ValueError`/`DockerException` to a `ClickException`), alongside
 `run_cert_update` and `require_update_flag` for the `update` group.
 
+### User registry and runtime state
+
+User provisioning spans three single-owner files, modelled on the config/state
+split Terraform uses for `.tf` vs `terraform.tfstate`: `dtaas.toml` holds the
+hand-edited `starting` users, `dtaas.users.registry.json` is the CLI-owned store
+of *additional* users, and `.dtaas.state.json` is a git-ignored runtime cache.
+
+- _src/pkg/registry.py_ owns `dtaas.users.registry.json`. `load_registry` reads
+  the `{username: details}` store (empty when absent), `add_to_registry` merges
+  new users, and `remove_from_registry` drops them — each persisted atomically
+  (temp file + `os.replace`), the way `useradd` owns `/etc/passwd`.
+  `read_csv_users` parses a `users.csv` for bulk import.
+- _src/pkg/users.py_ `add_users` provisions every registry user (idempotent);
+  `delete_users` deprovisions the named users and removes them from the
+  registry. `cmd_utils.import_users_file` merges a `--file users.csv` into the
+  registry before `add` runs.
+- _src/pkg/state.py_ owns `.dtaas.state.json`. After each add/delete it records,
+  per user, a `config_hash` (a stable sha256 of the compose service) plus
+  best-effort container id/status from python-on-whales.
+
 ### TOML File
 
 The base configuration file used by the CLI is the _dtaas.toml_ file.
@@ -90,7 +112,7 @@ It has the following sections:
 
 ```toml
 name="Digital Twin as a Service (DTaaS)"
-version="0.10.0"
+version="0.11.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 ```
@@ -130,17 +152,22 @@ shm_size="512m"
 
 ```toml
 [users]
-add=["username1","username2"]
-delete=["username2"]
+starting=["username1","username2"]
 
 [users.username1]
 email="username1@intocps.org"
+groups=["starting"]
+load_balance=true
 ```
 
-- _add_: list of usernames to create.
-- _delete_: list of usernames to remove.
-- Per-user sub-tables provide the _email_ field, written to
-  `config/conf.server` on `dtaas admin user add`.
+- _starting_: the initial users installed with the instance, hand-edited at
+  install time. Additional users added later via `dtaas admin user add` are
+  **not** listed here — they live in the CLI-owned `dtaas.users.registry.json`.
+- Per-user sub-tables provide _email_ (written to `config/conf.server` on
+  `dtaas admin user add`), plus _groups_ and _load_balance_ tags.
+
+See [User registry and runtime state](#user-registry-and-runtime-state) for the
+registry and `.dtaas.state.json` cache.
 
 #### [frontend]
 

--- a/cli/DEVELOPER.md
+++ b/cli/DEVELOPER.md
@@ -98,8 +98,13 @@ of *additional* users, and `.dtaas.state.json` is a git-ignored runtime cache.
 - _src/pkg/users.py_ `add_users` provisions every registry user (idempotent);
   `delete_users` deprovisions the named users and removes them from the
   registry (`dry_run=True` previews without changing anything).
+  `cmd_utils.resolve_delete_usernames` resolves the usernames to delete from
+  positional args or a `--file users.csv` (only the `username` column is
+  read), rejecting the call if both or neither are given.
   `cmd_utils.stage_users_for_add` merges a `--file users.csv` (or a single
-  USERNAME) into the registry before `add` runs.
+  USERNAME) into the registry before `add` runs, and rejects the call
+  (`ClickException`) if neither is given — a bare `user add` is never a silent
+  no-op or an implicit reprovision.
 - _src/pkg/state.py_ owns `.dtaas.state.json`. Each add/delete fully overwrites
   it with a fresh snapshot (not an append-only log) recording, per currently
   provisioned user, a `config_hash` (a stable sha256 of the compose service)
@@ -112,7 +117,11 @@ of *additional* users, and `.dtaas.state.json` is a git-ignored runtime cache.
   only for the third category, _drifted_ — a user present in both whose live
   config no longer matches the hash recorded when it was last provisioned; a
   user with no recorded hash is not flagged, since reconcile has nothing to
-  compare it against.
+  compare it against. `cmd_utils.run_reconcile(output_dir, fix=True)` reuses
+  `run_user_command`/`userPkg.add_users` (via `_fix_reconcile`) to reprovision
+  _missing_/_drifted_ users after reporting; it deliberately never acts on
+  _unexpected_ users, since removing something that's actually running is a
+  separate, explicit `user delete` decision.
 
 ### TOML File
 
@@ -305,3 +314,69 @@ The following are the planned next steps:
   This is because '.' is a special character for labels in docker compose.
   We need to include such usernames, simply by internally replacing
   '.' instances in usernames by '-' or '_'.
+
+## 👥 User Management Files: Design Rationale
+
+This section explains _why_ user management is split across three files. For
+_where_ each piece is implemented, see
+[User registry and runtime state](#user-registry-and-runtime-state) above.
+
+### The problem this design solves
+
+Earlier, `dtaas.toml` had a single `[users]` table with `add`/`delete` lists.
+That file was expected to do two incompatible jobs at once: be a
+human-edited setting, and be a machine-processed to-do list. Nothing ever
+cleared the list once it was processed, so after successfully adding
+`alice`, `dtaas.toml` still said `add = ["alice"]`. Running `user add` again say, to also add `bob` had no way to tell "alice is already done, only
+provision bob," which could lead to duplicate or conflicting containers.
+There was no persistent record, separate from the config file, of _who had
+actually already been provisioned_.
+
+### Three files, three owners
+
+The fix is to stop making one file do two jobs. Each file below has exactly
+one owner and one responsibility:
+
+| File | Owner | Responsibility |
+|---|---|---|
+| `dtaas.toml` `[users]` | Human, once, at install time | The `starting` users the instance is installed with |
+| `dtaas.users.registry.json` | The CLI, exclusively | Every `additional` user, added at any point after install |
+| `.dtaas.state.json` | The CLI, exclusively | A disposable snapshot of what is actually running right now |
+
+### Why each file behaves the way it does
+
+- **`dtaas.toml` is never rewritten by the CLI, ever.** Once a human commits
+  `starting` users at install time, the CLI only _reads_ that list (for
+  `admin install` and `generate-deployment`). A comment-bearing, reviewed
+  config file should never be silently mutated by a tool — that risk is
+  exactly what made the old `add`/`delete` design fragile.
+- **`dtaas.users.registry.json` is a merge, not a replace.** `user add`
+  unions new users into the existing store and skips (with a warning, not an
+  overwrite) anyone already present either already registered, or already
+  a `starting` user in `dtaas.toml`. This is what actually fixes the
+  duplicate-container bug: there is now one unambiguous, persistent answer to
+  "has this user already been added," instead of an unprocessed to-do list.
+- **`.dtaas.state.json` is disposable by design.** It is gitignored, and each
+  write fully replaces its contents with a fresh snapshot (it is _not_ an
+  append-only log). If you delete it, nothing is lost the CLI rebuilds it
+  on the next `add`/`delete`. Its only job is to remember, per user, a hash
+  of the config it was last provisioned with, so a later run can tell
+  whether that config has since changed underneath it.
+- **`dtaas admin config reconcile` treats the registry as the desired
+  state, not the state cache.** An earlier version of `reconcile` compared
+  `.dtaas.state.json` against the live compose services — but since the
+  state cache is written from that same compose data at the end of every
+  `add`/`delete`, the two would almost always agree by construction, so that
+  comparison rarely caught anything meaningful. Comparing the _registry_
+  (who should exist) against the _live services_ (who does exist) is the
+  comparison that actually matters, and is what lets `reconcile` catch a
+  registered user who never got provisioned (e.g. an interrupted `add`).
+  `.dtaas.state.json` is kept for exactly one narrower job it's suited for:
+  detecting whether a provisioned user's config has since drifted.
+- **`starting` and `additional` users are provisioned through genuinely
+  different mechanisms, on purpose.** `starting` users are baked into the
+  main `docker-compose.yml` at `generate-deployment` time, in a fixed number
+  of slots per deploy type. `additional` (registry) users get a dynamically
+  managed, separate `compose.users.yml`. This means `dtaas.users.registry.json`
+  and `.dtaas.state.json` only ever track `additional` users `starting`
+  users intentionally never appear in either file.

--- a/cli/DEVELOPER.md
+++ b/cli/DEVELOPER.md
@@ -91,17 +91,20 @@ hand-edited `starting` users, `dtaas.users.registry.json` is the CLI-owned store
 of *additional* users, and `.dtaas.state.json` is a git-ignored runtime cache.
 
 - _src/pkg/registry.py_ owns `dtaas.users.registry.json`. `load_registry` reads
-  the `{username: details}` store (empty when absent), `add_to_registry` merges
+  the `{username: details}` store (empty when absent), `register_new_users` merges
   new users, and `remove_from_registry` drops them — each persisted atomically
   (temp file + `os.replace`), the way `useradd` owns `/etc/passwd`.
   `read_csv_users` parses a `users.csv` for bulk import.
 - _src/pkg/users.py_ `add_users` provisions every registry user (idempotent);
   `delete_users` deprovisions the named users and removes them from the
-  registry. `cmd_utils.import_users_file` merges a `--file users.csv` into the
-  registry before `add` runs.
+  registry (`dry_run=True` previews without changing anything).
+  `cmd_utils.stage_users_for_add` merges a `--file users.csv` (or a single
+  USERNAME) into the registry before `add` runs.
 - _src/pkg/state.py_ owns `.dtaas.state.json`. After each add/delete it records,
   per user, a `config_hash` (a stable sha256 of the compose service) plus
-  best-effort container id/status from python-on-whales.
+  best-effort container id/status from python-on-whales. `find_drift` reads that
+  cache back to power `dtaas admin config reconcile`, which reports drifted,
+  untracked, and orphaned users against `compose.users.yml`.
 
 ### TOML File
 

--- a/cli/DEVELOPER.md
+++ b/cli/DEVELOPER.md
@@ -156,7 +156,7 @@ starting=["username1","username2"]
 
 [users.username1]
 email="username1@intocps.org"
-groups=["starting"]
+groups=["default","dtaas"]
 load_balance=true
 ```
 

--- a/cli/DEVELOPER.md
+++ b/cli/DEVELOPER.md
@@ -100,11 +100,19 @@ of *additional* users, and `.dtaas.state.json` is a git-ignored runtime cache.
   registry (`dry_run=True` previews without changing anything).
   `cmd_utils.stage_users_for_add` merges a `--file users.csv` (or a single
   USERNAME) into the registry before `add` runs.
-- _src/pkg/state.py_ owns `.dtaas.state.json`. After each add/delete it records,
-  per user, a `config_hash` (a stable sha256 of the compose service) plus
-  best-effort container id/status from python-on-whales. `find_drift` reads that
-  cache back to power `dtaas admin config reconcile`, which reports drifted,
-  untracked, and orphaned users against `compose.users.yml`.
+- _src/pkg/state.py_ owns `.dtaas.state.json`. Each add/delete fully overwrites
+  it with a fresh snapshot (not an append-only log) recording, per currently
+  provisioned user, a `config_hash` (a stable sha256 of the compose service)
+  plus best-effort container id/status from python-on-whales.
+  `find_drift(registry_users, state, services)` powers
+  `dtaas admin config reconcile`: it treats the registry as the desired state
+  and compares it against the live `compose.users.yml` services, reporting
+  _missing_ (registered, not provisioned) and _unexpected_ (provisioned, not
+  registered) users directly from that comparison. The state cache is used
+  only for the third category, _drifted_ — a user present in both whose live
+  config no longer matches the hash recorded when it was last provisioned; a
+  user with no recorded hash is not flagged, since reconcile has nothing to
+  compare it against.
 
 ### TOML File
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -419,8 +419,18 @@ the CLI-owned `dtaas.users.registry.json`
 (see [User files](#-user-files)), not in `dtaas.toml`. Add a single user:
 
 ```bash
-dtaas admin user add alice --email alice@intocps.org \
-  --group dtaas --load-balance
+dtaas admin user add --email alice@intocps.org --group dtaas --load-balance alice
+```
+
+> Click accepts `--email`, `--group`, and `--load-balance` in any position
+> relative to `USERNAME` the form above is the recommended convention,
+> matching `useradd [options] LOGIN`.
+
+`--group` is repeatable, not comma-separated pass it once per group to add a
+user to multiple groups:
+
+```bash
+dtaas admin user add --email alice@intocps.org --group dtaas --group testers alice
 ```
 
 Or bulk-add from a CSV:
@@ -454,7 +464,7 @@ dtaas admin user add
 | `USERNAME` | — | Add one user (requires `--email`) |
 | `--file PATH` | — | Bulk-add users from a CSV |
 | `--email TEXT` | — | Email for `USERNAME` (enables forward-auth routing) |
-| `--group TEXT` | `dtaas` | Group tag for `USERNAME` (repeatable) |
+| `--group TEXT` | `additional` | Group tag for `USERNAME`; repeat the flag for multiple groups, e.g. `--group dtaas --group testers` |
 | `--load-balance / --no-load-balance` | on | Mark `USERNAME` for load balancing |
 
 For each username the CLI checks whether `files/<username>/` already exists.
@@ -675,8 +685,7 @@ shm_size   = "512m"   # shared memory unit required
 # The users installed with this instance, hand-edited once at install time.
 # Additional users added later with `dtaas admin user add` live in the
 # CLI-owned dtaas.users.registry.json instead — never here.
-# Usernames must match GitLab accounts; usernames containing "." are not yet
-# supported.
+# Usernames must match GitLab accounts.
 [users]
 starting = ["alice", "bob"]
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -20,7 +20,7 @@ python -m venv .venv && source .venv/bin/activate   # Linux / macOS
 # 2. Install the package
 pip install dtaas
 
-# 3. Generate a dtaas.toml configuration template
+# 3. Generate dtaas.toml + a sample users.csv to fill in
 dtaas admin config generate
 
 # 4. Open dtaas.toml and fill in your server DNS, paths, and credentials
@@ -65,7 +65,8 @@ dtaas admin uninstall
    - [generate-project](#generate-project)
    - [admin user add](#-admin-user-add)
    - [admin user delete](#-admin-user-delete)
-3. [Configuration Reference: dtaas.toml](#️-configuration-reference--dtaastoml)
+3. [User files: dtaas.toml, registry, state](#-user-files)
+4. [Configuration Reference: dtaas.toml](#️-configuration-reference--dtaastoml)
 
 ---
 
@@ -104,6 +105,9 @@ validate before running any other command.
 dtaas admin config generate
 ```
 
+This writes `dtaas.toml` and a sample `users.csv` (bulk input for
+`dtaas admin user add --file`) into the target directory.
+
 **Validate an existing file**
 
 ```bash
@@ -123,7 +127,6 @@ directory) and reports all problems at once:
 | `[common.resources].cpus` | Positive number (e.g. `4` or `0.5`) |
 | `[common.resources].pids_limit` | Integer |
 | `[common.resources].mem_limit`, `shm_size` | Byte size with required unit (e.g. `4G`, `512m`) |
-| `[users].add`, `[users].delete` | When present, must be lists of strings |
 | `[users.<name>].email` | Valid RFC 5321/5322 address (no DNS lookup) |
 | Deployment-section URLs | When present, must be `http(s)` URLs |
 | Deployment-section `default-user` | When present, must be a valid username |
@@ -238,7 +241,7 @@ dtaas admin install
 
 Internally runs `docker compose up -d` against the `docker-compose.yml` in
 the installation directory. Before starting, it ensures per-user workspace
-directories listed in `[users].add` exist, recreating each from
+directories for the `[users].starting` list exist, recreating each from
 `files/template/` if missing and sets ownership to `1000:100`.
 
 **Options**
@@ -408,16 +411,28 @@ dtaas generate-project
 
 ### ➕ `admin user add`
 
-Adds one or more users to a running DTaaS instance.
+Provisions users on a running DTaaS instance. Additional users are recorded in
+the CLI-owned `dtaas.users.registry.json`
+(see [User files](#-user-files)), not in `dtaas.toml`.
+The typical flow is a bulk import from a CSV:
 
-Edit `dtaas.toml` to list the GitLab usernames to add:
-
-```toml
-[users]
-add = ["username1", "username2", "username3"]
+```bash
+# Merge users.csv into the registry, then provision every registry user
+dtaas admin user add --file users.csv
 ```
 
-Then run from the directory containing `dtaas.toml`:
+`dtaas admin config generate` writes a sample `users.csv` next to `dtaas.toml`:
+
+```csv
+username,email,groups,load_balance
+alice,alice@intocps.org,additional,true
+bob,bob@intocps.org,additional;beta-testers,false
+```
+
+`groups` is a `;`-separated list and `load_balance` is `true`/`false`. Passing
+`--file` merges the CSV into the registry (adding new users, updating existing
+ones) atomically, the registry is never hand-edited. Omit `--file` to
+(re)provision every user already in the registry:
 
 ```bash
 dtaas admin user add
@@ -465,7 +480,8 @@ and unconstrained users by toggling `set_limits` between runs.
 > **Notes**
 > - `user add` starts a container for a new user or restarts a stopped one; it
 >   reports *Running* for containers already up without restarting them.
-> - Returns an error if the `add` list is empty.
+> - Provisioning is idempotent: re-running `user add` reprovisions every
+>   registry user without duplicating work. An empty registry is a no-op.
 > - Usernames containing `.` cannot currently be added via the CLI (known
 >   issue; to be resolved in a future release).
 > - This command does not enable AuthMS authentication.
@@ -474,20 +490,17 @@ and unconstrained users by toggling `set_limits` between runs.
 
 ### ➖ `admin user delete`
 
-Removes users from a running DTaaS instance.
-
-Edit `dtaas.toml` to list the GitLab usernames to remove:
-
-```toml
-[users]
-delete = ["username1", "username2", "username3"]
-```
-
-Then run from the directory containing `dtaas.toml`:
+Removes one or more named users from a running DTaaS instance, like `userdel`.
+Pass the usernames as arguments:
 
 ```bash
-dtaas admin user delete
+dtaas admin user delete username1 username2
 ```
+
+Each user is deprovisioned (its container stopped, its compose service and
+forward-auth rule removed) and dropped from `dtaas.users.registry.json`. Users
+that are not currently provisioned are reported and skipped, but are still
+removed from the registry.
 
 The CLI automatically removes the traefik-forward-auth routing rules for
 deleted users from `config/conf.server`. Restart the container for the change
@@ -497,7 +510,30 @@ to take effect:
 docker compose -f compose.server.yml --env-file .env up -d --force-recreate traefik-forward-auth
 ```
 
-> Returns an error if the `delete` list is empty.
+> At least one username argument is required.
+
+---
+
+## 👥 User files
+
+User management spans three files, each with a single owner, modelled on the
+config/state split Terraform uses for `.tf` vs `terraform.tfstate`:
+
+| File | Owner | Contents | Git |
+|---|---|---|---|
+| `dtaas.toml` `[users]` | Human, at install time | **Starting** users: the `starting` list plus per-user `email`, `groups`, `load_balance` | Tracked hand-edited |
+| `dtaas.users.registry.json` | CLI (`user add` / `user delete`) | **Additional** users, same fields | Tracked CLI-written, never hand-edited |
+| `.dtaas.state.json` | CLI, at provisioning time | Observed runtime facts: container id, status, provisioned-at, config hash | Ignored runtime cache |
+
+- **`dtaas.toml`** is written once by a human and never rewritten by the CLI,
+  so a comment-bearing, reviewed config is never silently mutated.
+- **`dtaas.users.registry.json`** is a database the CLI owns and mutates
+  atomically (the way `useradd` owns `/etc/passwd`). Edit its users through
+  `dtaas admin user add --file users.csv` / `dtaas admin user delete`, not by
+  hand. `users.csv` copied by `dtaas admin config generate` is the
+  human-editable bulk input that feeds it.
+- **`.dtaas.state.json`** is a disposable cache of what is actually running,
+  refreshed on every add/delete. It is git-ignored and safe to delete.
 
 ---
 
@@ -577,19 +613,26 @@ mem_limit  = "4G"     # memory limit — unit required: G, m, k …
 pids_limit = 4960     # maximum number of processes per container (integer)
 shm_size   = "512m"   # shared memory — unit required
 
-# ── User list (all deployment types) ──────────────────────────────────────────
-# Usernames must match GitLab accounts on the configured instance.
-# Note: usernames containing "." are not yet supported.
+# ── Starting users (all deployment types) ─────────────────────────────────────
+# The users installed with this instance, hand-edited once at install time.
+# Additional users added later with `dtaas admin user add` live in the
+# CLI-owned dtaas.users.registry.json instead — never here.
+# Usernames must match GitLab accounts; usernames containing "." are not yet
+# supported.
 [users]
-add    = ["alice", "bob"]   # provisioned on: dtaas admin user add
-delete = []                 # removed on:      dtaas admin user delete
+starting = ["alice", "bob"]
 
-# Per-user email: enables traefik-forward-auth routing rules automatically.
+# Per-user email enables traefik-forward-auth routing rules automatically;
+# groups/load_balance carry per-user tags.
 [users.alice]
-email = "alice@example.com"
+email        = "alice@example.com"
+groups       = ["starting"]
+load_balance = true
 
 [users.bob]
-email = "bob@example.com"
+email        = "bob@example.com"
+groups       = ["starting"]
+load_balance = false
 
 # ── React web client OAuth app (insecure-server, secure-server,
 #                                secure-server-gitlab) ────────────────────────

--- a/cli/README.md
+++ b/cli/README.md
@@ -544,19 +544,23 @@ docker compose -f compose.server.yml --env-file .env up -d --force-recreate trae
 
 ### 🔍 `admin config reconcile`
 
-Reports which provisioned users have **drifted** from what the CLI last
-recorded in `.dtaas.state.json`. Read-only — it changes nothing.
+It is a Read-Only command. Reports drift between `dtaas.users.registry.json`
+(who **should** be provisioned) and the live `compose.users.yml` services
+(who **is** provisioned).
 
 ```bash
 dtaas admin config reconcile
 ```
 
-It compares the state cache against `compose.users.yml` and lists:
+It lists:
 
-- **drifted** — the compose config changed since the user was provisioned
-  (re-run `dtaas admin user add` to reprovision);
-- **untracked** — provisioned but not recorded in the state cache;
-- **orphaned** — in the state cache but no longer provisioned.
+- **missing** — registered but not currently provisioned (re-run
+  `dtaas admin user add` to provision them);
+- **unexpected** — provisioned but not in the registry (investigate — may be a
+  manual edit or a partial delete);
+- **drifted** — provisioned, but the live config no longer matches what
+  `.dtaas.state.json` recorded when it was last provisioned (re-run
+  `dtaas admin user add` to reprovision).
 
 When everything matches it prints `In sync: no drift detected.`
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -127,7 +127,10 @@ directory) and reports all problems at once:
 | `[common.resources].cpus` | Positive number (e.g. `4` or `0.5`) |
 | `[common.resources].pids_limit` | Integer |
 | `[common.resources].mem_limit`, `shm_size` | Byte size with required unit (e.g. `4G`, `512m`) |
+| `[users].starting` | When present, must be a list of strings |
 | `[users.<name>].email` | Valid RFC 5321/5322 address (no DNS lookup) |
+| `[users.<name>].groups` | When present, must be a list of strings |
+| `[users.<name>].load_balance` | When present, must be `true` or `false` |
 | Deployment-section URLs | When present, must be `http(s)` URLs |
 | Deployment-section `default-user` | When present, must be a valid username |
 
@@ -413,11 +416,16 @@ dtaas generate-project
 
 Provisions users on a running DTaaS instance. Additional users are recorded in
 the CLI-owned `dtaas.users.registry.json`
-(see [User files](#-user-files)), not in `dtaas.toml`.
-The typical flow is a bulk import from a CSV:
+(see [User files](#-user-files)), not in `dtaas.toml`. Add a single user:
 
 ```bash
-# Merge users.csv into the registry, then provision every registry user
+dtaas admin user add alice --email alice@intocps.org \
+  --group dtaas --load-balance
+```
+
+Or bulk-add from a CSV:
+
+```bash
 dtaas admin user add --file users.csv
 ```
 
@@ -429,14 +437,25 @@ alice,alice@intocps.org,additional,true
 bob,bob@intocps.org,additional;beta-testers,false
 ```
 
-`groups` is a `;`-separated list and `load_balance` is `true`/`false`. Passing
-`--file` merges the CSV into the registry (adding new users, updating existing
-ones) atomically, the registry is never hand-edited. Omit `--file` to
-(re)provision every user already in the registry:
+`groups` is a `;`-separated list and `load_balance` is `true`/`false`. Both
+forms merge into the registry (never hand-edited), then every registry user is
+provisioned. A username already in `dtaas.toml`'s `starting` list or the
+registry is **skipped with a warning** it is never added twice or overwritten.
+Omit both `USERNAME` and `--file` to (re)provision the existing registry:
 
 ```bash
 dtaas admin user add
 ```
+
+**Options**
+
+| Option | Default | Description |
+|---|---|---|
+| `USERNAME` | — | Add one user (requires `--email`) |
+| `--file PATH` | — | Bulk-add users from a CSV |
+| `--email TEXT` | — | Email for `USERNAME` (enables forward-auth routing) |
+| `--group TEXT` | `dtaas` | Group tag for `USERNAME` (repeatable) |
+| `--load-balance / --no-load-balance` | on | Mark `USERNAME` for load balancing |
 
 For each username the CLI checks whether `files/<username>/` already exists.
 If not, a new directory with the correct structure is created from
@@ -609,9 +628,9 @@ certs-src = "/etc/letsencrypt/live/dtaas.example.com"
 # The 4 fields are then optional and ignored. Defaults to true when omitted.
 set_limits = true
 cpus       = 4        # CPU cores; may be fractional, e.g. 0.5
-mem_limit  = "4G"     # memory limit — unit required: G, m, k …
+mem_limit  = "4G"     # memory limit unit required: G, m, k …
 pids_limit = 4960     # maximum number of processes per container (integer)
-shm_size   = "512m"   # shared memory — unit required
+shm_size   = "512m"   # shared memory unit required
 
 # ── Starting users (all deployment types) ─────────────────────────────────────
 # The users installed with this instance, hand-edited once at install time.
@@ -626,12 +645,12 @@ starting = ["alice", "bob"]
 # groups/load_balance carry per-user tags.
 [users.alice]
 email        = "alice@example.com"
-groups       = ["starting"]
+groups       = ["default", "dtaas"]
 load_balance = true
 
 [users.bob]
 email        = "bob@example.com"
-groups       = ["starting"]
+groups       = ["default", "dtaas"]
 load_balance = false
 
 # ── React web client OAuth app (insecure-server, secure-server,

--- a/cli/README.md
+++ b/cli/README.md
@@ -501,8 +501,8 @@ and unconstrained users by toggling `set_limits` between runs.
 >   reports *Running* for containers already up without restarting them.
 > - Provisioning is idempotent: re-running `user add` reprovisions every
 >   registry user without duplicating work. An empty registry is a no-op.
-> - Usernames containing `.` cannot currently be added via the CLI (known
->   issue; to be resolved in a future release).
+> - Usernames may include '.', '_' and '-' (must start with a letter or digit).
+>   (Whitespace, path separators, and shell metacharacters are rejected.)
 > - This command does not enable AuthMS authentication.
 
 ---
@@ -521,6 +521,15 @@ forward-auth rule removed) and dropped from `dtaas.users.registry.json`. Users
 that are not currently provisioned are reported and skipped, but are still
 removed from the registry.
 
+Preview a removal without making any changes with `--dry-run`:
+
+```bash
+dtaas admin user delete username1 username2 --dry-run
+```
+
+It lists which users would be deprovisioned and removed from the registry, then
+exits without stopping containers or editing any file.
+
 The CLI automatically removes the traefik-forward-auth routing rules for
 deleted users from `config/conf.server`. Restart the container for the change
 to take effect:
@@ -530,6 +539,32 @@ docker compose -f compose.server.yml --env-file .env up -d --force-recreate trae
 ```
 
 > At least one username argument is required.
+
+---
+
+### 🔍 `admin config reconcile`
+
+Reports which provisioned users have **drifted** from what the CLI last
+recorded in `.dtaas.state.json`. Read-only — it changes nothing.
+
+```bash
+dtaas admin config reconcile
+```
+
+It compares the state cache against `compose.users.yml` and lists:
+
+- **drifted** — the compose config changed since the user was provisioned
+  (re-run `dtaas admin user add` to reprovision);
+- **untracked** — provisioned but not recorded in the state cache;
+- **orphaned** — in the state cache but no longer provisioned.
+
+When everything matches it prints `In sync: no drift detected.`
+
+**Options**
+
+| Option | Default | Description |
+|---|---|---|
+| `--output-dir PATH` | `.` | Installation directory to inspect |
 
 ---
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -416,7 +416,19 @@ dtaas generate-project
 
 Provisions users on a running DTaaS instance. Additional users are recorded in
 the CLI-owned `dtaas.users.registry.json`
-(see [User files](#-user-files)), not in `dtaas.toml`. Add a single user:
+(see [User files](#-user-files)), not in `dtaas.toml`.
+
+**Options**
+
+| Option | Default | Description |
+|---|---|---|
+| `USERNAME` | — | Add one user (requires `--email`) |
+| `--file PATH` | — | Bulk-add users from a CSV |
+| `--email TEXT` | — | Email for `USERNAME` (enables forward-auth routing) |
+| `--group TEXT` | `additional` | Group tag for `USERNAME`; repeat the flag for multiple groups, e.g. `--group dtaas --group testers` |
+| `--load-balance / --no-load-balance` | on | Mark `USERNAME` for load balancing |
+
+Add a single user:
 
 ```bash
 dtaas admin user add --email alice@intocps.org --group dtaas --load-balance alice
@@ -451,11 +463,11 @@ bob,bob@intocps.org,additional;beta-testers,false
 forms merge into the registry (never hand-edited), then every registry user is
 provisioned. A username already in `dtaas.toml`'s `starting` list or the
 registry is **skipped with a warning** it is never added twice or overwritten.
-Omit both `USERNAME` and `--file` to (re)provision the existing registry:
 
-```bash
-dtaas admin user add
-```
+A `USERNAME` or `--file` is required a bare `dtaas admin user add` with
+neither is rejected rather than silently reprovisioning the whole registry.
+To resync everyone already in the registry (e.g. after `compose.users.yml`
+was lost), use `dtaas admin config reconcile --fix` instead.
 
 **Options**
 
@@ -519,12 +531,30 @@ and unconstrained users by toggling `set_limits` between runs.
 
 ### ➖ `admin user delete`
 
-Removes one or more named users from a running DTaaS instance, like `userdel`.
+Removes one or more users from a running DTaaS instance, like `userdel`.
+
+**Options**
+
+| Option | Default | Description |
+|---|---|---|
+| `USERNAMES` | — | One or more usernames to remove |
+| `--file PATH` | — | Bulk-delete users listed in a CSV (only the `username` column is used) |
+| `--dry-run` | off | Preview the removal without making any changes |
+
 Pass the usernames as arguments:
 
 ```bash
 dtaas admin user delete username1 username2
 ```
+
+Or bulk-delete from a CSV (the same `users.csv` format used by
+`admin user add --file` other columns are ignored):
+
+```bash
+dtaas admin user delete --file users.csv
+```
+
+`USERNAMES` and `--file` are mutually exclusive, and one of them is required.
 
 Each user is deprovisioned (its container stopped, its compose service and
 forward-auth rule removed) and dropped from `dtaas.users.registry.json`. Users
@@ -548,15 +578,13 @@ to take effect:
 docker compose -f compose.server.yml --env-file .env up -d --force-recreate traefik-forward-auth
 ```
 
-> At least one username argument is required.
-
 ---
 
 ### 🔍 `admin config reconcile`
 
-It is a Read-Only command. Reports drift between `dtaas.users.registry.json`
-(who **should** be provisioned) and the live `compose.users.yml` services
-(who **is** provisioned).
+Reports drift between `dtaas.users.registry.json` (who **should** be
+provisioned) and the live `compose.users.yml` services (who **is**
+provisioned).
 
 ```bash
 dtaas admin config reconcile
@@ -564,21 +592,32 @@ dtaas admin config reconcile
 
 It lists:
 
-- **missing** — registered but not currently provisioned (re-run
-  `dtaas admin user add` to provision them);
-- **unexpected** — provisioned but not in the registry (investigate — may be a
+- **missing** registered but not currently provisioned;
+- **unexpected** provisioned but not in the registry (investigate — may be a
   manual edit or a partial delete);
-- **drifted** — provisioned, but the live config no longer matches what
-  `.dtaas.state.json` recorded when it was last provisioned (re-run
-  `dtaas admin user add` to reprovision).
+- **drifted** provisioned, but the live config no longer matches what
+  `.dtaas.state.json` recorded when it was last provisioned.
 
 When everything matches it prints `In sync: no drift detected.`
+
+Without `--fix` this is read-only. Pass `--fix` to reprovision **missing** and
+**drifted** users afterward (equivalent to running `dtaas admin user add`, so
+it acts on the current directory, not `--output-dir`):
+
+```bash
+dtaas admin config reconcile --fix
+```
+
+**unexpected** services are never touched by `--fix` removing something
+that's actually running is a deliberate action use
+`dtaas admin user delete` for those.
 
 **Options**
 
 | Option | Default | Description |
 |---|---|---|
 | `--output-dir PATH` | `.` | Installation directory to inspect |
+| `--fix` | off | Reprovision missing/drifted registry users after reporting |
 
 ---
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dtaas"
-version = "0.10.0"
+version = "0.11.0"
 description = "DTaaS CLI"
 authors = ["Astitva Sehgal"]
 license = "INTO-CPS-Association"

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -2,25 +2,23 @@
 
 import click
 from python_on_whales.exceptions import DockerException
-from .pkg import users as userPkg
 from .pkg import project as projectPkg
 from .pkg import deploy as deployPkg
 from .pkg import config_validate as configValidatePkg
 from .pkg.project import DEPLOY_TYPES
-from .cmd_utils import (
+from .cmd_deploy_utils import (
     VerticalChoicesCommand,
     apply_deploy_config,
     provision_user_files,
-    stage_users_for_add,
-    run_user_command,
-    confirm_remove_user_files,
-    run_config_update,
-    run_reconcile,
-    run_cert_update,
-    require_update_flag,
 )
-
-NO_INSTALLATION_MESSAGE = "There is no existing DTaaS / Workspace installation"
+from .cmd_utils import (
+    UpdateOptions,
+    confirm_remove_user_files,
+    run_reconcile,
+    run_uninstall,
+    run_update,
+)
+from .cmd_user import add as user_add, delete as user_delete
 
 
 ### Groups
@@ -157,62 +155,9 @@ def user():
     return
 
 
-#### user group commands
-@user.command()
-@click.argument("username", required=False)
-@click.option(
-    "--file",
-    "csv_file",
-    type=click.Path(exists=True, dir_okay=False),
-    help="Bulk-add users from a CSV file into the registry.",
-)
-@click.option("--email", help="Email for USERNAME (enables forward-auth routing).")
-@click.option(
-    "--group",
-    "groups",
-    multiple=True,
-    help="Group tag for USERNAME (repeatable; defaults to 'additional').",
-)
-@click.option(
-    "--load-balance/--no-load-balance",
-    default=True,
-    help="Mark USERNAME for load balancing (default: enabled).",
-)
-def add(username, csv_file, email, groups, load_balance):
-    """
-    add users to DTaaS\n
-    Single user: dtaas admin user add alice --email alice@intocps.org\n
-    Bulk from CSV: dtaas admin user add --file users.csv\n
-    Both merge into dtaas.users.registry.json, then every registry user is
-    provisioned. With no USERNAME and no --file, the existing registry is
-    reprovisioned.\n
-    """
-    stage_users_for_add(username, csv_file, email, groups, load_balance)
-    run_user_command(
-        userPkg.add_users, "Users added successfully", "Error while adding users"
-    )
-
-
-@user.command()
-@click.argument("usernames", nargs=-1, required=True)
-@click.option(
-    "--dry-run",
-    is_flag=True,
-    help="Show which users would be removed without deleting anything.",
-)
-def delete(usernames, dry_run):
-    """
-    removes the named USERNAMES from DTaaS\n
-    Deprovisions each user and drops them from dtaas.users.registry.json.\n
-    Pass --dry-run to preview the removal without making any changes.\n
-    """
-    err = userPkg.delete_users(usernames, dry_run=dry_run)
-    if err is not None:
-        raise click.ClickException(f"Error while deleting users: {err}")
-    if dry_run:
-        click.echo("Dry run complete; nothing was deleted.")
-    else:
-        click.echo("Users deleted successfully")
+#### user group commands (defined in cmd_user.py to keep this file short)
+user.add_command(user_add)
+user.add_command(user_delete)
 
 
 @admin.command(name="install")
@@ -253,19 +198,7 @@ def install(output_dir):
 def uninstall(output_dir, remove_user_files, yes):
     """Tear the deployment down with 'docker compose down'."""
     confirm_remove_user_files(remove_user_files, yes)
-    try:
-        if deployPkg.installation_present(output_dir):
-            message = deployPkg.uninstall(output_dir, remove_user_files)
-            if message:
-                click.echo(message)
-            click.echo("Deployment uninstalled successfully")
-            return
-        click.echo(NO_INSTALLATION_MESSAGE)
-        if remove_user_files:
-            deployPkg.require_compose_file(output_dir)
-            click.echo(deployPkg.delete_user_files(output_dir))
-    except (OSError, DockerException) as exc:
-        raise click.ClickException(str(exc)) from exc
+    run_uninstall(output_dir, remove_user_files)
 
 
 @admin.command(name="update")
@@ -291,7 +224,7 @@ def uninstall(output_dir, remove_user_files, yes):
     show_default=True,
     help="Installation directory containing the generated deployment.",
 )
-def update(certs, config_, dry_run, output_dir):
+def update(**kwargs):
     """Update deployment assets in place.
 
     --certs validates the newest certificate pair from certs-src and swaps it
@@ -299,8 +232,4 @@ def update(certs, config_, dry_run, output_dir):
     service's config file and restarts the services whose files changed; add
     --dry-run to preview the changes first.
     """
-    require_update_flag(certs, config_)
-    if certs:
-        run_cert_update(output_dir)
-    if config_:
-        run_config_update(output_dir, dry_run)
+    run_update(UpdateOptions(**kwargs))

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -15,6 +15,7 @@ from .cmd_utils import (
     run_user_command,
     confirm_remove_user_files,
     run_config_update,
+    run_reconcile,
     run_cert_update,
     require_update_flag,
 )
@@ -99,6 +100,26 @@ def config_validate(output_dir):
     click.echo("Configuration is valid")
 
 
+@config.command(name="reconcile")
+@click.option(
+    "--output-dir",
+    default=".",
+    show_default=True,
+    help="Installation directory to inspect.",
+)
+def config_reconcile(output_dir):
+    """Report users whose running config has drifted from .dtaas.state.json.
+
+    Read-only: compares the state cache against compose.users.yml and lists
+    drifted, untracked, and orphaned users. Re-run 'dtaas admin user add' to
+    reprovision drifted users.
+    """
+    try:
+        run_reconcile(output_dir)
+    except (OSError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
 @dtaas.command(name="generate-deployment", cls=VerticalChoicesCommand)
 @click.option(
     "--type",
@@ -150,7 +171,7 @@ def user():
     "--group",
     "groups",
     multiple=True,
-    help="Group tag for USERNAME (repeatable; defaults to 'dtaas').",
+    help="Group tag for USERNAME (repeatable; defaults to 'additional').",
 )
 @click.option(
     "--load-balance/--no-load-balance",
@@ -174,15 +195,24 @@ def add(username, csv_file, email, groups, load_balance):
 
 @user.command()
 @click.argument("usernames", nargs=-1, required=True)
-def delete(usernames):
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show which users would be removed without deleting anything.",
+)
+def delete(usernames, dry_run):
     """
     removes the named USERNAMES from DTaaS\n
-    Deprovisions each user and drops them from dtaas.users.registry.json\n
+    Deprovisions each user and drops them from dtaas.users.registry.json.\n
+    Pass --dry-run to preview the removal without making any changes.\n
     """
-    err = userPkg.delete_users(usernames)
+    err = userPkg.delete_users(usernames, dry_run=dry_run)
     if err is not None:
         raise click.ClickException(f"Error while deleting users: {err}")
-    click.echo("Users deleted successfully")
+    if dry_run:
+        click.echo("Dry run complete; nothing was deleted.")
+    else:
+        click.echo("Users deleted successfully")
 
 
 @admin.command(name="install")

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -11,6 +11,7 @@ from .cmd_utils import (
     VerticalChoicesCommand,
     apply_deploy_config,
     provision_user_files,
+    import_users_file,
     run_user_command,
     confirm_remove_user_files,
     run_config_update,
@@ -137,25 +138,36 @@ def user():
 
 #### user group commands
 @user.command()
-def add():
+@click.option(
+    "--file",
+    "csv_file",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Import users from a CSV file into the registry before adding.",
+)
+def add(csv_file):
     """
-    add a list of users to DTaaS at once\n
-    Specify the list in dtaas.toml [users].add\n
+    add users to DTaaS from the user registry\n
+    Provisions every user in dtaas.users.registry.json.\n
+    Pass --file to merge a users CSV into the registry first.\n
     """
+    if csv_file:
+        import_users_file(csv_file)
     run_user_command(
         userPkg.add_users, "Users added successfully", "Error while adding users"
     )
 
 
 @user.command()
-def delete():
+@click.argument("usernames", nargs=-1, required=True)
+def delete(usernames):
     """
-    removes the USERNAME user from DTaaS\n
-    Specify the users in dtaas.toml [users].delete\n
+    removes the named USERNAMES from DTaaS\n
+    Deprovisions each user and drops them from dtaas.users.registry.json\n
     """
-    run_user_command(
-        userPkg.delete_user, "User deleted successfully", "Error while deleting users"
-    )
+    err = userPkg.delete_users(usernames)
+    if err is not None:
+        raise click.ClickException(f"Error while deleting users: {err}")
+    click.echo("Users deleted successfully")
 
 
 @admin.command(name="install")

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -106,11 +106,13 @@ def config_validate(output_dir):
     help="Installation directory to inspect.",
 )
 def config_reconcile(output_dir):
-    """Report users whose running config has drifted from .dtaas.state.json.
+    """Report drift between the user registry and what is actually provisioned.
 
-    Read-only: compares the state cache against compose.users.yml and lists
-    drifted, untracked, and orphaned users. Re-run 'dtaas admin user add' to
-    reprovision drifted users.
+    Read-only: compares dtaas.users.registry.json (desired) against the live
+    compose.users.yml services (actual), and lists users that are missing,
+    unexpected, or whose config has drifted since it was last provisioned
+    (using .dtaas.state.json). Re-run 'dtaas admin user add' to fix missing or
+    drifted users.
     """
     try:
         run_reconcile(output_dir)

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -11,7 +11,7 @@ from .cmd_utils import (
     VerticalChoicesCommand,
     apply_deploy_config,
     provision_user_files,
-    import_users_file,
+    stage_users_for_add,
     run_user_command,
     confirm_remove_user_files,
     run_config_update,
@@ -138,20 +138,35 @@ def user():
 
 #### user group commands
 @user.command()
+@click.argument("username", required=False)
 @click.option(
     "--file",
     "csv_file",
     type=click.Path(exists=True, dir_okay=False),
-    help="Import users from a CSV file into the registry before adding.",
+    help="Bulk-add users from a CSV file into the registry.",
 )
-def add(csv_file):
+@click.option("--email", help="Email for USERNAME (enables forward-auth routing).")
+@click.option(
+    "--group",
+    "groups",
+    multiple=True,
+    help="Group tag for USERNAME (repeatable; defaults to 'dtaas').",
+)
+@click.option(
+    "--load-balance/--no-load-balance",
+    default=True,
+    help="Mark USERNAME for load balancing (default: enabled).",
+)
+def add(username, csv_file, email, groups, load_balance):
     """
-    add users to DTaaS from the user registry\n
-    Provisions every user in dtaas.users.registry.json.\n
-    Pass --file to merge a users CSV into the registry first.\n
+    add users to DTaaS\n
+    Single user: dtaas admin user add alice --email alice@intocps.org\n
+    Bulk from CSV: dtaas admin user add --file users.csv\n
+    Both merge into dtaas.users.registry.json, then every registry user is
+    provisioned. With no USERNAME and no --file, the existing registry is
+    reprovisioned.\n
     """
-    if csv_file:
-        import_users_file(csv_file)
+    stage_users_for_add(username, csv_file, email, groups, load_balance)
     run_user_command(
         userPkg.add_users, "Users added successfully", "Error while adding users"
     )

--- a/cli/src/cmd.py
+++ b/cli/src/cmd.py
@@ -105,17 +105,27 @@ def config_validate(output_dir):
     show_default=True,
     help="Installation directory to inspect.",
 )
-def config_reconcile(output_dir):
+@click.option(
+    "--fix",
+    is_flag=True,
+    help="Reprovision missing/drifted registry users after reporting.",
+)
+def config_reconcile(output_dir, fix):
     """Report drift between the user registry and what is actually provisioned.
 
-    Read-only: compares dtaas.users.registry.json (desired) against the live
+    Compares dtaas.users.registry.json (desired) against the live
     compose.users.yml services (actual), and lists users that are missing,
     unexpected, or whose config has drifted since it was last provisioned
-    (using .dtaas.state.json). Re-run 'dtaas admin user add' to fix missing or
-    drifted users.
+    (using .dtaas.state.json).
+
+    Without --fix this is read-only. With --fix, missing and drifted users are
+    reprovisioned afterward (equivalent to running 'dtaas admin user add', so
+    it operates on the current directory regardless of --output-dir).
+    'unexpected' services (running but not registered) are never touched by
+    --fix -- remove those deliberately with 'dtaas admin user delete'.
     """
     try:
-        run_reconcile(output_dir)
+        run_reconcile(output_dir, fix)
     except (OSError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc
 

--- a/cli/src/cmd_deploy_utils.py
+++ b/cli/src/cmd_deploy_utils.py
@@ -1,0 +1,113 @@
+"""Deployment-generation helpers used by cmd.py.
+
+This module holds the help-text formatter and the dtaas.toml substitution/
+certificate-copy orchestration used by 'generate-deployment' and provisioning
+user workspace files ahead of 'admin install'.
+"""
+
+import click
+from .pkg import project as projectPkg
+from .pkg import certs as certsPkg
+from .pkg import deploy_config as deployConfigPkg
+from .pkg import utils as utilsPkg
+
+
+class VerticalChoicesCommand(click.Command):
+    """Format Choice options as a vertical list in help text."""
+
+    def format_help_text(self, ctx, formatter):
+        if self.help:
+            formatter.write_paragraph()
+            with formatter.indentation():
+                formatter.write_text(self.help)
+
+    def format_options(self, ctx, formatter):
+        rows = []
+        for param in self.get_params(ctx):
+            rows.extend(self._param_rows(param, ctx))
+        if rows:
+            with formatter.section("Options"):
+                formatter.write_dl(rows)
+
+    @staticmethod
+    def _param_rows(param, ctx):
+        """Return the help rows for a single param (empty list if hidden)."""
+        rv = param.get_help_record(ctx)
+        if rv is None:
+            return []
+        if not isinstance(param.type, click.Choice):
+            return [rv]
+        prefix = f"{rv[1]}. " if rv[1] else ""
+        rows = [(rv[0], f"{prefix}One of:")]
+        rows.extend(("", choice) for choice in param.type.choices)
+        return rows
+
+
+def _find_toml(output_dir):
+    """Return path to dtaas.toml, checking output_dir first then cwd, or None."""
+    return utilsPkg.find_toml(output_dir)
+
+
+def apply_deploy_config(deploy_type, output_dir, force=False):
+    """Read dtaas.toml and substitute values into generated deployment files."""
+    toml_path = _find_toml(output_dir)
+    if toml_path is None:
+        click.echo("Note: dtaas.toml not found; template values not substituted.")
+        return
+    toml_data, err = utilsPkg.import_toml(str(toml_path))
+    if err is not None:
+        raise click.ClickException(f"Error reading dtaas.toml: {err}")
+    _substitute_config(deploy_type, output_dir, toml_data)
+    _create_user_dirs(output_dir, toml_data)
+    spec = certsPkg.CertsCopySpec(deploy_type, _certs_src(toml_data), force)
+    _copy_deploy_certs(output_dir, spec)
+
+
+def _substitute_config(deploy_type, output_dir, toml_data):
+    """Build file specs from toml and substitute them into the generated files."""
+    try:
+        specs = deployConfigPkg.build_file_specs(deploy_type, toml_data)
+        deployConfigPkg.apply_config(output_dir, specs)
+    except (OSError, ValueError, TypeError) as exc:
+        raise click.ClickException(f"Error substituting config values: {exc}") from exc
+    for warning in deployConfigPkg.check_placeholders(output_dir, specs):
+        click.echo(warning)
+
+
+def _certs_src(toml_data):
+    """Resolve [common.security].certs-src from dtaas.toml, or '' if unset."""
+    return utilsPkg.resolve_certs_src(toml_data)
+
+
+def _copy_deploy_certs(output_dir, spec):
+    """Copy TLS certificates into output_dir/certs for secure deployments."""
+    try:
+        note = certsPkg.copy_certs(output_dir, spec)
+    except OSError as exc:
+        raise click.ClickException(f"Error copying certificates: {exc}") from exc
+    if note:
+        click.echo(note)
+
+
+def _create_user_dirs(output_dir, toml_data):
+    """Create per-user directories from the [users].starting list in dtaas.toml."""
+    users = toml_data.get("users", {}) if toml_data else {}
+    usernames = users.get("starting", []) if isinstance(users, dict) else []
+    if not usernames:
+        return
+    try:
+        projectPkg.create_user_dirs(output_dir, usernames)
+    except OSError as exc:
+        raise click.ClickException(f"Error creating user directories: {exc}") from exc
+
+
+def provision_user_files(output_dir):
+    """Ensure per-user workspace directories exist and are owned 1000:100."""
+    toml_path = _find_toml(output_dir)
+    if toml_path is None:
+        return
+    toml_data, err = utilsPkg.import_toml(str(toml_path))
+    if err is not None:
+        raise click.ClickException(f"Error reading dtaas.toml: {err}")
+    _create_user_dirs(output_dir, toml_data)
+    projectPkg.set_files_permissions(output_dir)

--- a/cli/src/cmd_user.py
+++ b/cli/src/cmd_user.py
@@ -7,7 +7,12 @@ wired onto the 'user' group by cmd.py via Group.add_command.
 
 import click
 from .pkg import users as userPkg
-from .cmd_utils import UserAddInput, run_user_command, stage_users_for_add
+from .cmd_utils import (
+    UserAddInput,
+    resolve_delete_usernames,
+    run_user_command,
+    stage_users_for_add,
+)
 
 
 @click.command()
@@ -36,8 +41,7 @@ def add(**kwargs):
     Single user: dtaas admin user add --email alice@intocps.org alice\n
     Bulk from CSV: dtaas admin user add --file users.csv\n
     Both merge into dtaas.users.registry.json, then every registry user is
-    provisioned. With no USERNAME and no --file, the existing registry is
-    reprovisioned.\n
+    provisioned. A USERNAME or --file is required.\n
     """
     user_input = UserAddInput(**kwargs)
 
@@ -52,19 +56,28 @@ def add(**kwargs):
 
 
 @click.command()
-@click.argument("usernames", nargs=-1, required=True)
+@click.argument("usernames", nargs=-1, required=False)
+@click.option(
+    "--file",
+    "csv_file",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Bulk-delete users listed in a CSV file (only the username column is used).",
+)
 @click.option(
     "--dry-run",
     is_flag=True,
     help="Show which users would be removed without deleting anything.",
 )
-def delete(usernames, dry_run):
+def delete(usernames, csv_file, dry_run):
     """
-    removes the named USERNAMES from DTaaS\n
+    removes users from DTaaS\n
+    By name: dtaas admin user delete alice bob\n
+    Bulk from CSV: dtaas admin user delete --file users.csv\n
     Deprovisions each user and drops them from dtaas.users.registry.json.\n
     Pass --dry-run to preview the removal without making any changes.\n
     """
-    err = userPkg.delete_users(usernames, dry_run=dry_run)
+    resolved = resolve_delete_usernames(usernames, csv_file)
+    err = userPkg.delete_users(resolved, dry_run=dry_run)
     if err is not None:
         raise click.ClickException(f"Error while deleting users: {err}")
     if dry_run:

--- a/cli/src/cmd_user.py
+++ b/cli/src/cmd_user.py
@@ -39,9 +39,15 @@ def add(**kwargs):
     provisioned. With no USERNAME and no --file, the existing registry is
     reprovisioned.\n
     """
-    stage_users_for_add(UserAddInput(**kwargs))
+    user_input = UserAddInput(**kwargs)
+
+    def _stage_then_add(config_obj):
+        """Stage the registry only once dtaas.toml has loaded successfully."""
+        stage_users_for_add(user_input)
+        return userPkg.add_users(config_obj)
+
     run_user_command(
-        userPkg.add_users, "Users added successfully", "Error while adding users"
+        _stage_then_add, "Users added successfully", "Error while adding users"
     )
 
 

--- a/cli/src/cmd_user.py
+++ b/cli/src/cmd_user.py
@@ -1,0 +1,67 @@
+"""The 'user' subcommands: add and delete DTaaS users.
+
+Defined here as standalone commands (rather than under cmd.py's 'user' group
+decorator) purely to keep cmd.py within a reasonable line count; they are
+wired onto the 'user' group by cmd.py via Group.add_command.
+"""
+
+import click
+from .pkg import users as userPkg
+from .cmd_utils import UserAddInput, run_user_command, stage_users_for_add
+
+
+@click.command()
+@click.argument("username", required=False)
+@click.option(
+    "--file",
+    "csv_file",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Bulk-add users from a CSV file into the registry.",
+)
+@click.option("--email", help="Email for USERNAME (enables forward-auth routing).")
+@click.option(
+    "--group",
+    "groups",
+    multiple=True,
+    help="Group tag for USERNAME (repeatable; defaults to 'additional').",
+)
+@click.option(
+    "--load-balance/--no-load-balance",
+    default=True,
+    help="Mark USERNAME for load balancing (default: enabled).",
+)
+def add(**kwargs):
+    """
+    add users to DTaaS\n
+    Single user: dtaas admin user add alice --email alice@intocps.org\n
+    Bulk from CSV: dtaas admin user add --file users.csv\n
+    Both merge into dtaas.users.registry.json, then every registry user is
+    provisioned. With no USERNAME and no --file, the existing registry is
+    reprovisioned.\n
+    """
+    stage_users_for_add(UserAddInput(**kwargs))
+    run_user_command(
+        userPkg.add_users, "Users added successfully", "Error while adding users"
+    )
+
+
+@click.command()
+@click.argument("usernames", nargs=-1, required=True)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show which users would be removed without deleting anything.",
+)
+def delete(usernames, dry_run):
+    """
+    removes the named USERNAMES from DTaaS\n
+    Deprovisions each user and drops them from dtaas.users.registry.json.\n
+    Pass --dry-run to preview the removal without making any changes.\n
+    """
+    err = userPkg.delete_users(usernames, dry_run=dry_run)
+    if err is not None:
+        raise click.ClickException(f"Error while deleting users: {err}")
+    if dry_run:
+        click.echo("Dry run complete; nothing was deleted.")
+    else:
+        click.echo("Users deleted successfully")

--- a/cli/src/cmd_user.py
+++ b/cli/src/cmd_user.py
@@ -33,7 +33,7 @@ from .cmd_utils import UserAddInput, run_user_command, stage_users_for_add
 def add(**kwargs):
     """
     add users to DTaaS\n
-    Single user: dtaas admin user add alice --email alice@intocps.org\n
+    Single user: dtaas admin user add --email alice@intocps.org alice\n
     Bulk from CSV: dtaas admin user add --file users.csv\n
     Both merge into dtaas.users.registry.json, then every registry user is
     provisioned. With no USERNAME and no --file, the existing registry is

--- a/cli/src/cmd_utils.py
+++ b/cli/src/cmd_utils.py
@@ -8,6 +8,7 @@ the user-command wrapper, and the destructive-action confirmation prompt.
 import click
 from python_on_whales.exceptions import DockerException
 from .pkg import config as configPkg
+from .pkg import registry as registryPkg
 from .pkg import project as projectPkg
 from .pkg import certs as certsPkg
 from .pkg import deploy_config as deployConfigPkg
@@ -96,9 +97,9 @@ def _copy_deploy_certs(deploy_type, output_dir, toml_data, force):
 
 
 def _create_user_dirs(output_dir, toml_data):
-    """Create per-user directories from the [users].add list in dtaas.toml."""
+    """Create per-user directories from the [users].starting list in dtaas.toml."""
     users = toml_data.get("users", {}) if toml_data else {}
-    usernames = users.get("add", []) if isinstance(users, dict) else []
+    usernames = users.get("starting", []) if isinstance(users, dict) else []
     if not usernames:
         return
     try:
@@ -117,6 +118,14 @@ def provision_user_files(output_dir):
         raise click.ClickException(f"Error reading dtaas.toml: {err}")
     _create_user_dirs(output_dir, toml_data)
     projectPkg.set_files_permissions(output_dir)
+
+
+def import_users_file(csv_file):
+    """Merge a users CSV into the registry store, mapping errors to ClickException."""
+    try:
+        registryPkg.add_to_registry(registryPkg.read_csv_users(csv_file))
+    except (OSError, KeyError, ValueError) as exc:
+        raise click.ClickException(f"Error importing users file: {exc}") from exc
 
 
 def run_user_command(action, success_msg, error_prefix):

--- a/cli/src/cmd_utils.py
+++ b/cli/src/cmd_utils.py
@@ -155,9 +155,9 @@ def run_uninstall(output_dir, remove_user_files):
 
 
 _RECONCILE_LABELS = (
+    ("missing", "registered but not provisioned; re-run 'dtaas admin user add'"),
+    ("unexpected", "provisioned but not in the registry; investigate"),
     ("drifted", "config changed since provisioning; re-run 'dtaas admin user add'"),
-    ("untracked", "provisioned but not recorded in the state cache"),
-    ("orphaned", "in the state cache but no longer provisioned"),
 )
 
 
@@ -172,13 +172,18 @@ def _echo_reconcile(report):
 
 
 def run_reconcile(output_dir):
-    """Report drift between .dtaas.state.json and compose.users.yml."""
+    """Report drift between dtaas.users.registry.json (desired) and the live
+    compose.users.yml services (actual), using .dtaas.state.json to detect
+    config changes on users present in both."""
+    registry_users = registryPkg.load_registry(
+        str(Path(output_dir) / registryPkg.REGISTRY_FILE)
+    )
     state = statePkg.load_state(str(Path(output_dir) / statePkg.STATE_FILE))
     compose, err = utilsPkg.import_yaml(str(Path(output_dir) / COMPOSE_USERS_YML))
     if err is not None:
         raise click.ClickException(f"Error reading {COMPOSE_USERS_YML}: {err}")
     services = compose.get("services", {}) if isinstance(compose, dict) else {}
-    _echo_reconcile(statePkg.find_drift(state, services))
+    _echo_reconcile(statePkg.find_drift(registry_users, state, services))
 
 
 def run_config_update(output_dir, dry_run):

--- a/cli/src/cmd_utils.py
+++ b/cli/src/cmd_utils.py
@@ -14,7 +14,7 @@ from .pkg import config as configPkg
 from .pkg import registry as registryPkg
 from .pkg import state as statePkg
 from .pkg import deploy as deployPkg
-from .pkg.constants import COMPOSE_USERS_YML
+from .pkg.constants import COMPOSE_USERS_YML, REGISTRY_FILE, STATE_FILE
 from .pkg.users_utils import validate_usernames
 from .pkg import config_update as configUpdatePkg
 from .pkg import cert_update as certUpdatePkg
@@ -175,10 +175,8 @@ def run_reconcile(output_dir):
     """Report drift between dtaas.users.registry.json (desired) and the live
     compose.users.yml services (actual), using .dtaas.state.json to detect
     config changes on users present in both."""
-    registry_users = registryPkg.load_registry(
-        str(Path(output_dir) / registryPkg.REGISTRY_FILE)
-    )
-    state = statePkg.load_state(str(Path(output_dir) / statePkg.STATE_FILE))
+    registry_users = registryPkg.load_registry(str(Path(output_dir) / REGISTRY_FILE))
+    state = statePkg.load_state(str(Path(output_dir) / STATE_FILE))
     compose, err = utilsPkg.import_yaml(str(Path(output_dir) / COMPOSE_USERS_YML))
     if err is not None:
         raise click.ClickException(f"Error reading {COMPOSE_USERS_YML}: {err}")

--- a/cli/src/cmd_utils.py
+++ b/cli/src/cmd_utils.py
@@ -1,127 +1,27 @@
 """Helper functions shared by the DTaaS CLI command definitions in cmd.py.
 
-This module holds everything that is not a Click command itself: the help-text
-formatter, the deployment-config orchestration used by generate-deployment,
-the user-command wrapper, and the destructive-action confirmation prompt.
+This module holds the user-registry staging logic and the uninstall/
+reconcile/update orchestration. See cmd_deploy_utils.py for the
+deployment-generation helpers and cmd_user.py for the 'user add'/'user
+delete' command bodies.
 """
 
+from dataclasses import dataclass
 from pathlib import Path
 import click
 from python_on_whales.exceptions import DockerException
 from .pkg import config as configPkg
 from .pkg import registry as registryPkg
-from .pkg import project as projectPkg
 from .pkg import state as statePkg
+from .pkg import deploy as deployPkg
 from .pkg.constants import COMPOSE_USERS_YML
 from .pkg.users_utils import validate_usernames
-from .pkg import certs as certsPkg
-from .pkg import deploy_config as deployConfigPkg
 from .pkg import config_update as configUpdatePkg
 from .pkg import cert_update as certUpdatePkg
 from .pkg import utils as utilsPkg
 from .pkg.cert_validate import CertValidationError
 
-
-class VerticalChoicesCommand(click.Command):
-    """Format Choice options as a vertical list in help text."""
-
-    def format_help_text(self, ctx, formatter):
-        if self.help:
-            formatter.write_paragraph()
-            with formatter.indentation():
-                formatter.write_text(self.help)
-
-    def format_options(self, ctx, formatter):
-        rows = []
-        for param in self.get_params(ctx):
-            rows.extend(self._param_rows(param, ctx))
-        if rows:
-            with formatter.section("Options"):
-                formatter.write_dl(rows)
-
-    @staticmethod
-    def _param_rows(param, ctx):
-        """Return the help rows for a single param (empty list if hidden)."""
-        rv = param.get_help_record(ctx)
-        if rv is None:
-            return []
-        if not isinstance(param.type, click.Choice):
-            return [rv]
-        prefix = f"{rv[1]}. " if rv[1] else ""
-        rows = [(rv[0], f"{prefix}One of:")]
-        rows.extend(("", choice) for choice in param.type.choices)
-        return rows
-
-
-def _find_toml(output_dir):
-    """Return path to dtaas.toml, checking output_dir first then cwd, or None."""
-    return utilsPkg.find_toml(output_dir)
-
-
-def apply_deploy_config(deploy_type, output_dir, force=False):
-    """Read dtaas.toml and substitute values into generated deployment files."""
-    toml_path = _find_toml(output_dir)
-    if toml_path is None:
-        click.echo("Note: dtaas.toml not found; template values not substituted.")
-        return
-    toml_data, err = utilsPkg.import_toml(str(toml_path))
-    if err is not None:
-        raise click.ClickException(f"Error reading dtaas.toml: {err}")
-    _substitute_config(deploy_type, output_dir, toml_data)
-    _create_user_dirs(output_dir, toml_data)
-    _copy_deploy_certs(deploy_type, output_dir, toml_data, force)
-
-
-def _substitute_config(deploy_type, output_dir, toml_data):
-    """Build file specs from toml and substitute them into the generated files."""
-    try:
-        specs = deployConfigPkg.build_file_specs(deploy_type, toml_data)
-        deployConfigPkg.apply_config(output_dir, specs)
-    except (OSError, ValueError, TypeError) as exc:
-        raise click.ClickException(f"Error substituting config values: {exc}") from exc
-    for warning in deployConfigPkg.check_placeholders(output_dir, specs):
-        click.echo(warning)
-
-
-def _certs_src(toml_data):
-    """Resolve [common.security].certs-src from dtaas.toml, or '' if unset."""
-    return utilsPkg.resolve_certs_src(toml_data)
-
-
-def _copy_deploy_certs(deploy_type, output_dir, toml_data, force):
-    """Copy TLS certificates into output_dir/certs for secure deployments."""
-    try:
-        note = certsPkg.copy_certs(
-            deploy_type, output_dir, _certs_src(toml_data), force
-        )
-    except OSError as exc:
-        raise click.ClickException(f"Error copying certificates: {exc}") from exc
-    if note:
-        click.echo(note)
-
-
-def _create_user_dirs(output_dir, toml_data):
-    """Create per-user directories from the [users].starting list in dtaas.toml."""
-    users = toml_data.get("users", {}) if toml_data else {}
-    usernames = users.get("starting", []) if isinstance(users, dict) else []
-    if not usernames:
-        return
-    try:
-        projectPkg.create_user_dirs(output_dir, usernames)
-    except OSError as exc:
-        raise click.ClickException(f"Error creating user directories: {exc}") from exc
-
-
-def provision_user_files(output_dir):
-    """Ensure per-user workspace directories exist and are owned 1000:100."""
-    toml_path = _find_toml(output_dir)
-    if toml_path is None:
-        return
-    toml_data, err = utilsPkg.import_toml(str(toml_path))
-    if err is not None:
-        raise click.ClickException(f"Error reading dtaas.toml: {err}")
-    _create_user_dirs(output_dir, toml_data)
-    projectPkg.set_files_permissions(output_dir)
+NO_INSTALLATION_MESSAGE = "There is no existing DTaaS / Workspace installation"
 
 
 def _starting_usernames():
@@ -143,29 +43,40 @@ def _read_users_csv(csv_file):
         raise click.ClickException(f"Error importing users file: {exc}") from exc
 
 
-def _users_from_args(username, email, groups, load_balance):
+@dataclass
+class UserAddInput:
+    """CLI inputs for 'user add': a single USERNAME or a --file import, not both."""
+
+    username: str | None
+    csv_file: str | None
+    email: str | None
+    groups: tuple
+    load_balance: bool
+
+
+def _users_from_args(user_input):
     """Build a one-user {name: details} mapping from CLI arguments.
 
     Defaults groups to ['additional'] when --group is omitted, matching the CSV
     import path (registry._parse_csv_row) so the two produce identical users.
     """
-    if not email:
+    if not user_input.email:
         raise click.ClickException("Provide --email when adding a single user.")
     return {
-        username: {
-            "email": email,
-            "groups": list(groups) or ["additional"],
-            "load_balance": load_balance,
+        user_input.username: {
+            "email": user_input.email,
+            "groups": list(user_input.groups) or ["additional"],
+            "load_balance": user_input.load_balance,
         }
     }
 
 
-def _users_to_add(username, csv_file, email, groups, load_balance):
+def _users_to_add(user_input):
     """Collect the users to add from --file or a single USERNAME argument."""
-    if csv_file:
-        return _read_users_csv(csv_file)
-    if username:
-        return _users_from_args(username, email, groups, load_balance)
+    if user_input.csv_file:
+        return _read_users_csv(user_input.csv_file)
+    if user_input.username:
+        return _users_from_args(user_input)
     return {}
 
 
@@ -180,7 +91,7 @@ def _register_users(new_users):
         click.echo(f"'{name}' already exists, skipping")
 
 
-def stage_users_for_add(username, csv_file, email, groups, load_balance):
+def stage_users_for_add(user_input):
     """Merge CLI/CSV users into the registry before provisioning.
 
     Rejects malformed usernames and, with a warning, skips any already in
@@ -188,9 +99,9 @@ def stage_users_for_add(username, csv_file, email, groups, load_balance):
     input. A bare 'user add' (no USERNAME, no --file) is a no-op here and just
     reprovisions the existing registry.
     """
-    if username and csv_file:
+    if user_input.username and user_input.csv_file:
         raise click.ClickException("Pass either a USERNAME or --file, not both.")
-    new_users = _users_to_add(username, csv_file, email, groups, load_balance)
+    new_users = _users_to_add(user_input)
     if new_users:
         _register_users(new_users)
 
@@ -214,6 +125,33 @@ def confirm_remove_user_files(remove_user_files, yes):
             "This permanently deletes all per-user workspace files. Continue?",
             abort=True,
         )
+
+
+def _uninstall_existing(output_dir, remove_user_files):
+    """Tear down a present installation and report what happened."""
+    message = deployPkg.uninstall(output_dir, remove_user_files)
+    if message:
+        click.echo(message)
+    click.echo("Deployment uninstalled successfully")
+
+
+def _uninstall_absent(output_dir, remove_user_files):
+    """Report a missing installation, still clearing user files if asked."""
+    click.echo(NO_INSTALLATION_MESSAGE)
+    if remove_user_files:
+        deployPkg.require_compose_file(output_dir)
+        click.echo(deployPkg.delete_user_files(output_dir))
+
+
+def run_uninstall(output_dir, remove_user_files):
+    """Tear the deployment down with 'docker compose down', or report it absent."""
+    try:
+        if deployPkg.installation_present(output_dir):
+            _uninstall_existing(output_dir, remove_user_files)
+        else:
+            _uninstall_absent(output_dir, remove_user_files)
+    except (OSError, DockerException) as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 _RECONCILE_LABELS = (
@@ -265,3 +203,22 @@ def run_cert_update(output_dir):
     except (CertValidationError, OSError, DockerException, RuntimeError) as exc:
         raise click.ClickException(str(exc)) from exc
     click.echo(message)
+
+
+@dataclass
+class UpdateOptions:
+    """CLI inputs for 'admin update': which assets to refresh and where."""
+
+    certs: bool
+    config_: bool
+    dry_run: bool
+    output_dir: str
+
+
+def run_update(options):
+    """Refresh certs and/or re-apply config, per the requested UpdateOptions."""
+    require_update_flag(options.certs, options.config_)
+    if options.certs:
+        run_cert_update(options.output_dir)
+    if options.config_:
+        run_config_update(options.output_dir, options.dry_run)

--- a/cli/src/cmd_utils.py
+++ b/cli/src/cmd_utils.py
@@ -14,6 +14,7 @@ from .pkg import config as configPkg
 from .pkg import registry as registryPkg
 from .pkg import state as statePkg
 from .pkg import deploy as deployPkg
+from .pkg import users as userPkg
 from .pkg.constants import COMPOSE_USERS_YML, REGISTRY_FILE, STATE_FILE
 from .pkg.users_utils import validate_usernames
 from .pkg import config_update as configUpdatePkg
@@ -96,14 +97,33 @@ def stage_users_for_add(user_input):
 
     Rejects malformed usernames and, with a warning, skips any already in
     dtaas.toml's starting list or the registry. Raises ClickException on bad
-    input. A bare 'user add' (no USERNAME, no --file) is a no-op here and just
-    reprovisions the existing registry.
+    or missing input: a USERNAME or --file is required, and not both.
     """
     if user_input.username and user_input.csv_file:
         raise click.ClickException("Pass either a USERNAME or --file, not both.")
-    new_users = _users_to_add(user_input)
-    if new_users:
-        _register_users(new_users)
+    if not user_input.username and not user_input.csv_file:
+        raise click.ClickException(
+            "Provide a USERNAME (e.g. 'dtaas admin user add alice --email "
+            "a@x.io') or --file <users.csv> to add users."
+        )
+    _register_users(_users_to_add(user_input))
+
+
+def resolve_delete_usernames(usernames, csv_file):
+    """Resolve the usernames to delete from positional USERNAMES or --file.
+
+    Only the username column of the CSV is used; email/groups/load_balance are
+    ignored for delete. Raises ClickException if both or neither are given.
+    """
+    if usernames and csv_file:
+        raise click.ClickException("Pass either USERNAMES or --file, not both.")
+    if csv_file:
+        return list(_read_users_csv(csv_file))
+    if usernames:
+        return list(usernames)
+    raise click.ClickException(
+        "Provide one or more USERNAMES or --file <users.csv> to delete users."
+    )
 
 
 def run_user_command(action, success_msg, error_prefix):
@@ -171,17 +191,28 @@ def _echo_reconcile(report):
             click.echo(f"- {name}: {label}")
 
 
-def run_reconcile(output_dir):
+def _fix_reconcile():
+    """Reprovision missing/drifted registry users (equivalent to 'user add')."""
+    run_user_command(
+        userPkg.add_users,
+        "Reprovisioned missing/drifted users.",
+        "Error while fixing drift",
+    )
+
+
+def run_reconcile(output_dir, fix=False):
     """Report drift between dtaas.users.registry.json (desired) and the live
-    compose.users.yml services (actual), using .dtaas.state.json to detect
-    config changes on users present in both."""
+    compose.users.yml services (actual)"""
     registry_users = registryPkg.load_registry(str(Path(output_dir) / REGISTRY_FILE))
     state = statePkg.load_state(str(Path(output_dir) / STATE_FILE))
     compose, err = utilsPkg.import_yaml(str(Path(output_dir) / COMPOSE_USERS_YML))
     if err is not None:
         raise click.ClickException(f"Error reading {COMPOSE_USERS_YML}: {err}")
     services = compose.get("services", {}) if isinstance(compose, dict) else {}
-    _echo_reconcile(statePkg.find_drift(registry_users, state, services))
+    report = statePkg.find_drift(registry_users, state, services)
+    _echo_reconcile(report)
+    if fix and (report["missing"] or report["drifted"]):
+        _fix_reconcile()
 
 
 def run_config_update(output_dir, dry_run):

--- a/cli/src/cmd_utils.py
+++ b/cli/src/cmd_utils.py
@@ -5,11 +5,14 @@ formatter, the deployment-config orchestration used by generate-deployment,
 the user-command wrapper, and the destructive-action confirmation prompt.
 """
 
+from pathlib import Path
 import click
 from python_on_whales.exceptions import DockerException
 from .pkg import config as configPkg
 from .pkg import registry as registryPkg
 from .pkg import project as projectPkg
+from .pkg import state as statePkg
+from .pkg.constants import COMPOSE_USERS_YML
 from .pkg.users_utils import validate_usernames
 from .pkg import certs as certsPkg
 from .pkg import deploy_config as deployConfigPkg
@@ -141,13 +144,17 @@ def _read_users_csv(csv_file):
 
 
 def _users_from_args(username, email, groups, load_balance):
-    """Build a one-user {name: details} mapping from CLI arguments."""
+    """Build a one-user {name: details} mapping from CLI arguments.
+
+    Defaults groups to ['additional'] when --group is omitted, matching the CSV
+    import path (registry._parse_csv_row) so the two produce identical users.
+    """
     if not email:
         raise click.ClickException("Provide --email when adding a single user.")
     return {
         username: {
             "email": email,
-            "groups": list(groups) or ["dtaas"],
+            "groups": list(groups) or ["additional"],
             "load_balance": load_balance,
         }
     }
@@ -207,6 +214,33 @@ def confirm_remove_user_files(remove_user_files, yes):
             "This permanently deletes all per-user workspace files. Continue?",
             abort=True,
         )
+
+
+_RECONCILE_LABELS = (
+    ("drifted", "config changed since provisioning; re-run 'dtaas admin user add'"),
+    ("untracked", "provisioned but not recorded in the state cache"),
+    ("orphaned", "in the state cache but no longer provisioned"),
+)
+
+
+def _echo_reconcile(report):
+    """Print a drift report, noting when everything is in sync."""
+    if not any(report.values()):
+        click.echo("In sync: no drift detected.")
+        return
+    for key, label in _RECONCILE_LABELS:
+        for name in report[key]:
+            click.echo(f"- {name}: {label}")
+
+
+def run_reconcile(output_dir):
+    """Report drift between .dtaas.state.json and compose.users.yml."""
+    state = statePkg.load_state(str(Path(output_dir) / statePkg.STATE_FILE))
+    compose, err = utilsPkg.import_yaml(str(Path(output_dir) / COMPOSE_USERS_YML))
+    if err is not None:
+        raise click.ClickException(f"Error reading {COMPOSE_USERS_YML}: {err}")
+    services = compose.get("services", {}) if isinstance(compose, dict) else {}
+    _echo_reconcile(statePkg.find_drift(state, services))
 
 
 def run_config_update(output_dir, dry_run):

--- a/cli/src/cmd_utils.py
+++ b/cli/src/cmd_utils.py
@@ -10,6 +10,7 @@ from python_on_whales.exceptions import DockerException
 from .pkg import config as configPkg
 from .pkg import registry as registryPkg
 from .pkg import project as projectPkg
+from .pkg.users_utils import validate_usernames
 from .pkg import certs as certsPkg
 from .pkg import deploy_config as deployConfigPkg
 from .pkg import config_update as configUpdatePkg
@@ -120,12 +121,71 @@ def provision_user_files(output_dir):
     projectPkg.set_files_permissions(output_dir)
 
 
-def import_users_file(csv_file):
-    """Merge a users CSV into the registry store, mapping errors to ClickException."""
+def _starting_usernames():
+    """The [users].starting list from dtaas.toml, or [] when unavailable."""
     try:
-        registryPkg.add_to_registry(registryPkg.read_csv_users(csv_file))
+        config_obj = configPkg.Config()
+    except RuntimeError:
+        return []
+    users, _ = config_obj.get_users()
+    starting = users.get("starting", []) if isinstance(users, dict) else []
+    return [str(x) for x in starting] if isinstance(starting, list) else []
+
+
+def _read_users_csv(csv_file):
+    """Parse a users CSV, mapping parse errors to ClickException."""
+    try:
+        return registryPkg.read_csv_users(csv_file)
     except (OSError, KeyError, ValueError) as exc:
         raise click.ClickException(f"Error importing users file: {exc}") from exc
+
+
+def _users_from_args(username, email, groups, load_balance):
+    """Build a one-user {name: details} mapping from CLI arguments."""
+    if not email:
+        raise click.ClickException("Provide --email when adding a single user.")
+    return {
+        username: {
+            "email": email,
+            "groups": list(groups) or ["dtaas"],
+            "load_balance": load_balance,
+        }
+    }
+
+
+def _users_to_add(username, csv_file, email, groups, load_balance):
+    """Collect the users to add from --file or a single USERNAME argument."""
+    if csv_file:
+        return _read_users_csv(csv_file)
+    if username:
+        return _users_from_args(username, email, groups, load_balance)
+    return {}
+
+
+def _register_users(new_users):
+    """Validate and register new users, warning about skipped duplicates."""
+    try:
+        validate_usernames(new_users)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _, skipped = registryPkg.register_new_users(new_users, _starting_usernames())
+    for name in skipped:
+        click.echo(f"'{name}' already exists, skipping")
+
+
+def stage_users_for_add(username, csv_file, email, groups, load_balance):
+    """Merge CLI/CSV users into the registry before provisioning.
+
+    Rejects malformed usernames and, with a warning, skips any already in
+    dtaas.toml's starting list or the registry. Raises ClickException on bad
+    input. A bare 'user add' (no USERNAME, no --file) is a no-op here and just
+    reprovisions the existing registry.
+    """
+    if username and csv_file:
+        raise click.ClickException("Pass either a USERNAME or --file, not both.")
+    new_users = _users_to_add(username, csv_file, email, groups, load_balance)
+    if new_users:
+        _register_users(new_users)
 
 
 def run_user_command(action, success_msg, error_prefix):

--- a/cli/src/pkg/certs.py
+++ b/cli/src/pkg/certs.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 
 import click
@@ -82,41 +83,76 @@ def _cert_copy_message(certs_dir, copied, missing):
     return "\n".join(parts)
 
 
+@dataclass
+class _CertCopyTarget:
+    """Grouped context for copying a single cert file."""
+
+    src: Path
+    certs_dir: Path
+    force: bool
+
+
+def _copy_one_cert(target, name):
+    """Copy a single cert file; return 'copied', 'missing', or 'skipped'."""
+    latest = find_latest_cert(target.src, name[: -len(".pem")])
+    if latest is None:
+        return "missing"
+    dest = target.certs_dir / name
+    if dest.exists() and not target.force:
+        return "skipped"
+    shutil.copy2(latest, dest)
+    return "copied"
+
+
 def _copy_cert_pair(src, certs_dir, force):
     """Copy the latest fullchain/privkey from src into certs_dir.
 
     Existing files are skipped unless force is True. Returns a status note.
     Raises OSError on copy failure.
     """
+    target = _CertCopyTarget(src, certs_dir, force)
     copied, missing = [], []
     for name in CERT_FILES:
-        latest = find_latest_cert(src, name[: -len(".pem")])
-        if latest is None:
+        status = _copy_one_cert(target, name)
+        if status == "copied":
+            copied.append(name)
+        elif status == "missing":
             missing.append(name)
-            continue
-        dest = certs_dir / name
-        if dest.exists() and not force:
-            continue
-        shutil.copy2(latest, dest)
-        copied.append(name)
     secure_private_key(certs_dir / PRIVATE_KEY_NAME)
     return _cert_copy_message(certs_dir, copied, missing)
 
 
-def copy_certs(deploy_type, dest_dir, certs_src, force=False):
+def _certs_src_issue(certs_src):
+    """Return a note describing why certs_src is unusable, or None if it's fine."""
+    if not certs_src:
+        return "Note: certs-src not set in dtaas.toml; TLS certificates not copied."
+    src = Path(certs_src)
+    if not src.is_dir():
+        return f"Note: certs-src not found ({src}); TLS certificates not copied."
+    return None
+
+
+@dataclass
+class CertsCopySpec:
+    """Grouped inputs for copying TLS certs into a generated deployment."""
+
+    deploy_type: str
+    certs_src: str
+    force: bool = False
+
+
+def copy_certs(dest_dir, spec):
     """Copy TLS certificates into dest_dir/certs for a secure deployment.
 
     Returns an informative note, or None when nothing applies (non-TLS deploy).
     Skips gracefully with a note when no source is configured or the source
     directory is missing. Raises OSError only on an actual copy failure.
     """
-    if deploy_type not in TLS_DEPLOY_TYPES:
+    if spec.deploy_type not in TLS_DEPLOY_TYPES:
         return None
-    if not certs_src:
-        return "Note: certs-src not set in dtaas.toml; TLS certificates not copied."
-    src = Path(certs_src)
-    if not src.is_dir():
-        return f"Note: certs-src not found ({src}); TLS certificates not copied."
+    issue = _certs_src_issue(spec.certs_src)
+    if issue:
+        return issue
     certs_dir = Path(dest_dir) / "certs"
     certs_dir.mkdir(parents=True, exist_ok=True)
-    return _copy_cert_pair(src, certs_dir, force)
+    return _copy_cert_pair(Path(spec.certs_src), certs_dir, spec.force)

--- a/cli/src/pkg/config.py
+++ b/cli/src/pkg/config.py
@@ -3,6 +3,18 @@
 from . import utils
 
 
+def _users_list_error(conf_users, key):
+    """Return an Exception describing why config.users.<key> is invalid, or None."""
+    if key not in conf_users:
+        return Exception(f"Config file error: No {key} list in 'users' tag")
+    value = conf_users[key]
+    is_list = isinstance(value, list)
+    if not is_list or not value:
+        problem = "must be a list" if not is_list else "list is empty"
+        return Exception(f"Config file error: users.{key} {problem}")
+    return None
+
+
 class Config:
     """The Config class for DTaaS"""
 
@@ -56,18 +68,11 @@ class Config:
         if err is not None or not isinstance(conf_users, dict):
             return None, err
 
-        if key not in conf_users:
-            return None, Exception(f"Config file error: No {key} list in 'users' tag")
+        err = _users_list_error(conf_users, key)
+        if err is not None:
+            return None, err
 
-        value = conf_users[key]
-        if not isinstance(value, list):
-            return None, Exception(f"Config file error: users.{key} must be a list")
-
-        strings_list = [str(x) for x in value]
-        if not strings_list:
-            return None, Exception(f"Config file error: users.{key} list is empty")
-
-        return strings_list, None
+        return [str(x) for x in conf_users[key]], None
 
     def get_path(self):
         """Gets the 'path' from config.common"""

--- a/cli/src/pkg/config_update.py
+++ b/cli/src/pkg/config_update.py
@@ -62,15 +62,13 @@ _SECRETS_HINT = (
 )
 
 
-def _summary(deploy_type, changed, head, tail, warnings=()):
-    """Build the human-readable result or dry-run preview, plus any warnings."""
+def _summary(deploy_type, changed, dry_run):
+    """Build the human-readable result or dry-run preview."""
     if not changed:
-        base = f"No configuration changes for '{deploy_type}'; nothing to update."
-    else:
-        base = f"{head} {', '.join(changed)}; {tail} all services."
-    if warnings:
-        return "\n".join([base, *warnings, _SECRETS_HINT])
-    return base
+        return f"No configuration changes for '{deploy_type}'; nothing to update."
+    if dry_run:
+        return f"Would update {', '.join(changed)}; would restart all services."
+    return f"Updated {', '.join(changed)}; restarted all services."
 
 
 def update_config(output_dir, dry_run=False):
@@ -92,9 +90,12 @@ def update_config(output_dir, dry_run=False):
     specs = deploy_config.build_file_specs(deploy_type, data)
     changed = deploy_config.diff_specs(output_dir, specs)
     if dry_run:
-        return _summary(deploy_type, changed, "Would update", "would restart")
+        return _summary(deploy_type, changed, dry_run=True)
     deploy_config.apply_config(output_dir, specs)
     if changed:
         deploy.restart_all(output_dir)
     warnings = deploy_config.check_placeholders(output_dir, specs)
-    return _summary(deploy_type, changed, "Updated", "restarted", warnings)
+    base = _summary(deploy_type, changed, dry_run=False)
+    if warnings:
+        return "\n".join([base, *warnings, _SECRETS_HINT])
+    return base

--- a/cli/src/pkg/config_validate.py
+++ b/cli/src/pkg/config_validate.py
@@ -2,140 +2,44 @@
 
 Used by 'dtaas admin config validate'. Each check returns a list of human
 readable problems (empty when acceptable); validate_config aggregates them so
-the user sees every issue at once rather than one at a time.
+the user sees every issue at once rather than one at a time. See
+validators.py for the generic, DTaaS-agnostic predicates each check builds on.
 """
 
-import ipaddress
-import re
-from pathlib import Path, PurePosixPath, PureWindowsPath
-from email_validator import EmailNotValidError, validate_email
-from fqdn import FQDN
 from . import utils
-from .constants import USERNAME_RE
-
-
-URL_RE = re.compile(r"^https?://[A-Za-z0-9.-]+(:\d+)?(/[A-Za-z0-9._~%/+-]*)?$")
-SIZE_RE = re.compile(r"^\d+(\.\d+)?\s*([kmgt]i?b?|b)$", re.IGNORECASE)
-NUMERIC_HOST_RE = re.compile(r"^[0-9.]+$")
+from .validators import (
+    get_nested,
+    is_email,
+    is_existing_dir,
+    is_host,
+    is_int,
+    is_number,
+    is_size,
+    is_string_list,
+    is_url,
+    is_username,
+    optional,
+    required,
+)
 
 _SIZE_FIELDS = (("mem_limit", "4G"), ("shm_size", "512m"))
 
 
-def _get(data, *keys):
-    """Return the nested value at *keys*, or None if any step is missing."""
-    node = data
-    for key in keys:
-        node = node.get(key) if isinstance(node, dict) else None
-    return node
-
-
-def _is_url(value):
-    """True when *value* is an http(s) URL (case-insensitive) with a host/path."""
-    return isinstance(value, str) and bool(URL_RE.match(value.lower()))
-
-
-def _is_ip(value):
-    """True when *value* is a valid IPv4 or IPv6 address."""
-    try:
-        ipaddress.ip_address(value)
-        return True
-    except ValueError:
-        return False
-
-
-def _is_fqdn(value):
-    """True when *value* is an RFC 1123 fully qualified domain name."""
-    return FQDN(value).is_valid
-
-
-def _is_host(value):
-    """True for 'localhost', an IP literal, or a dotted FQDN (numeric => IP)."""
-    if not isinstance(value, str):
-        return False
-    if NUMERIC_HOST_RE.match(value):
-        return _is_ip(value)
-    return value == "localhost" or _is_fqdn(value)
-
-
-def _is_abs_path(value):
-    """True when *value* is an absolute path in POSIX or Windows form."""
-    if not isinstance(value, str) or not value.strip():
-        return False
-    return PurePosixPath(value).is_absolute() or PureWindowsPath(value).is_absolute()
-
-
-def _is_existing_dir(value):
-    """True when *value* is an absolute path to a directory that exists."""
-    return _is_abs_path(value) and Path(value).is_dir()
-
-
-def _is_int(value):
-    """True when *value* is an integer (and not a bool, which subclasses int)."""
-    return isinstance(value, int) and not isinstance(value, bool)
-
-
-def _is_number(value):
-    """True when *value* is a positive number of cores (int or float, not bool)."""
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return False
-    return value > 0
-
-
-def _is_size(value):
-    """True when *value* is a byte size with a required unit, e.g. '4G' or '512m'."""
-    return isinstance(value, str) and bool(SIZE_RE.match(value))
-
-
-def _is_email(value):
-    """True when *value* is a valid email address (no DNS lookup)."""
-    try:
-        validate_email(value, check_deliverability=False)
-        return True
-    except (EmailNotValidError, TypeError):  # TypeError: non-string value
-        return False
-
-
-def _is_username(value):
-    """True when *value* is a non-empty username (alphanumeric plus . _ -)."""
-    return isinstance(value, str) and bool(USERNAME_RE.match(value))
-
-
-def _required(data, keys, rule):
-    """Return [message] if the value at *keys* is missing or fails *rule*.
-
-    *rule* is a (predicate, message) pair.
-    """
-    predicate, message = rule
-    value = _get(data, *keys)
-    if value is None:
-        return [".".join(keys) + " is missing"]
-    return [] if predicate(value) else [message]
-
-
-def _optional(data, keys, rule):
-    """Like _required, but a missing value is allowed (no error)."""
-    predicate, message = rule
-    value = _get(data, *keys)
-    if value is None:
-        return []
-    return [] if predicate(value) else [message]
-
-
 def _check_git_repo(data):
     """git-repo must be a URL."""
-    return _required(data, ("git-repo",), (_is_url, "git-repo must be a valid URL"))
+    return required(data, ("git-repo",), (is_url, "git-repo must be a valid URL"))
 
 
 def _check_server_dns(data):
     """common.server-dns must be a hostname or IP."""
     message = "common.server-dns must be a valid hostname or IP address"
-    return _required(data, ("common", "server-dns"), (_is_host, message))
+    return required(data, ("common", "server-dns"), (is_host, message))
 
 
 def _check_path(data):
     """common.path must be an absolute path to an existing directory."""
     message = "common.path must be an absolute path to an existing directory"
-    return _required(data, ("common", "path"), (_is_existing_dir, message))
+    return required(data, ("common", "path"), (is_existing_dir, message))
 
 
 def _check_certs_src(data):
@@ -144,7 +48,7 @@ def _check_certs_src(data):
     message = (
         "common.security.certs-src must be an absolute path to an existing directory"
     )
-    return _optional(data, keys, (_is_existing_dir, message))
+    return optional(data, keys, (is_existing_dir, message))
 
 
 def _check_resources(data):
@@ -153,35 +57,30 @@ def _check_resources(data):
     With set_limits = false the container runs uncapped, so the fields are
     optional; any values that are present are still checked.
     """
-    enabled = _get(data, "common", "resources", "set_limits") is not False
-    check = _required if enabled else _optional
+    enabled = get_nested(data, "common", "resources", "set_limits") is not False
+    check = required if enabled else optional
     cpus_msg = "common.resources.cpus must be a positive number of CPU cores"
-    errors = check(data, ("common", "resources", "cpus"), (_is_number, cpus_msg))
+    errors = check(data, ("common", "resources", "cpus"), (is_number, cpus_msg))
     pids_msg = "common.resources.pids_limit must be an integer"
-    errors += check(data, ("common", "resources", "pids_limit"), (_is_int, pids_msg))
+    errors += check(data, ("common", "resources", "pids_limit"), (is_int, pids_msg))
     for field, example in _SIZE_FIELDS:
         message = f"common.resources.{field} must include a unit, e.g. '{example}'"
-        errors += check(data, ("common", "resources", field), (_is_size, message))
+        errors += check(data, ("common", "resources", field), (is_size, message))
     return errors
 
 
-def _is_string_list(value):
-    """True when *value* is a list whose entries are all strings."""
-    return isinstance(value, list) and all(isinstance(x, str) for x in value)
-
-
-def _check_starting(data):
+def _check_default(data):
     """users.starting, when present, must be a list of strings."""
-    return _optional(
+    return optional(
         data,
         ("users", "starting"),
-        (_is_string_list, "users.starting must be a list of strings"),
+        (is_string_list, "users.starting must be a list of strings"),
     )
 
 
 def _email_error(name, info):
     """users.<name>.email must be a valid address."""
-    if _is_email(info.get("email", "")):
+    if is_email(info.get("email", "")):
         return []
     return [f"users.{name}.email is not a valid email address"]
 
@@ -189,7 +88,7 @@ def _email_error(name, info):
 def _groups_error(name, info):
     """users.<name>.groups, when present, must be a list of strings."""
     groups = info.get("groups")
-    if groups is None or _is_string_list(groups):
+    if groups is None or is_string_list(groups):
         return []
     return [f"users.{name}.groups must be a list of strings"]
 
@@ -215,7 +114,7 @@ def _user_table_errors(name, info):
 
 def _check_user_tables(data):
     """Every [users.<name>] sub-table must hold a valid email and valid tags."""
-    users = _get(data, "users")
+    users = get_nested(data, "users")
     if not isinstance(users, dict):
         return []
     errors = []
@@ -226,15 +125,15 @@ def _check_user_tables(data):
 
 # Deployment-section fields checked when present: (section, key, predicate, label).
 _DEPLOY_FIELDS = (
-    ("frontend", "react-app-oauth-url", _is_url, "URL"),
-    ("localhost", "auth-authority", _is_url, "URL"),
-    ("localhost", "default-user", _is_username, "username"),
-    ("insecure-server", "oauth-url", _is_url, "URL"),
-    ("secure-server", "oauth-url", _is_url, "URL"),
-    ("workspace-localhost", "auth-authority", _is_url, "URL"),
-    ("workspace-localhost", "default-user", _is_username, "username"),
-    ("workspace-secure-server", "keycloak-issuer-url", _is_url, "URL"),
-    ("workspace-secure-server", "auth-authority", _is_url, "URL"),
+    ("frontend", "react-app-oauth-url", is_url, "URL"),
+    ("localhost", "auth-authority", is_url, "URL"),
+    ("localhost", "default-user", is_username, "username"),
+    ("insecure-server", "oauth-url", is_url, "URL"),
+    ("secure-server", "oauth-url", is_url, "URL"),
+    ("workspace-localhost", "auth-authority", is_url, "URL"),
+    ("workspace-localhost", "default-user", is_username, "username"),
+    ("workspace-secure-server", "keycloak-issuer-url", is_url, "URL"),
+    ("workspace-secure-server", "auth-authority", is_url, "URL"),
 )
 
 
@@ -243,7 +142,7 @@ def _check_deploy_fields(data):
     errors = []
     for section, key, predicate, label in _DEPLOY_FIELDS:
         message = f"{section}.{key} must be a valid {label}"
-        errors += _optional(data, (section, key), (predicate, message))
+        errors += optional(data, (section, key), (predicate, message))
     return errors
 
 
@@ -253,7 +152,7 @@ _CHECKS = (
     _check_path,
     _check_certs_src,
     _check_resources,
-    _check_starting,
+    _check_default,
     _check_user_tables,
     _check_deploy_fields,
 )

--- a/cli/src/pkg/config_validate.py
+++ b/cli/src/pkg/config_validate.py
@@ -11,15 +11,14 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from email_validator import EmailNotValidError, validate_email
 from fqdn import FQDN
 from . import utils
+from .constants import USERNAME_RE
 
 
 URL_RE = re.compile(r"^https?://[A-Za-z0-9.-]+(:\d+)?(/[A-Za-z0-9._~%/+-]*)?$")
 SIZE_RE = re.compile(r"^\d+(\.\d+)?\s*([kmgt]i?b?|b)$", re.IGNORECASE)
-USERNAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 NUMERIC_HOST_RE = re.compile(r"^[0-9.]+$")
 
 _SIZE_FIELDS = (("mem_limit", "4G"), ("shm_size", "512m"))
-_LIST_FIELDS = ("add", "delete")
 
 
 def _get(data, *keys):
@@ -166,32 +165,58 @@ def _is_string_list(value):
     return isinstance(value, list) and all(isinstance(x, str) for x in value)
 
 
-def _check_user_lists(data):
-    """users.add and users.delete, when present, must be lists of strings."""
-    errors = []
-    for field in _LIST_FIELDS:
-        message = f"users.{field} must be a list of strings"
-        errors += _optional(data, ("users", field), _is_string_list, message)
-    return errors
+def _check_starting(data):
+    """users.starting, when present, must be a list of strings."""
+    return _optional(
+        data,
+        ("users", "starting"),
+        _is_string_list,
+        "users.starting must be a list of strings",
+    )
 
 
 def _email_error(name, info):
-    """Return an error for a user sub-table whose email is missing or invalid."""
-    if not isinstance(info, dict):
-        return []
+    """users.<name>.email must be a valid address."""
     if _is_email(info.get("email", "")):
         return []
     return [f"users.{name}.email is not a valid email address"]
 
 
-def _check_emails(data):
-    """Every [users.<name>] sub-table must hold a valid email."""
+def _groups_error(name, info):
+    """users.<name>.groups, when present, must be a list of strings."""
+    groups = info.get("groups")
+    if groups is None or _is_string_list(groups):
+        return []
+    return [f"users.{name}.groups must be a list of strings"]
+
+
+def _load_balance_error(name, info):
+    """users.<name>.load_balance, when present, must be a boolean."""
+    load_balance = info.get("load_balance")
+    if load_balance is None or isinstance(load_balance, bool):
+        return []
+    return [f"users.{name}.load_balance must be true or false"]
+
+
+def _user_table_errors(name, info):
+    """Validate one [users.<name>] sub-table; the starting list is not a table."""
+    if not isinstance(info, dict):
+        return []
+    return (
+        _email_error(name, info)
+        + _groups_error(name, info)
+        + _load_balance_error(name, info)
+    )
+
+
+def _check_user_tables(data):
+    """Every [users.<name>] sub-table must hold a valid email and valid tags."""
     users = _get(data, "users")
     if not isinstance(users, dict):
         return []
     errors = []
     for name, info in users.items():
-        errors += _email_error(name, info)
+        errors += _user_table_errors(name, info)
     return errors
 
 
@@ -224,8 +249,8 @@ _CHECKS = (
     _check_path,
     _check_certs_src,
     _check_resources,
-    _check_user_lists,
-    _check_emails,
+    _check_starting,
+    _check_user_tables,
     _check_deploy_fields,
 )
 

--- a/cli/src/pkg/config_validate.py
+++ b/cli/src/pkg/config_validate.py
@@ -100,16 +100,21 @@ def _is_username(value):
     return isinstance(value, str) and bool(USERNAME_RE.match(value))
 
 
-def _required(data, keys, predicate, message):
-    """Return [message] if the value at *keys* is missing or fails *predicate*."""
+def _required(data, keys, rule):
+    """Return [message] if the value at *keys* is missing or fails *rule*.
+
+    *rule* is a (predicate, message) pair.
+    """
+    predicate, message = rule
     value = _get(data, *keys)
     if value is None:
         return [".".join(keys) + " is missing"]
     return [] if predicate(value) else [message]
 
 
-def _optional(data, keys, predicate, message):
+def _optional(data, keys, rule):
     """Like _required, but a missing value is allowed (no error)."""
+    predicate, message = rule
     value = _get(data, *keys)
     if value is None:
         return []
@@ -118,19 +123,19 @@ def _optional(data, keys, predicate, message):
 
 def _check_git_repo(data):
     """git-repo must be a URL."""
-    return _required(data, ("git-repo",), _is_url, "git-repo must be a valid URL")
+    return _required(data, ("git-repo",), (_is_url, "git-repo must be a valid URL"))
 
 
 def _check_server_dns(data):
     """common.server-dns must be a hostname or IP."""
     message = "common.server-dns must be a valid hostname or IP address"
-    return _required(data, ("common", "server-dns"), _is_host, message)
+    return _required(data, ("common", "server-dns"), (_is_host, message))
 
 
 def _check_path(data):
     """common.path must be an absolute path to an existing directory."""
     message = "common.path must be an absolute path to an existing directory"
-    return _required(data, ("common", "path"), _is_existing_dir, message)
+    return _required(data, ("common", "path"), (_is_existing_dir, message))
 
 
 def _check_certs_src(data):
@@ -139,7 +144,7 @@ def _check_certs_src(data):
     message = (
         "common.security.certs-src must be an absolute path to an existing directory"
     )
-    return _optional(data, keys, _is_existing_dir, message)
+    return _optional(data, keys, (_is_existing_dir, message))
 
 
 def _check_resources(data):
@@ -151,12 +156,12 @@ def _check_resources(data):
     enabled = _get(data, "common", "resources", "set_limits") is not False
     check = _required if enabled else _optional
     cpus_msg = "common.resources.cpus must be a positive number of CPU cores"
-    errors = check(data, ("common", "resources", "cpus"), _is_number, cpus_msg)
+    errors = check(data, ("common", "resources", "cpus"), (_is_number, cpus_msg))
     pids_msg = "common.resources.pids_limit must be an integer"
-    errors += check(data, ("common", "resources", "pids_limit"), _is_int, pids_msg)
+    errors += check(data, ("common", "resources", "pids_limit"), (_is_int, pids_msg))
     for field, example in _SIZE_FIELDS:
         message = f"common.resources.{field} must include a unit, e.g. '{example}'"
-        errors += check(data, ("common", "resources", field), _is_size, message)
+        errors += check(data, ("common", "resources", field), (_is_size, message))
     return errors
 
 
@@ -170,8 +175,7 @@ def _check_starting(data):
     return _optional(
         data,
         ("users", "starting"),
-        _is_string_list,
-        "users.starting must be a list of strings",
+        (_is_string_list, "users.starting must be a list of strings"),
     )
 
 
@@ -239,7 +243,7 @@ def _check_deploy_fields(data):
     errors = []
     for section, key, predicate, label in _DEPLOY_FIELDS:
         message = f"{section}.{key} must be a valid {label}"
-        errors += _optional(data, (section, key), predicate, message)
+        errors += _optional(data, (section, key), (predicate, message))
     return errors
 
 

--- a/cli/src/pkg/config_validate.py
+++ b/cli/src/pkg/config_validate.py
@@ -69,7 +69,7 @@ def _check_resources(data):
     return errors
 
 
-def _check_default(data):
+def _check_starting(data):
     """users.starting, when present, must be a list of strings."""
     return optional(
         data,
@@ -152,7 +152,7 @@ _CHECKS = (
     _check_path,
     _check_certs_src,
     _check_resources,
-    _check_default,
+    _check_starting,
     _check_user_tables,
     _check_deploy_fields,
 )

--- a/cli/src/pkg/constants.py
+++ b/cli/src/pkg/constants.py
@@ -1,2 +1,8 @@
+import re
+
 # For users.py
 COMPOSE_USERS_YML = "compose.users.yml"
+
+# A safe username: alphanumeric plus . _ - only, so it never carries shell
+# metacharacters, whitespace, or path separators into container commands.
+USERNAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")

--- a/cli/src/pkg/constants.py
+++ b/cli/src/pkg/constants.py
@@ -6,3 +6,14 @@ COMPOSE_USERS_YML = "compose.users.yml"
 # A safe username: alphanumeric plus . _ - only, so it never carries shell
 # metacharacters, whitespace, or path separators into container commands.
 USERNAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+# For pkg/validators.py
+URL_RE = re.compile(r"^https?://[A-Za-z0-9.-]+(:\d+)?(/[A-Za-z0-9._~%/+-]*)?$")
+SIZE_RE = re.compile(r"^\d+(\.\d+)?\s*([kmgt]i?b?|b)$", re.IGNORECASE)
+NUMERIC_HOST_RE = re.compile(r"^[0-9.]+$")
+
+# For users_utils.py: rule.onlyu<N>. prefixes in config/conf.server.
+CONF_SERVER_RULE_NUM_RE = re.compile(r"rule\.onlyu(\d+)\.")
+
+# For deploy_config.py: username<N>/email<N> pseudo-keys under [users].
+USER_PSEUDO_KEY_RE = re.compile(r"(username|email)(\d+)$")

--- a/cli/src/pkg/constants.py
+++ b/cli/src/pkg/constants.py
@@ -1,7 +1,16 @@
 import re
 
-# For users.py
+# For users.py / deploy.py
 COMPOSE_USERS_YML = "compose.users.yml"
+
+# For registry.py
+REGISTRY_FILE = "dtaas.users.registry.json"
+
+# For state.py
+STATE_FILE = ".dtaas.state.json"
+
+# For utils.py
+LOCALHOST_SERVER = "localhost"
 
 # A safe username: alphanumeric plus . _ - only, so it never carries shell
 # metacharacters, whitespace, or path separators into container commands.

--- a/cli/src/pkg/deploy.py
+++ b/cli/src/pkg/deploy.py
@@ -5,9 +5,9 @@ from pathlib import Path
 import yaml
 from python_on_whales import DockerClient
 from python_on_whales.utils import ValidPath
+from .constants import COMPOSE_USERS_YML
 
 COMPOSE_FILE = "docker-compose.yml"
-USERS_COMPOSE_FILE = "compose.users.yml"
 USER_FILES_DIR = "files"
 ENV_FILE = Path("config") / ".env"
 # files/ entries provided by the deployment template (shared workspace and the
@@ -38,7 +38,7 @@ def _users_client(directory):
     Users added via 'dtaas admin user add' run from compose.users.yml as a
     separate compose project, so the main compose file does not know about them.
     """
-    users_compose = Path(directory) / USERS_COMPOSE_FILE
+    users_compose = Path(directory) / COMPOSE_USERS_YML
     if not users_compose.is_file():
         return None
     return DockerClient(compose_files=[str(users_compose)])

--- a/cli/src/pkg/deploy_config.py
+++ b/cli/src/pkg/deploy_config.py
@@ -28,17 +28,26 @@ def _set_yaml_value(text, key, value):
 _SETTERS = {"env": _set_env_value, "js": _set_js_value, "yaml": _set_yaml_value}
 
 
-def _user_value(users, key):
-    """Resolve a ``username<N>`` or ``email<N>`` pseudo-key from [users]."""
+def _resolved_starting_index(users, key):
+    """Parse a ``username<N>``/``email<N>`` key into (field, index, starting), or None."""
     m = re.match(r"(username|email)(\d+)$", key)
     if not m:
-        return ""
+        return None
     index = int(m.group(2)) - 1
     starting = users.get("starting", [])
     if index >= len(starting):
+        return None
+    return m.group(1), index, starting
+
+
+def _user_value(users, key):
+    """Resolve a ``username<N>`` or ``email<N>`` pseudo-key from [users]."""
+    resolved = _resolved_starting_index(users, key)
+    if resolved is None:
         return ""
+    field, index, starting = resolved
     username = str(starting[index]).strip()
-    if m.group(1) == "username":
+    if field == "username":
         return username
     section = users.get(username, {})
     return str(section.get("email", "")).strip() if isinstance(section, dict) else ""
@@ -101,16 +110,22 @@ def _missing_placeholder_warnings(text, rel_path):
     ]
 
 
+def _placeholder_warnings_for_file(dest_dir, rel_path):
+    """Return placeholder warnings for one generated file, or [] if unreadable/missing."""
+    path = Path(dest_dir) / rel_path
+    if not path.is_file():
+        return []
+    text = _read_file_text(path)
+    if text is None:
+        return []
+    return _missing_placeholder_warnings(text, rel_path)
+
+
 def check_placeholders(dest_dir, specs):
     """Return warnings for known secret placeholders still present after substitution."""
     warnings = []
     for rel_path, _, _ in specs:
-        path = Path(dest_dir) / rel_path
-        if not path.is_file():
-            continue
-        text = _read_file_text(path)
-        if text is not None:
-            warnings.extend(_missing_placeholder_warnings(text, rel_path))
+        warnings.extend(_placeholder_warnings_for_file(dest_dir, rel_path))
     return warnings
 
 
@@ -146,14 +161,20 @@ def _apply_to_file(path, file_format, values):
     return None
 
 
+def _apply_one_error(dest_dir, spec):
+    """Apply one (rel_path, file_format, values) spec; return an error string, or None."""
+    rel_path, file_format, values = spec
+    path = Path(dest_dir) / rel_path
+    if not path.is_file():
+        return None
+    return _apply_to_file(path, file_format, values)
+
+
 def _collect_apply_errors(dest_dir, specs):
     """Apply substitution specs and return a list of error strings."""
     errors = []
-    for rel_path, file_format, values in specs:
-        path = Path(dest_dir) / rel_path
-        if not path.is_file():
-            continue
-        err = _apply_to_file(path, file_format, values)
+    for spec in specs:
+        err = _apply_one_error(dest_dir, spec)
         if err:
             errors.append(err)
     return errors

--- a/cli/src/pkg/deploy_config.py
+++ b/cli/src/pkg/deploy_config.py
@@ -3,6 +3,7 @@
 import re
 from pathlib import Path
 from ._deploy_data import _DEPLOY_FILES, _SECRET_PLACEHOLDERS
+from .constants import USER_PSEUDO_KEY_RE
 
 
 def _set_env_value(text, key, value):
@@ -30,7 +31,7 @@ _SETTERS = {"env": _set_env_value, "js": _set_js_value, "yaml": _set_yaml_value}
 
 def _resolved_starting_index(users, key):
     """Parse a ``username<N>``/``email<N>`` key into (field, index, starting), or None."""
-    m = re.match(r"(username|email)(\d+)$", key)
+    m = USER_PSEUDO_KEY_RE.match(key)
     if not m:
         return None
     index = int(m.group(2)) - 1

--- a/cli/src/pkg/deploy_config.py
+++ b/cli/src/pkg/deploy_config.py
@@ -34,10 +34,10 @@ def _user_value(users, key):
     if not m:
         return ""
     index = int(m.group(2)) - 1
-    add = users.get("add", [])
-    if index >= len(add):
+    starting = users.get("starting", [])
+    if index >= len(starting):
         return ""
-    username = str(add[index]).strip()
+    username = str(starting[index]).strip()
     if m.group(1) == "username":
         return username
     section = users.get(username, {})

--- a/cli/src/pkg/project.py
+++ b/cli/src/pkg/project.py
@@ -79,16 +79,28 @@ def generate_project(dest_dir=".", force=False):
     _create_workspace_dirs(dest_dir)
 
 
+def _copy_config_file(template_name, dest_dir, force):
+    """Copy one config template into dest_dir, echoing when skipped.
+
+    Returns True if the existing file was kept (skipped), else False.
+    Raises OSError on copy failure.
+    """
+    skipped = _copy_template(template_name, dest_dir, force)
+    if skipped:
+        click.echo(f"'{template_name}' already exists, skipping")
+    return skipped
+
+
 def generate_config(dest_dir=".", force=False):
-    """Copy only the dtaas.toml template into dest_dir for the user to fill in.
+    """Copy the dtaas.toml and sample users.csv templates into dest_dir.
 
     Returns True if an existing dtaas.toml was kept (skipped), False if it was
-    written. Raises OSError on copy failure.
+    written. The users.csv sample is copied alongside it (skipped if present).
+    Raises OSError on copy failure.
     """
     _validate_project_inputs(dest_dir)
-    skipped = _copy_template("dtaas.toml", dest_dir, force)
-    if skipped:
-        click.echo("'dtaas.toml' already exists, skipping")
+    skipped = _copy_config_file("dtaas.toml", dest_dir, force)
+    _copy_config_file("users.csv", dest_dir, force)
     return skipped
 
 

--- a/cli/src/pkg/registry.py
+++ b/cli/src/pkg/registry.py
@@ -108,4 +108,4 @@ def _parse_csv_row(row):
 def read_csv_users(csv_path):
     """Return {username: details} parsed from a users CSV file."""
     with open(csv_path, newline="", encoding="utf-8") as handle:
-        return dict(_parse_csv_row(row) for row in csv.DictReader(handle))
+        return dict(map(_parse_csv_row, csv.DictReader(handle)))

--- a/cli/src/pkg/registry.py
+++ b/cli/src/pkg/registry.py
@@ -1,0 +1,71 @@
+"""The CLI-owned user registry, dtaas.users.registry.json.
+
+A store of the *additional* users provisioned by 'dtaas admin user add' /
+'delete', mutated directly and atomically by the CLI and never hand-edited,
+the way useradd owns /etc/passwd. Starting users live in dtaas.toml instead;
+deployment settings (server, path, resources, TLS) also come from dtaas.toml.
+
+Shape:
+    {"users": {"alice": {"email": ..., "groups": [...], "load_balance": bool}}}
+"""
+
+import csv
+import json
+import os
+from pathlib import Path
+
+REGISTRY_FILE = "dtaas.users.registry.json"
+
+
+def load_registry(path=REGISTRY_FILE):
+    """Return the registry's user store ({name: details}); empty when absent."""
+    file = Path(path)
+    if not file.is_file():
+        return {}
+    data = json.loads(file.read_text(encoding="utf-8"))
+    users = data.get("users") if isinstance(data, dict) else None
+    return users if isinstance(users, dict) else {}
+
+
+def _write_registry(users, path):
+    """Atomically persist the user store to *path* (temp file + os.replace)."""
+    text = json.dumps({"users": users}, indent=2) + "\n"
+    tmp = f"{path}.tmp"
+    Path(tmp).write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def add_to_registry(new_users, path=REGISTRY_FILE):
+    """Merge *new_users* ({name: details}) into the store and persist it."""
+    users = load_registry(path)
+    users.update(new_users)
+    _write_registry(users, path)
+    return users
+
+
+def remove_from_registry(usernames, path=REGISTRY_FILE):
+    """Drop *usernames* from the store and persist it; returns the removed names."""
+    users = load_registry(path)
+    removed = [name for name in usernames if users.pop(name, None) is not None]
+    _write_registry(users, path)
+    return removed
+
+
+def _parse_csv_row(row):
+    """Convert one users.csv row into (username, details).
+
+    'groups' is a ';'-separated cell and 'load_balance' is a true/false string.
+    """
+    groups = [g for g in row.get("groups", "").split(";") if g]
+    details = {
+        "email": row.get("email", "").strip(),
+        "groups": groups,
+        "load_balance": row.get("load_balance", "").strip().lower() == "true",
+    }
+    return row["username"].strip(), details
+
+
+def read_csv_users(csv_path):
+    """Return {username: details} parsed from a users CSV file."""
+    with open(csv_path, newline="", encoding="utf-8") as handle:
+        return dict(_parse_csv_row(row) for row in csv.DictReader(handle))

--- a/cli/src/pkg/registry.py
+++ b/cli/src/pkg/registry.py
@@ -13,8 +13,7 @@ import csv
 import json
 import os
 from pathlib import Path
-
-REGISTRY_FILE = "dtaas.users.registry.json"
+from .constants import REGISTRY_FILE
 
 
 def load_registry(path=REGISTRY_FILE):

--- a/cli/src/pkg/registry.py
+++ b/cli/src/pkg/registry.py
@@ -28,19 +28,44 @@ def load_registry(path=REGISTRY_FILE):
 
 
 def _write_registry(users, path):
-    """Atomically persist the user store to *path* (temp file + os.replace)."""
+    """Atomically persist the user store to *path* (temp file + os.replace).
+
+    The temp file is flushed and fsync'd before the rename so a crash or power
+    loss cannot leave a truncated registry behind.
+    """
     text = json.dumps({"users": users}, indent=2) + "\n"
     tmp = f"{path}.tmp"
-    Path(tmp).write_text(text, encoding="utf-8")
+    with open(tmp, "w", encoding="utf-8") as handle:
+        handle.write(text)
+        handle.flush()
+        os.fsync(handle.fileno())
     os.replace(tmp, path)
 
 
-def add_to_registry(new_users, path=REGISTRY_FILE):
-    """Merge *new_users* ({name: details}) into the store and persist it."""
+def _partition_new(new_users, known):
+    """Split new_users into ({name: details} to add, [names] to skip)."""
+    added, skipped = {}, []
+    for name, details in new_users.items():
+        if name in known:
+            skipped.append(name)
+        else:
+            added[name] = details
+    return added, skipped
+
+
+def register_new_users(new_users, reserved, path=REGISTRY_FILE):
+    """Merge new_users into the store, skipping names that already exist.
+
+    Names in *reserved* (dtaas.toml's starting users) or already present in the
+    registry are skipped rather than overwritten, so a user can never end up in
+    both files. Returns (added_names, skipped_names).
+    """
     users = load_registry(path)
-    users.update(new_users)
+    known = set(users) | set(reserved)
+    added, skipped = _partition_new(new_users, known)
+    users.update(added)
     _write_registry(users, path)
-    return users
+    return list(added), skipped
 
 
 def remove_from_registry(usernames, path=REGISTRY_FILE):
@@ -51,16 +76,31 @@ def remove_from_registry(usernames, path=REGISTRY_FILE):
     return removed
 
 
+def _parse_load_balance(value):
+    """Parse a true/false load_balance cell; reject other non-empty values.
+
+    An empty cell defaults to False; any value other than true/false is
+    rejected so a typo never silently provisions with unintended settings.
+    """
+    text = value.strip().lower()
+    if text in ("", "false"):
+        return False
+    if text == "true":
+        return True
+    raise ValueError(f"Invalid load_balance '{value}': expected 'true' or 'false'.")
+
+
 def _parse_csv_row(row):
     """Convert one users.csv row into (username, details).
 
-    'groups' is a ';'-separated cell and 'load_balance' is a true/false string.
+    'groups' is a ';'-separated cell (each tag stripped; an empty cell defaults
+    to ['additional']) and 'load_balance' must be a true/false string.
     """
-    groups = [g for g in row.get("groups", "").split(";") if g]
+    groups = [g.strip() for g in row.get("groups", "").split(";") if g.strip()]
     details = {
         "email": row.get("email", "").strip(),
-        "groups": groups,
-        "load_balance": row.get("load_balance", "").strip().lower() == "true",
+        "groups": groups or ["additional"],
+        "load_balance": _parse_load_balance(row.get("load_balance", "")),
     }
     return row["username"].strip(), details
 

--- a/cli/src/pkg/registry.py
+++ b/cli/src/pkg/registry.py
@@ -105,6 +105,16 @@ def _parse_csv_row(row):
 
 
 def read_csv_users(csv_path):
-    """Return {username: details} parsed from a users CSV file."""
+    """Return {username: details} parsed from a users CSV file.
+
+    Raises ValueError if the same username appears in more than one row, so a
+    duplicate can never silently overwrite an earlier row's details.
+    """
+    users = {}
     with open(csv_path, newline="", encoding="utf-8") as handle:
-        return dict(map(_parse_csv_row, csv.DictReader(handle)))
+        for row in csv.DictReader(handle):
+            username, details = _parse_csv_row(row)
+            if username in users:
+                raise ValueError(f"Duplicate username '{username}' in {csv_path}")
+            users[username] = details
+    return users

--- a/cli/src/pkg/state.py
+++ b/cli/src/pkg/state.py
@@ -19,9 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from python_on_whales import DockerClient
 from python_on_whales.exceptions import DockerException
-from .constants import COMPOSE_USERS_YML
-
-STATE_FILE = ".dtaas.state.json"
+from .constants import COMPOSE_USERS_YML, STATE_FILE
 
 
 def config_hash(service):

--- a/cli/src/pkg/state.py
+++ b/cli/src/pkg/state.py
@@ -1,0 +1,63 @@
+"""The CLI-owned runtime state cache, .dtaas.state.json (never git-tracked).
+
+Observed facts about provisioned user containers -- config hash, provisioning
+time, and best-effort container id/status -- written whenever 'dtaas admin user
+add'/'delete' changes the running set. The config hash lets a later run detect
+which users have drifted from the config they were provisioned with.
+"""
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from python_on_whales import DockerClient
+from python_on_whales.exceptions import DockerException
+from .constants import COMPOSE_USERS_YML
+
+STATE_FILE = ".dtaas.state.json"
+
+
+def config_hash(service):
+    """Return a stable sha256 over a user's compose service config."""
+    blob = json.dumps(service, sort_keys=True).encode("utf-8")
+    return "sha256:" + hashlib.sha256(blob).hexdigest()
+
+
+def _service_facts():
+    """Best-effort {service: (container_id, status)} for compose.users.yml.
+
+    Returns an empty mapping when Docker is unreachable; the state cache then
+    records config hashes without live container facts.
+    """
+    try:
+        containers = DockerClient(compose_files=[COMPOSE_USERS_YML]).compose.ps()
+    except DockerException:
+        return {}
+    facts = {}
+    for container in containers:
+        labels = container.config.labels or {}
+        service = labels.get("com.docker.compose.service", container.name)
+        facts[service] = (container.id, container.state.status)
+    return facts
+
+
+def build_state(services, facts):
+    """Build the {username: runtime facts} mapping for provisioned services."""
+    now = datetime.now(timezone.utc).isoformat()
+    state = {}
+    for username, service in services.items():
+        container_id, status = facts.get(username, (None, None))
+        state[username] = {
+            "container_id": container_id,
+            "status": status,
+            "provisioned_at": now,
+            "config_hash": config_hash(service),
+        }
+    return state
+
+
+def write_state(services, path=STATE_FILE):
+    """Write .dtaas.state.json for the currently provisioned services."""
+    state = build_state(services, _service_facts())
+    Path(path).write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+    return state

--- a/cli/src/pkg/state.py
+++ b/cli/src/pkg/state.py
@@ -61,3 +61,40 @@ def write_state(services, path=STATE_FILE):
     state = build_state(services, _service_facts())
     Path(path).write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
     return state
+
+
+def load_state(path=STATE_FILE):
+    """Load the runtime state cache, returning {} when the file is absent."""
+    file = Path(path)
+    if not file.is_file():
+        return {}
+    return json.loads(file.read_text(encoding="utf-8"))
+
+
+def _missing(names, other):
+    """Names present in *names* but absent from *other*."""
+    return [name for name in names if name not in other]
+
+
+def _drifted_users(state, services):
+    """Users whose current compose config differs from the provisioned hash."""
+    drifted = []
+    for user, service in services.items():
+        stored = state.get(user)
+        if stored is not None and stored.get("config_hash") != config_hash(service):
+            drifted.append(user)
+    return drifted
+
+
+def find_drift(state, services):
+    """Compare the state cache against the current compose services.
+
+    Returns {'drifted', 'untracked', 'orphaned'} username lists: drifted =
+    config changed since provisioning; untracked = provisioned but absent from
+    the state cache; orphaned = in the state cache but no longer provisioned.
+    """
+    return {
+        "drifted": _drifted_users(state, services),
+        "untracked": _missing(services, state),
+        "orphaned": _missing(state, services),
+    }

--- a/cli/src/pkg/state.py
+++ b/cli/src/pkg/state.py
@@ -2,8 +2,15 @@
 
 Observed facts about provisioned user containers -- config hash, provisioning
 time, and best-effort container id/status -- written whenever 'dtaas admin user
-add'/'delete' changes the running set. The config hash lets a later run detect
-which users have drifted from the config they were provisioned with.
+add'/'delete' changes the running set. Each write fully replaces the file's
+contents with the current set of provisioned services: it is a point-in-time
+snapshot, not an append-only log, so it only ever reflects the most recent
+add/delete. The config hash lets a later run detect which users' running
+config has changed since they were provisioned.
+
+dtaas.users.registry.json remains the source of truth for who *should* be
+provisioned; this cache only records what the CLI last observed. See
+find_drift(), which compares the two against the live compose services.
 """
 
 import hashlib
@@ -76,25 +83,34 @@ def _missing(names, other):
     return [name for name in names if name not in other]
 
 
-def _drifted_users(state, services):
-    """Users whose current compose config differs from the provisioned hash."""
+def _drifted_users(registry_users, state, services):
+    """Registry users whose live compose config no longer matches the hash
+    recorded the last time they were provisioned.
+
+    A user with no recorded hash (state cache missing or stale) is not
+    flagged, since there is nothing to compare against -- that gap is exactly
+    what 'missing'/'unexpected' below are for.
+    """
     drifted = []
-    for user, service in services.items():
-        stored = state.get(user)
-        if stored is not None and stored.get("config_hash") != config_hash(service):
-            drifted.append(user)
+    for name in registry_users:
+        service, recorded = services.get(name), state.get(name)
+        if service is not None and recorded is not None:
+            if recorded.get("config_hash") != config_hash(service):
+                drifted.append(name)
     return drifted
 
 
-def find_drift(state, services):
-    """Compare the state cache against the current compose services.
+def find_drift(registry_users, state, services):
+    """Compare the registry (desired) against the live compose services (actual).
 
-    Returns {'drifted', 'untracked', 'orphaned'} username lists: drifted =
-    config changed since provisioning; untracked = provisioned but absent from
-    the state cache; orphaned = in the state cache but no longer provisioned.
+    Returns {'missing', 'unexpected', 'drifted'} username lists: missing =
+    registered but not currently provisioned (re-run 'user add'); unexpected =
+    provisioned but not in the registry (investigate -- may be a manual edit or
+    a partial delete); drifted = provisioned with a config that no longer
+    matches what was recorded when it was last provisioned.
     """
     return {
-        "drifted": _drifted_users(state, services),
-        "untracked": _missing(services, state),
-        "orphaned": _missing(state, services),
+        "missing": _missing(registry_users, services),
+        "unexpected": _missing(services, registry_users),
+        "drifted": _drifted_users(registry_users, state, services),
     }

--- a/cli/src/pkg/users.py
+++ b/cli/src/pkg/users.py
@@ -138,7 +138,8 @@ def _delete_context(usernames):
     utils.check_error(err)
     if compose is None:
         raise ValueError("Failed to load compose configuration")
-    existing_services = compose.get("services", {})
+    services = compose.get("services")
+    existing_services = services if isinstance(services, dict) else {}
     existing, missing = categorize_users(list(usernames), existing_services)
     report_missing_users(missing)
     return compose, existing

--- a/cli/src/pkg/users.py
+++ b/cli/src/pkg/users.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 from . import utils
 from .constants import COMPOSE_USERS_YML
@@ -34,14 +35,14 @@ def _load_template(server, tls):
         return None, Exception("user add is not supported for localhost installations")
     name = "users.server.secure.yml" if tls else "users.server.yml"
     template, err = utils.import_yaml(name)
-    if err is not None:
-        return None, err
-    if not template:
-        return None, Exception(
+    if err is None and not template:
+        err = Exception(
             f"User workspace template '{name}' is missing or empty in this "
             "directory. Run 'dtaas generate-project' (or "
             "'dtaas generate-deployment') here first."
         )
+    if err is not None:
+        return None, err
     return template, None
 
 
@@ -84,18 +85,23 @@ def get_compose_config(username, config):
     return result, None
 
 
+def _create_one_user_dir(username, file_path):
+    """Copy the template into username's workspace dir and chown it (best-effort)."""
+    user_dir = Path(file_path) / username
+    shutil.copytree(Path(file_path) / "template", user_dir, dirs_exist_ok=True)
+    try:
+        shutil.chown(user_dir, user=1000, group=100)
+        for item in user_dir.rglob("*"):
+            shutil.chown(item, user=1000, group=100)
+    except (AttributeError, PermissionError):
+        # Skip os.chown in tests to avoid PermissionError
+        pass
+
+
 def create_user_files(users, file_path):
     """Creates all the users' workspace directories"""
     for username in users:
-        user_dir = Path(file_path) / username
-        shutil.copytree(Path(file_path) / "template", user_dir, dirs_exist_ok=True)
-        try:
-            shutil.chown(user_dir, user=1000, group=100)
-            for item in user_dir.rglob("*"):
-                shutil.chown(item, user=1000, group=100)
-        except (AttributeError, PermissionError):
-            # Skip os.chown in tests to avoid PermissionError
-            pass
+        _create_one_user_dir(username, file_path)
     return None
 
 
@@ -185,52 +191,114 @@ def _finalize_compose(compose):
     write_state(compose["services"])
 
 
+@dataclass
+class _AddContext:
+    """Everything needed to provision the registry's users."""
+
+    compose: dict
+    user_list: list
+    users_section: dict
+    config: dict
+
+
+def _load_add_context(config_obj):
+    """Load compose, registry users, and deploy config for provisioning.
+
+    Returns an _AddContext, or None when the registry is empty (nothing to
+    provision). Raises on any other error.
+    """
+    compose, err = utils.import_yaml(COMPOSE_USERS_YML)
+    utils.check_error(err)
+    compose = compose or {}
+    user_list, users_section = _get_registry_users()
+    if not user_list:
+        return None
+    validate_usernames(user_list)
+    server, path, resources, tls, set_limits = _get_deploy_config(config_obj)
+    config = {
+        "server": server,
+        "path": path,
+        "resources": resources,
+        "tls": tls,
+        "set_limits": set_limits,
+    }
+    return _AddContext(compose, user_list, users_section, config)
+
+
+def _authorise_user(username, users_section):
+    """Validate username/email are newline-free, then add the forward-auth rule.
+
+    Raises ValueError if either contains a newline (which would corrupt
+    conf.server).
+    """
+    section = (users_section or {}).get(username, {})
+    email = str(section.get("email", "") if isinstance(section, dict) else "").strip()
+    if any(c in username for c in ("\n", "\r")) or any(
+        c in email for c in ("\n", "\r")
+    ):
+        raise ValueError(
+            f"Invalid user config for '{username}': "
+            "username/email must not contain newlines"
+        )
+    add_conf_server_entry(username, email)
+
+
+def _provision_users(ctx):
+    """Create workspace files, compose entries, and forward-auth rules.
+
+    Authorising each user in the forward-auth config happens before starting
+    their container: writing conf.server first means a later 'compose up'
+    failure cannot leave the forward-auth rules stale.
+    """
+    create_user_files(ctx.user_list, ctx.config["path"] + "/files")
+    err = add_users_to_compose(ctx.user_list, ctx.compose, ctx.config)
+    utils.check_error(err)
+    for username in ctx.user_list:
+        _authorise_user(username, ctx.users_section)
+    _finalize_compose(ctx.compose)
+
+
 def add_users(config_obj):
     """add cli command handler"""
     try:
-        compose, err = utils.import_yaml(COMPOSE_USERS_YML)
-        utils.check_error(err)
-        user_list, users_section = _get_registry_users()
-        if not user_list:
+        ctx = _load_add_context(config_obj)
+        if ctx is None:
             return None  # empty registry: nothing to provision
-        validate_usernames(user_list)
-        server, path, resources, tls, set_limits = _get_deploy_config(config_obj)
+        _setup_compose_structure(ctx.compose)
+        _provision_users(ctx)
     except Exception as e:
         return e
-
-    _setup_compose_structure(compose)
-
-    try:
-        create_user_files(user_list, path + "/files")
-        config = {
-            "server": server,
-            "path": path,
-            "resources": resources,
-            "tls": tls,
-            "set_limits": set_limits,
-        }
-        err = add_users_to_compose(user_list, compose, config)
-        utils.check_error(err)
-        # Authorise each user in the forward-auth config before starting their
-        # container. Writing conf.server first means a later 'compose up'
-        # failure cannot leave the forward-auth rules stale.
-        for username in user_list:
-            section = (users_section or {}).get(username, {})
-            email = str(
-                section.get("email", "") if isinstance(section, dict) else ""
-            ).strip()
-            if any(c in username for c in ("\n", "\r")) or any(
-                c in email for c in ("\n", "\r")
-            ):
-                raise ValueError(
-                    f"Invalid user config for '{username}': username/email must not contain newlines"
-                )
-            add_conf_server_entry(username, email)
-        _finalize_compose(compose)
-    except Exception as e:
-        return e
-
     return None
+
+
+def _delete_context(usernames):
+    """Validate usernames and load compose, returning (compose, existing users).
+
+    Raises on validation/import failure or a missing compose file.
+    """
+    validate_usernames(usernames)
+    compose, err = utils.import_yaml(COMPOSE_USERS_YML)
+    utils.check_error(err)
+    if compose is None:
+        raise ValueError("Failed to load compose configuration")
+    existing_services = compose.get("services", {})
+    existing, missing = categorize_users(list(usernames), existing_services)
+    report_missing_users(missing)
+    return compose, existing
+
+
+def _remove_users(compose, existing, usernames):
+    """Stop containers, rewrite compose, clear auth rules, and update state."""
+    if existing:
+        err = stop_user_containers(existing)
+        utils.check_error(err)
+    remove_users_from_compose(compose, existing)
+    err = utils.export_yaml(compose, COMPOSE_USERS_YML)
+    utils.check_error(err)
+    for username in usernames:
+        remove_conf_server_entry(username)
+    remove_from_registry(usernames)
+    write_state(compose.get("services", {}))
 
 
 def delete_users(usernames, dry_run=False):
@@ -238,28 +306,11 @@ def delete_users(usernames, dry_run=False):
     the CLI-owned user registry. With dry_run, report what would happen and make
     no changes."""
     try:
-        validate_usernames(usernames)
-        compose, err = utils.import_yaml(COMPOSE_USERS_YML)
-        utils.check_error(err)
-        if compose is None:
-            return Exception("Failed to load compose configuration")
-        existing_services = compose.get("services", {})
-        existing, missing = categorize_users(list(usernames), existing_services)
-        report_missing_users(missing)
+        compose, existing = _delete_context(usernames)
         if dry_run:
             report_delete_preview(existing, usernames)
-            return None
-        if existing:
-            err = stop_user_containers(existing)
-            utils.check_error(err)
-        remove_users_from_compose(compose, existing)
-        err = utils.export_yaml(compose, COMPOSE_USERS_YML)
-        utils.check_error(err)
-        for username in usernames:
-            remove_conf_server_entry(username)
-        remove_from_registry(usernames)
-        write_state(compose.get("services", {}))
+        else:
+            _remove_users(compose, existing, usernames)
     except Exception as e:
         return e
-
     return None

--- a/cli/src/pkg/users.py
+++ b/cli/src/pkg/users.py
@@ -5,6 +5,8 @@ import shutil
 from pathlib import Path
 from . import utils
 from .constants import COMPOSE_USERS_YML
+from .registry import load_registry, remove_from_registry
+from .state import write_state
 from .users_utils import (
     add_conf_server_entry,
     remove_conf_server_entry,
@@ -138,10 +140,14 @@ def _setup_compose_structure(compose):
         compose["networks"] = {"users": {"name": "dtaas-users", "external": True}}
 
 
-def _get_add_users_config(config_obj):
-    """Retrieve configuration needed for adding users."""
-    user_list, err = config_obj.get_add_users_list()
-    utils.check_error(err)
+def _get_registry_users():
+    """Return (all registry usernames, the additional-user store) to provision."""
+    users_section = load_registry()
+    return list(users_section), users_section
+
+
+def _get_deploy_config(config_obj):
+    """Retrieve deployment settings (server, path, resources, TLS) from dtaas.toml."""
     server, err = config_obj.get_server_dns()
     utils.check_error(err)
     path, err = config_obj.get_path()
@@ -152,16 +158,17 @@ def _get_add_users_config(config_obj):
     utils.check_error(err)
     set_limits, err = config_obj.get_set_limits()
     utils.check_error(err)
-    return user_list, server, path, resources, tls, set_limits
+    return server, path, resources, tls, set_limits
 
 
 def _finalize_compose(compose):
-    """Export and start user containers."""
+    """Export, start user containers, and record runtime state."""
     err = utils.export_yaml(compose, COMPOSE_USERS_YML)
     utils.check_error(err)
     users_list = list(compose["services"].keys())
     err = start_user_containers(users_list)
     utils.check_error(err)
+    write_state(compose["services"])
 
 
 def add_users(config_obj):
@@ -169,11 +176,8 @@ def add_users(config_obj):
     try:
         compose, err = utils.import_yaml(COMPOSE_USERS_YML)
         utils.check_error(err)
-        user_list, server, path, resources, tls, set_limits = _get_add_users_config(
-            config_obj
-        )
-        users_section, err = config_obj.get_users()
-        utils.check_error(err)
+        user_list, users_section = _get_registry_users()
+        server, path, resources, tls, set_limits = _get_deploy_config(config_obj)
     except Exception as e:
         return e
 
@@ -212,17 +216,16 @@ def add_users(config_obj):
     return None
 
 
-def delete_user(config_obj):
-    """delete cli command handler"""
+def delete_users(usernames):
+    """delete cli command handler: deprovision *usernames* and drop them from
+    the CLI-owned user registry."""
     try:
         compose, err = utils.import_yaml(COMPOSE_USERS_YML)
         utils.check_error(err)
         if compose is None:
             return Exception("Failed to load compose configuration")
-        user_list, err = config_obj.get_delete_users_list()
-        utils.check_error(err)
         existing_services = compose.get("services", {})
-        existing, missing = categorize_users(user_list, existing_services)
+        existing, missing = categorize_users(list(usernames), existing_services)
         report_missing_users(missing)
         if existing:
             err = stop_user_containers(existing)
@@ -232,6 +235,8 @@ def delete_user(config_obj):
         utils.check_error(err)
         for username in existing:
             remove_conf_server_entry(username)
+        remove_from_registry(usernames)
+        write_state(compose["services"])
     except Exception as e:
         return e
 

--- a/cli/src/pkg/users.py
+++ b/cli/src/pkg/users.py
@@ -13,6 +13,7 @@ from .users_utils import (
     categorize_users,
     report_missing_users,
     remove_users_from_compose,
+    report_delete_preview,
     build_base_mapping,
     resource_mapping,
     validate_usernames,
@@ -120,8 +121,13 @@ def start_user_containers(users):
 
 
 def stop_user_containers(users):
-    """Stops all the user containers in the 'users' list"""
-    cmd = ["docker", "compose", "-f", COMPOSE_USERS_YML, "down"]
+    """Stops and removes only the named user containers.
+
+    'docker compose down' takes no SERVICE arguments and always tears down the
+    whole project, so 'rm --stop --force' is used instead to target just the
+    given services.
+    """
+    cmd = ["docker", "compose", "-f", COMPOSE_USERS_YML, "rm", "--stop", "--force"]
     return run_command_for_containers(cmd, users)
 
 
@@ -227,9 +233,10 @@ def add_users(config_obj):
     return None
 
 
-def delete_users(usernames):
+def delete_users(usernames, dry_run=False):
     """delete cli command handler: deprovision *usernames* and drop them from
-    the CLI-owned user registry."""
+    the CLI-owned user registry. With dry_run, report what would happen and make
+    no changes."""
     try:
         validate_usernames(usernames)
         compose, err = utils.import_yaml(COMPOSE_USERS_YML)
@@ -239,6 +246,9 @@ def delete_users(usernames):
         existing_services = compose.get("services", {})
         existing, missing = categorize_users(list(usernames), existing_services)
         report_missing_users(missing)
+        if dry_run:
+            report_delete_preview(existing, usernames)
+            return None
         if existing:
             err = stop_user_containers(existing)
             utils.check_error(err)

--- a/cli/src/pkg/users.py
+++ b/cli/src/pkg/users.py
@@ -15,6 +15,7 @@ from .users_utils import (
     remove_users_from_compose,
     build_base_mapping,
     resource_mapping,
+    validate_usernames,
 )
 
 
@@ -30,9 +31,17 @@ def _load_template(server, tls):
     """
     if server == utils.LOCALHOST_SERVER:
         return None, Exception("user add is not supported for localhost installations")
-    if tls:
-        return utils.import_yaml("users.server.secure.yml")
-    return utils.import_yaml("users.server.yml")
+    name = "users.server.secure.yml" if tls else "users.server.yml"
+    template, err = utils.import_yaml(name)
+    if err is not None:
+        return None, err
+    if not template:
+        return None, Exception(
+            f"User workspace template '{name}' is missing or empty in this "
+            "directory. Run 'dtaas generate-project' (or "
+            "'dtaas generate-deployment') here first."
+        )
+    return template, None
 
 
 def _apply_resource_limits(service, config):
@@ -106,27 +115,26 @@ def add_users_to_compose(users, compose, config):
 
 def start_user_containers(users):
     """Starts all the user containers in the 'users' list"""
-    cmd = "docker compose -f compose.users.yml up -d"
-    err = run_command_for_containers(cmd, users)
-    return err
+    cmd = ["docker", "compose", "-f", COMPOSE_USERS_YML, "up", "-d"]
+    return run_command_for_containers(cmd, users)
 
 
 def stop_user_containers(users):
     """Stops all the user containers in the 'users' list"""
-    cmd = "docker compose -f compose.users.yml down"
-    err = run_command_for_containers(cmd, users)
-    return err
+    cmd = ["docker", "compose", "-f", COMPOSE_USERS_YML, "down"]
+    return run_command_for_containers(cmd, users)
 
 
 def run_command_for_containers(command, containers):
-    """Runs the given docker command for the given containers"""
-    cmd = [command]
-    for name in containers:
-        cmd.append(name)
-    cmd_str = " ".join(cmd)
-    result = subprocess.run(cmd_str, shell=True, check=False)
+    """Runs the given docker command (an argv list) for the given containers.
+
+    Invoked with shell=False so usernames are passed as literal argv entries and
+    can never be interpreted as shell syntax.
+    """
+    argv = command + list(containers)
+    result = subprocess.run(argv, shell=False, check=False)
     if result.returncode != 0:
-        return Exception(f"failed to run '{cmd_str}' command")
+        return Exception(f"failed to run '{' '.join(argv)}' command")
     return None
 
 
@@ -177,6 +185,9 @@ def add_users(config_obj):
         compose, err = utils.import_yaml(COMPOSE_USERS_YML)
         utils.check_error(err)
         user_list, users_section = _get_registry_users()
+        if not user_list:
+            return None  # empty registry: nothing to provision
+        validate_usernames(user_list)
         server, path, resources, tls, set_limits = _get_deploy_config(config_obj)
     except Exception as e:
         return e
@@ -220,6 +231,7 @@ def delete_users(usernames):
     """delete cli command handler: deprovision *usernames* and drop them from
     the CLI-owned user registry."""
     try:
+        validate_usernames(usernames)
         compose, err = utils.import_yaml(COMPOSE_USERS_YML)
         utils.check_error(err)
         if compose is None:
@@ -233,10 +245,10 @@ def delete_users(usernames):
         remove_users_from_compose(compose, existing)
         err = utils.export_yaml(compose, COMPOSE_USERS_YML)
         utils.check_error(err)
-        for username in existing:
+        for username in usernames:
             remove_conf_server_entry(username)
         remove_from_registry(usernames)
-        write_state(compose["services"])
+        write_state(compose.get("services", {}))
     except Exception as e:
         return e
 

--- a/cli/src/pkg/users.py
+++ b/cli/src/pkg/users.py
@@ -1,13 +1,21 @@
-"""This file has functions that handle the user cli commands"""
+"""The 'user add'/'user delete' CLI command handlers.
 
-import subprocess
-import shutil
+Loads registry/deploy config, then drives the compose/container plumbing in
+users_compose.py to provision or deprovision the requested users.
+"""
+
 from dataclasses import dataclass
-from pathlib import Path
 from . import utils
 from .constants import COMPOSE_USERS_YML
 from .registry import load_registry, remove_from_registry
 from .state import write_state
+from .users_compose import (
+    add_users_to_compose,
+    create_user_files,
+    finalize_compose,
+    setup_compose_structure,
+    stop_user_containers,
+)
 from .users_utils import (
     add_conf_server_entry,
     remove_conf_server_entry,
@@ -15,149 +23,8 @@ from .users_utils import (
     report_missing_users,
     remove_users_from_compose,
     report_delete_preview,
-    build_base_mapping,
-    resource_mapping,
     validate_usernames,
 )
-
-
-def _load_template(server, tls):
-    """Load the appropriate template based on server type and TLS.
-
-    Args:
-        server: Server DNS name (not 'localhost')
-        tls: Whether to use TLS/secure template
-
-    Returns:
-        Tuple of (template dict, error if any)
-    """
-    if server == utils.LOCALHOST_SERVER:
-        return None, Exception("user add is not supported for localhost installations")
-    name = "users.server.secure.yml" if tls else "users.server.yml"
-    template, err = utils.import_yaml(name)
-    if err is None and not template:
-        err = Exception(
-            f"User workspace template '{name}' is missing or empty in this "
-            "directory. Run 'dtaas generate-project' (or "
-            "'dtaas generate-deployment') here first."
-        )
-    if err is not None:
-        return None, err
-    return template, None
-
-
-def _apply_resource_limits(service, config):
-    """Merge substituted resource limits into the service dict when enabled.
-
-    When set_limits is false the service is returned unchanged so the container
-    runs without CPU/memory/process caps. Raises on a template load or
-    substitution error.
-    """
-    if not config.get("set_limits", True):
-        return service
-    template, err = utils.import_yaml("users.resources.yml")
-    utils.check_error(err)
-    resources, err = utils.replace_all(template, resource_mapping(config["resources"]))
-    utils.check_error(err)
-    service.update(resources)
-    return service
-
-
-def get_compose_config(username, config):
-    """Makes and returns the config for the user
-
-    Args:
-        username: Username for the config
-        config: Dict with 'server', 'path', 'resources', 'tls', 'set_limits' keys
-
-    Returns:
-        Tuple of (user config dict, error if any)
-    """
-    try:
-        template, err = _load_template(config["server"], config.get("tls"))
-        utils.check_error(err)
-        mapping = build_base_mapping(username, config)
-        result, err = utils.replace_all(template, mapping)
-        utils.check_error(err)
-        result = _apply_resource_limits(result, config)
-    except Exception as e:
-        return None, e
-    return result, None
-
-
-def _create_one_user_dir(username, file_path):
-    """Copy the template into username's workspace dir and chown it (best-effort)."""
-    user_dir = Path(file_path) / username
-    shutil.copytree(Path(file_path) / "template", user_dir, dirs_exist_ok=True)
-    try:
-        shutil.chown(user_dir, user=1000, group=100)
-        for item in user_dir.rglob("*"):
-            shutil.chown(item, user=1000, group=100)
-    except (AttributeError, PermissionError):
-        # Skip os.chown in tests to avoid PermissionError
-        pass
-
-
-def create_user_files(users, file_path):
-    """Creates all the users' workspace directories"""
-    for username in users:
-        _create_one_user_dir(username, file_path)
-    return None
-
-
-def add_users_to_compose(users, compose, config):
-    """Adds all the users config to the compose dictionary
-    Args:
-        users: List of usernames
-        compose: Compose dict to update
-        config: Dict with 'server', 'path', 'resources' keys
-    """
-    for username in users:
-        user_conf, err = get_compose_config(username, config)
-        if err is not None:
-            return err
-        compose["services"][username] = user_conf
-    return None
-
-
-def start_user_containers(users):
-    """Starts all the user containers in the 'users' list"""
-    cmd = ["docker", "compose", "-f", COMPOSE_USERS_YML, "up", "-d"]
-    return run_command_for_containers(cmd, users)
-
-
-def stop_user_containers(users):
-    """Stops and removes only the named user containers.
-
-    'docker compose down' takes no SERVICE arguments and always tears down the
-    whole project, so 'rm --stop --force' is used instead to target just the
-    given services.
-    """
-    cmd = ["docker", "compose", "-f", COMPOSE_USERS_YML, "rm", "--stop", "--force"]
-    return run_command_for_containers(cmd, users)
-
-
-def run_command_for_containers(command, containers):
-    """Runs the given docker command (an argv list) for the given containers.
-
-    Invoked with shell=False so usernames are passed as literal argv entries and
-    can never be interpreted as shell syntax.
-    """
-    argv = command + list(containers)
-    result = subprocess.run(argv, shell=False, check=False)
-    if result.returncode != 0:
-        return Exception(f"failed to run '{' '.join(argv)}' command")
-    return None
-
-
-def _setup_compose_structure(compose):
-    """Ensure compose has required structure for services."""
-    if "version" not in compose:
-        compose["version"] = "3"
-    if "services" not in compose:
-        compose["services"] = {}
-    if "networks" not in compose:
-        compose["networks"] = {"users": {"name": "dtaas-users", "external": True}}
 
 
 def _get_registry_users():
@@ -179,16 +46,6 @@ def _get_deploy_config(config_obj):
     set_limits, err = config_obj.get_set_limits()
     utils.check_error(err)
     return server, path, resources, tls, set_limits
-
-
-def _finalize_compose(compose):
-    """Export, start user containers, and record runtime state."""
-    err = utils.export_yaml(compose, COMPOSE_USERS_YML)
-    utils.check_error(err)
-    users_list = list(compose["services"].keys())
-    err = start_user_containers(users_list)
-    utils.check_error(err)
-    write_state(compose["services"])
 
 
 @dataclass
@@ -255,7 +112,7 @@ def _provision_users(ctx):
     utils.check_error(err)
     for username in ctx.user_list:
         _authorise_user(username, ctx.users_section)
-    _finalize_compose(ctx.compose)
+    finalize_compose(ctx.compose)
 
 
 def add_users(config_obj):
@@ -264,7 +121,7 @@ def add_users(config_obj):
         ctx = _load_add_context(config_obj)
         if ctx is None:
             return None  # empty registry: nothing to provision
-        _setup_compose_structure(ctx.compose)
+        setup_compose_structure(ctx.compose)
         _provision_users(ctx)
     except Exception as e:
         return e

--- a/cli/src/pkg/users_compose.py
+++ b/cli/src/pkg/users_compose.py
@@ -9,7 +9,7 @@ import subprocess
 import shutil
 from pathlib import Path
 from . import utils
-from .constants import COMPOSE_USERS_YML
+from .constants import COMPOSE_USERS_YML, LOCALHOST_SERVER
 from .state import write_state
 from .users_utils import build_base_mapping, resource_mapping
 
@@ -24,7 +24,7 @@ def _load_template(server, tls):
     Returns:
         Tuple of (template dict, error if any)
     """
-    if server == utils.LOCALHOST_SERVER:
+    if server == LOCALHOST_SERVER:
         return None, Exception("user add is not supported for localhost installations")
     name = "users.server.secure.yml" if tls else "users.server.yml"
     template, err = utils.import_yaml(name)

--- a/cli/src/pkg/users_compose.py
+++ b/cli/src/pkg/users_compose.py
@@ -1,0 +1,163 @@
+"""Compose/container plumbing for provisioning and running user services.
+
+Everything here builds or applies a single user's compose service definition,
+or drives 'docker compose' for a set of user containers. See users.py for the
+'user add'/'user delete' command orchestration built on top of this.
+"""
+
+import subprocess
+import shutil
+from pathlib import Path
+from . import utils
+from .constants import COMPOSE_USERS_YML
+from .state import write_state
+from .users_utils import build_base_mapping, resource_mapping
+
+
+def _load_template(server, tls):
+    """Load the appropriate template based on server type and TLS.
+
+    Args:
+        server: Server DNS name (not 'localhost')
+        tls: Whether to use TLS/secure template
+
+    Returns:
+        Tuple of (template dict, error if any)
+    """
+    if server == utils.LOCALHOST_SERVER:
+        return None, Exception("user add is not supported for localhost installations")
+    name = "users.server.secure.yml" if tls else "users.server.yml"
+    template, err = utils.import_yaml(name)
+    if err is None and not template:
+        err = Exception(
+            f"User workspace template '{name}' is missing or empty in this "
+            "directory. Run 'dtaas generate-project' (or "
+            "'dtaas generate-deployment') here first."
+        )
+    if err is not None:
+        return None, err
+    return template, None
+
+
+def _apply_resource_limits(service, config):
+    """Merge substituted resource limits into the service dict when enabled.
+
+    When set_limits is false the service is returned unchanged so the container
+    runs without CPU/memory/process caps. Raises on a template load or
+    substitution error.
+    """
+    if not config.get("set_limits", True):
+        return service
+    template, err = utils.import_yaml("users.resources.yml")
+    utils.check_error(err)
+    resources, err = utils.replace_all(template, resource_mapping(config["resources"]))
+    utils.check_error(err)
+    service.update(resources)
+    return service
+
+
+def get_compose_config(username, config):
+    """Makes and returns the config for the user
+
+    Args:
+        username: Username for the config
+        config: Dict with 'server', 'path', 'resources', 'tls', 'set_limits' keys
+
+    Returns:
+        Tuple of (user config dict, error if any)
+    """
+    try:
+        template, err = _load_template(config["server"], config.get("tls"))
+        utils.check_error(err)
+        mapping = build_base_mapping(username, config)
+        result, err = utils.replace_all(template, mapping)
+        utils.check_error(err)
+        result = _apply_resource_limits(result, config)
+    except Exception as e:
+        return None, e
+    return result, None
+
+
+def _create_one_user_dir(username, file_path):
+    """Copy the template into username's workspace dir and chown it (best-effort)."""
+    user_dir = Path(file_path) / username
+    shutil.copytree(Path(file_path) / "template", user_dir, dirs_exist_ok=True)
+    try:
+        shutil.chown(user_dir, user=1000, group=100)
+        for item in user_dir.rglob("*"):
+            shutil.chown(item, user=1000, group=100)
+    except (AttributeError, PermissionError):
+        # Skip os.chown in tests to avoid PermissionError
+        pass
+
+
+def create_user_files(users, file_path):
+    """Creates all the users' workspace directories"""
+    for username in users:
+        _create_one_user_dir(username, file_path)
+    return None
+
+
+def add_users_to_compose(users, compose, config):
+    """Adds all the users config to the compose dictionary
+    Args:
+        users: List of usernames
+        compose: Compose dict to update
+        config: Dict with 'server', 'path', 'resources' keys
+    """
+    for username in users:
+        user_conf, err = get_compose_config(username, config)
+        if err is not None:
+            return err
+        compose["services"][username] = user_conf
+    return None
+
+
+def start_user_containers(users):
+    """Starts all the user containers in the 'users' list"""
+    cmd = ["docker", "compose", "-f", COMPOSE_USERS_YML, "up", "-d"]
+    return run_command_for_containers(cmd, users)
+
+
+def stop_user_containers(users):
+    """Stops and removes only the named user containers.
+
+    'docker compose down' takes no SERVICE arguments and always tears down the
+    whole project, so 'rm --stop --force' is used instead to target just the
+    given services.
+    """
+    cmd = ["docker", "compose", "-f", COMPOSE_USERS_YML, "rm", "--stop", "--force"]
+    return run_command_for_containers(cmd, users)
+
+
+def run_command_for_containers(command, containers):
+    """Runs the given docker command (an argv list) for the given containers.
+
+    Invoked with shell=False so usernames are passed as literal argv entries and
+    can never be interpreted as shell syntax.
+    """
+    argv = command + list(containers)
+    result = subprocess.run(argv, shell=False, check=False)
+    if result.returncode != 0:
+        return Exception(f"failed to run '{' '.join(argv)}' command")
+    return None
+
+
+def setup_compose_structure(compose):
+    """Ensure compose has required structure for services."""
+    if "version" not in compose:
+        compose["version"] = "3"
+    if "services" not in compose:
+        compose["services"] = {}
+    if "networks" not in compose:
+        compose["networks"] = {"users": {"name": "dtaas-users", "external": True}}
+
+
+def finalize_compose(compose):
+    """Export, start user containers, and record runtime state."""
+    err = utils.export_yaml(compose, COMPOSE_USERS_YML)
+    utils.check_error(err)
+    users_list = list(compose["services"].keys())
+    err = start_user_containers(users_list)
+    utils.check_error(err)
+    write_state(compose["services"])

--- a/cli/src/pkg/users_utils.py
+++ b/cli/src/pkg/users_utils.py
@@ -4,7 +4,7 @@ import re
 import click
 from pathlib import Path
 from . import utils
-from .constants import USERNAME_RE
+from .constants import CONF_SERVER_RULE_NUM_RE, USERNAME_RE
 
 CONF_SERVER_PATH = Path("config") / "conf.server"
 
@@ -51,7 +51,7 @@ def resource_mapping(resources):
 
 def _next_rule_num(text):
     """Return the next available onlyu<N> index from existing conf.server content."""
-    nums = [int(m) for m in re.findall(r"rule\.onlyu(\d+)\.", text)]
+    nums = [int(m) for m in CONF_SERVER_RULE_NUM_RE.findall(text)]
     return max(nums, default=0) + 1
 
 

--- a/cli/src/pkg/users_utils.py
+++ b/cli/src/pkg/users_utils.py
@@ -141,6 +141,13 @@ def report_missing_users(missing):
         click.echo(f"'{username}' does not exist, skipping deletion")
 
 
+def report_delete_preview(existing, usernames):
+    """Print what 'user delete' would do, without changing anything (dry-run)."""
+    if existing:
+        click.echo(f"Would deprovision and stop: {', '.join(existing)}")
+    click.echo(f"Would remove from registry: {', '.join(usernames)}")
+
+
 def remove_users_from_compose(compose, user_list):
     """Remove users from compose configuration."""
     for username in user_list:

--- a/cli/src/pkg/users_utils.py
+++ b/cli/src/pkg/users_utils.py
@@ -4,8 +4,24 @@ import re
 import click
 from pathlib import Path
 from . import utils
+from .constants import USERNAME_RE
 
 CONF_SERVER_PATH = Path("config") / "conf.server"
+
+
+def is_valid_username(name):
+    """True when *name* is a safe username (alphanumeric plus . _ -)."""
+    return isinstance(name, str) and bool(USERNAME_RE.match(name))
+
+
+def validate_usernames(usernames):
+    """Raise ValueError naming the first username that is not shell-safe."""
+    for name in usernames:
+        if not is_valid_username(name):
+            raise ValueError(
+                f"Invalid username '{name}': only letters, digits, '.', '_' "
+                "and '-' are allowed."
+            )
 
 
 def build_base_mapping(username, config):

--- a/cli/src/pkg/users_utils.py
+++ b/cli/src/pkg/users_utils.py
@@ -3,8 +3,7 @@
 import re
 import click
 from pathlib import Path
-from . import utils
-from .constants import CONF_SERVER_RULE_NUM_RE, USERNAME_RE
+from .constants import CONF_SERVER_RULE_NUM_RE, LOCALHOST_SERVER, USERNAME_RE
 
 CONF_SERVER_PATH = Path("config") / "conf.server"
 
@@ -34,7 +33,7 @@ def build_base_mapping(username, config):
         "${DTAAS_DIR}": config["path"],
         "${username}": username,
     }
-    if config["server"] != utils.LOCALHOST_SERVER:
+    if config["server"] != LOCALHOST_SERVER:
         mapping["${SERVER_DNS}"] = config["server"]
     return mapping
 

--- a/cli/src/pkg/utils.py
+++ b/cli/src/pkg/utils.py
@@ -3,8 +3,7 @@
 from pathlib import Path
 import yaml
 import tomlkit
-
-LOCALHOST_SERVER = "localhost"
+from .constants import LOCALHOST_SERVER
 
 
 def find_toml(output_dir):

--- a/cli/src/pkg/validators.py
+++ b/cli/src/pkg/validators.py
@@ -1,0 +1,116 @@
+"""Generic, DTaaS-agnostic value predicates and rule-running helpers.
+
+Used by config_validate.py to check individual dtaas.toml values. Nothing
+here knows about dtaas.toml's specific field names or structure.
+"""
+
+import ipaddress
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from email_validator import EmailNotValidError, validate_email
+from fqdn import FQDN
+from .constants import NUMERIC_HOST_RE, SIZE_RE, URL_RE, USERNAME_RE
+
+
+def get_nested(data, *keys):
+    """Return the nested value at *keys*, or None if any step is missing."""
+    node = data
+    for key in keys:
+        node = node.get(key) if isinstance(node, dict) else None
+    return node
+
+
+def is_url(value):
+    """True when *value* is an http(s) URL (case-insensitive) with a host/path."""
+    return isinstance(value, str) and bool(URL_RE.match(value.lower()))
+
+
+def _is_ip(value):
+    """True when *value* is a valid IPv4 or IPv6 address."""
+    try:
+        ipaddress.ip_address(value)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_fqdn(value):
+    """True when *value* is an RFC 1123 fully qualified domain name."""
+    return FQDN(value).is_valid
+
+
+def is_host(value):
+    """True for 'localhost', an IP literal, or a dotted FQDN (numeric => IP)."""
+    if not isinstance(value, str):
+        return False
+    if NUMERIC_HOST_RE.match(value):
+        return _is_ip(value)
+    return value == "localhost" or _is_fqdn(value)
+
+
+def _is_abs_path(value):
+    """True when *value* is an absolute path in POSIX or Windows form."""
+    if not isinstance(value, str) or not value.strip():
+        return False
+    return PurePosixPath(value).is_absolute() or PureWindowsPath(value).is_absolute()
+
+
+def is_existing_dir(value):
+    """True when *value* is an absolute path to a directory that exists."""
+    return _is_abs_path(value) and Path(value).is_dir()
+
+
+def is_int(value):
+    """True when *value* is an integer (and not a bool, which subclasses int)."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def is_number(value):
+    """True when *value* is a positive number of cores (int or float, not bool)."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    return value > 0
+
+
+def is_size(value):
+    """True when *value* is a byte size with a required unit, e.g. '4G' or '512m'."""
+    return isinstance(value, str) and bool(SIZE_RE.match(value))
+
+
+def is_email(value):
+    """True when *value* is a valid email address (no DNS lookup)."""
+    try:
+        validate_email(value, check_deliverability=False)
+        return True
+    except (EmailNotValidError, TypeError):  # TypeError: non-string value
+        return False
+
+
+def is_username(value):
+    """True when *value* is a non-empty username (alphanumeric plus . _ -)."""
+    return isinstance(value, str) and bool(USERNAME_RE.match(value))
+
+
+def is_string_list(value):
+    """True when *value* is a list whose entries are all strings."""
+    return isinstance(value, list) and all(isinstance(x, str) for x in value)
+
+
+def required(data, keys, rule):
+    """Return [message] if the value at *keys* is missing or fails *rule*.
+
+    *rule* is a (predicate, message) pair.
+    """
+    predicate, message = rule
+    value = get_nested(data, *keys)
+    if value is None:
+        return [".".join(keys) + " is missing"]
+    return [] if predicate(value) else [message]
+
+
+def optional(data, keys, rule):
+    """Like required, but a missing value is allowed (no error)."""
+    predicate, message = rule
+    value = get_nested(data, *keys)
+    if value is None:
+        return []
+    return [] if predicate(value) else [message]

--- a/cli/src/templates/dtaas.toml
+++ b/cli/src/templates/dtaas.toml
@@ -53,19 +53,19 @@ starting=["username1","username2","username3"]
 
 [users.username1]
 email="username1@intocps.org"
-groups=["starting"]
+groups=["default","dtaas"]
 load_balance=true
 
 [users.username2]
 email="username2@intocps.org"
-groups=["starting"]
+groups=["default","dtaas"]
 load_balance=false
 
 [users.username3]
-# A starting user can also carry additional, non-reserved group tags
-# alongside "starting" -- groups is always a list, even for one entry.
+# A user can also carry additional, non-reserved group tags alongside the
+# "default" and "dtaas" groups -- groups is always a list, even for one entry.
 email="username3@intocps.org"
-groups=["starting","beta-testers","load-balanced-tier1"]
+groups=["default","dtaas","beta-testers","load-balanced-tier1"]
 load_balance=true
 
 # Installation-specific configuration

--- a/cli/src/templates/dtaas.toml
+++ b/cli/src/templates/dtaas.toml
@@ -1,7 +1,7 @@
 # This is the config for DTaaS CLI
 
 name="Digital Twin as a Service (DTaaS)"
-version="0.10.0"
+version="0.11.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 
@@ -40,22 +40,37 @@ shm_size="512m" # Shared memory size
 
 
 [users]
-# matching user info must present in this config file
-add=["username1","username2", "username3"]
-delete=["username2", "username3"]
+# Starting users installed with this DTaaS instance. This list is
+# declarative and human-edited, set once at install time.
+#
+# Additional users added later via `dtaas admin user add` (or
+# `--file users.csv`) are NOT tracked here. They live in the CLI-owned
+# dtaas.users.registry.json instead, and `dtaas admin user add`/`delete`
+# never write to this file.
+#
+# Every username below must have a matching [users.<username>] table.
+starting=["username1","username2","username3"]
 
 [users.username1]
 email="username1@intocps.org"
+groups=["starting"]
+load_balance=true
 
 [users.username2]
 email="username2@intocps.org"
+groups=["starting"]
+load_balance=false
 
 [users.username3]
+# A starting user can also carry additional, non-reserved group tags
+# alongside "starting" -- groups is always a list, even for one entry.
 email="username3@intocps.org"
+groups=["starting","beta-testers","load-balanced-tier1"]
+load_balance=true
 
 # Installation-specific configuration
-# For non-localhost deployments, usernames (USERNAME1, USERNAME2, ...)
-# are taken from the [users] add list above.
+# For non-localhost deployments, the starting usernames (USERNAME1,
+# USERNAME2, ...) are taken from the [users] starting list above.
 
 # OAuth application for the DTaaS client website (React frontend).
 # This is a separate OAuth application from the server one used by

--- a/cli/src/templates/users.csv
+++ b/cli/src/templates/users.csv
@@ -1,0 +1,3 @@
+username,email,groups,load_balance
+alice,alice@intocps.org,additional,true
+bob,bob@intocps.org,additional;beta-testers;load-balanced-tier1,false

--- a/cli/tests/dtaas.test.toml
+++ b/cli/tests/dtaas.test.toml
@@ -1,7 +1,7 @@
 # This is the config for DTaaS CLI
 
 name="Digital Twin as a Service (DTaaS)"
-version="0.10.0"
+version="0.11.0"
 owner="The INTO-CPS-Association"
 git-repo="https://github.com/into-cps-association/DTaaS.git"
 

--- a/cli/tests/test_certs.py
+++ b/cli/tests/test_certs.py
@@ -2,7 +2,12 @@
 
 import os
 from unittest.mock import patch
-from src.pkg.certs import copy_certs, find_latest_cert, secure_private_key
+from src.pkg.certs import (
+    CertsCopySpec,
+    copy_certs,
+    find_latest_cert,
+    secure_private_key,
+)
 
 
 def _make_cert_src(src, files):
@@ -34,12 +39,13 @@ def test_find_latest_cert_ignores_unrelated_names(tmp_path):
 
 def test_copy_certs_skips_non_tls_deploy(tmp_path):
     """copy_certs is a no-op (returns None) for non-TLS deploy types."""
-    assert copy_certs("localhost", str(tmp_path), str(tmp_path)) is None
+    spec = CertsCopySpec("localhost", str(tmp_path))
+    assert copy_certs(str(tmp_path), spec) is None
 
 
 def test_copy_certs_notes_when_no_source(tmp_path):
     """A TLS deploy with no certs-src returns an informative note, copies nothing."""
-    note = copy_certs("secure-server", str(tmp_path), "")
+    note = copy_certs(str(tmp_path), CertsCopySpec("secure-server", ""))
 
     assert note is not None and "certs-src not set" in note
     assert not (tmp_path / "certs").exists()
@@ -47,7 +53,8 @@ def test_copy_certs_notes_when_no_source(tmp_path):
 
 def test_copy_certs_notes_when_source_missing(tmp_path):
     """A non-existent certs-src directory yields a note without raising."""
-    note = copy_certs("secure-server", str(tmp_path), str(tmp_path / "nope"))
+    spec = CertsCopySpec("secure-server", str(tmp_path / "nope"))
+    note = copy_certs(str(tmp_path), spec)
 
     assert note is not None and "not found" in note
 
@@ -69,7 +76,7 @@ def test_copy_certs_copies_latest_pair(tmp_path):
         os.utime(src / f"privkey{name}", (when, when))
     dest = tmp_path / "install"
 
-    note = copy_certs("secure-server", str(dest), str(src))
+    note = copy_certs(str(dest), CertsCopySpec("secure-server", str(src)))
 
     assert (dest / "certs" / "fullchain.pem").read_text() == "fc-new"
     assert (dest / "certs" / "privkey.pem").read_text() == "pk-new"
@@ -82,7 +89,7 @@ def test_copy_certs_sets_private_key_permissions(tmp_path):
     _make_cert_src(src, {"fullchain.pem": "fc", "privkey.pem": "pk"})
     dest = tmp_path / "install"
 
-    copy_certs("secure-server", str(dest), str(src))
+    copy_certs(str(dest), CertsCopySpec("secure-server", str(src)))
 
     key = dest / "certs" / "privkey.pem"
     assert key.exists()
@@ -100,7 +107,7 @@ def test_copy_certs_skips_existing_without_force(tmp_path):
     (certs / "fullchain.pem").write_text("fc-old")
     (certs / "privkey.pem").write_text("pk-old")
 
-    copy_certs("secure-server", str(dest), str(src), force=False)
+    copy_certs(str(dest), CertsCopySpec("secure-server", str(src), force=False))
 
     assert (certs / "fullchain.pem").read_text() == "fc-old"
 
@@ -114,7 +121,7 @@ def test_copy_certs_overwrites_with_force(tmp_path):
     certs.mkdir(parents=True)
     (certs / "fullchain.pem").write_text("fc-old")
 
-    copy_certs("secure-server", str(dest), str(src), force=True)
+    copy_certs(str(dest), CertsCopySpec("secure-server", str(src), force=True))
 
     assert (certs / "fullchain.pem").read_text() == "fc-new"
 
@@ -138,7 +145,7 @@ def test_copy_certs_notes_partial_source(tmp_path):
     _make_cert_src(src, {"fullchain.pem": "fc"})  # privkey.pem absent
     dest = tmp_path / "install"
 
-    note = copy_certs("secure-server", str(dest), str(src))
+    note = copy_certs(str(dest), CertsCopySpec("secure-server", str(src)))
 
     assert note is not None and "privkey.pem" in note
     assert (dest / "certs" / "fullchain.pem").exists()

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -20,7 +20,7 @@ def runner():
 def mock_user_pkg():
     """Mock user package functions and Config to avoid filesystem dependency"""
     with patch("src.cmd.userPkg.add_users") as mock_add, patch(
-        "src.cmd.userPkg.delete_user"
+        "src.cmd.userPkg.delete_users"
     ) as mock_delete, patch("src.cmd_utils.configPkg.Config") as mock_cfg:
         mock_cfg.return_value = MagicMock()
         yield {"add": mock_add, "delete": mock_delete, "config": mock_cfg}
@@ -30,10 +30,10 @@ def test_delete_user_success(runner, mock_user_pkg):
     """Test successful user deletion"""
     mock_user_pkg["delete"].return_value = None
 
-    result = runner.invoke(dtaas, ["admin", "user", "delete"])
+    result = runner.invoke(dtaas, ["admin", "user", "delete", "alice", "bob"])
     assert result.exit_code == 0
-    assert "User deleted successfully" in result.output
-    mock_user_pkg["delete"].assert_called_once()
+    assert "Users deleted successfully" in result.output
+    mock_user_pkg["delete"].assert_called_once_with(("alice", "bob"))
 
 
 def test_generate_project_success(runner):
@@ -151,6 +151,45 @@ def test_add_users_config_error(runner):
 
     assert result.exit_code != 0
     assert "no config" in result.output
+
+
+def test_add_users_with_file_imports_registry(runner, mock_user_pkg, tmp_path):
+    """add --file imports the CSV into the registry before provisioning."""
+    mock_user_pkg["add"].return_value = None
+    csv_file = tmp_path / "users.csv"
+    csv_file.write_text("username,email,groups,load_balance\nalice,a@x.io,g,true\n")
+
+    with patch("src.cmd.import_users_file") as mock_import:
+        result = runner.invoke(dtaas, ["admin", "user", "add", "--file", str(csv_file)])
+
+    assert result.exit_code == 0
+    mock_import.assert_called_once_with(str(csv_file))
+    mock_user_pkg["add"].assert_called_once()
+
+
+def test_add_users_without_file_skips_import(runner, mock_user_pkg):
+    """add without --file provisions from the existing registry, no import."""
+    mock_user_pkg["add"].return_value = None
+
+    with patch("src.cmd.import_users_file") as mock_import:
+        result = runner.invoke(dtaas, ["admin", "user", "add"])
+
+    assert result.exit_code == 0
+    mock_import.assert_not_called()
+
+
+def test_add_users_file_import_error(runner, tmp_path):
+    """A malformed users file surfaces as a ClickException."""
+    csv_file = tmp_path / "users.csv"
+    csv_file.write_text("no-username-column\n")
+
+    with patch(
+        "src.cmd_utils.registryPkg.read_csv_users", side_effect=KeyError("username")
+    ):
+        result = runner.invoke(dtaas, ["admin", "user", "add", "--file", str(csv_file)])
+
+    assert result.exit_code != 0
+    assert "Error importing users file" in result.output
 
 
 @pytest.fixture

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -33,7 +33,36 @@ def test_delete_user_success(runner, mock_user_pkg):
     result = runner.invoke(dtaas, ["admin", "user", "delete", "alice", "bob"])
     assert result.exit_code == 0
     assert "Users deleted successfully" in result.output
-    mock_user_pkg["delete"].assert_called_once_with(("alice", "bob"))
+    mock_user_pkg["delete"].assert_called_once_with(("alice", "bob"), dry_run=False)
+
+
+def test_delete_user_dry_run(runner, mock_user_pkg):
+    """delete --dry-run previews without deleting and prints the dry-run message."""
+    mock_user_pkg["delete"].return_value = None
+
+    result = runner.invoke(dtaas, ["admin", "user", "delete", "alice", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "Dry run complete" in result.output
+    mock_user_pkg["delete"].assert_called_once_with(("alice",), dry_run=True)
+
+
+def test_config_reconcile_invokes_run_reconcile(runner):
+    """config reconcile delegates to run_reconcile with the output dir."""
+    with patch("src.cmd.run_reconcile") as mock_reconcile:
+        result = runner.invoke(dtaas, ["admin", "config", "reconcile"])
+
+    assert result.exit_code == 0
+    mock_reconcile.assert_called_once_with(".")
+
+
+def test_config_reconcile_maps_errors(runner):
+    """A malformed state cache surfaces as a ClickException."""
+    with patch("src.cmd.run_reconcile", side_effect=ValueError("bad state")):
+        result = runner.invoke(dtaas, ["admin", "config", "reconcile"])
+
+    assert result.exit_code != 0
+    assert "bad state" in result.output
 
 
 def test_generate_project_success(runner):

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -1,6 +1,6 @@
 """Tests for CLI commands."""
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from pathlib import Path
 import pytest
 from click.testing import CliRunner
@@ -14,37 +14,6 @@ from src.pkg.cert_validate import CertValidationError
 def runner():
     """CLI test runner"""
     return CliRunner()
-
-
-@pytest.fixture
-def mock_user_pkg():
-    """Mock user package functions and Config to avoid filesystem dependency"""
-    with patch("src.cmd.userPkg.add_users") as mock_add, patch(
-        "src.cmd.userPkg.delete_users"
-    ) as mock_delete, patch("src.cmd_utils.configPkg.Config") as mock_cfg:
-        mock_cfg.return_value = MagicMock()
-        yield {"add": mock_add, "delete": mock_delete, "config": mock_cfg}
-
-
-def test_delete_user_success(runner, mock_user_pkg):
-    """Test successful user deletion"""
-    mock_user_pkg["delete"].return_value = None
-
-    result = runner.invoke(dtaas, ["admin", "user", "delete", "alice", "bob"])
-    assert result.exit_code == 0
-    assert "Users deleted successfully" in result.output
-    mock_user_pkg["delete"].assert_called_once_with(("alice", "bob"), dry_run=False)
-
-
-def test_delete_user_dry_run(runner, mock_user_pkg):
-    """delete --dry-run previews without deleting and prints the dry-run message."""
-    mock_user_pkg["delete"].return_value = None
-
-    result = runner.invoke(dtaas, ["admin", "user", "delete", "alice", "--dry-run"])
-
-    assert result.exit_code == 0
-    assert "Dry run complete" in result.output
-    mock_user_pkg["delete"].assert_called_once_with(("alice",), dry_run=True)
 
 
 def test_config_reconcile_invokes_run_reconcile(runner):
@@ -89,7 +58,7 @@ def test_generate_project_error(runner):
 def test_generate_deployment_without_config_prints_note(runner):
     """generate-deployment prints a note when dtaas.toml is absent"""
     with patch("src.cmd.projectPkg.generate_deploy_project"), patch(
-        "src.cmd_utils._find_toml", return_value=None
+        "src.cmd_deploy_utils._find_toml", return_value=None
     ):
         result = runner.invoke(dtaas, ["generate-deployment", "--type", "localhost"])
 
@@ -171,57 +140,6 @@ def test_config_validate_missing_file(runner):
 
     assert result.exit_code != 0
     assert "dtaas.toml not found" in result.output
-
-
-def test_add_users_config_error(runner):
-    """add command raises ClickException when Config() fails"""
-    with patch("src.cmd_utils.configPkg.Config", side_effect=RuntimeError("no config")):
-        result = runner.invoke(dtaas, ["admin", "user", "add"])
-
-    assert result.exit_code != 0
-    assert "no config" in result.output
-
-
-def test_add_users_with_file(runner, mock_user_pkg, tmp_path):
-    """add --file stages the CSV then provisions."""
-    mock_user_pkg["add"].return_value = None
-    csv_file = tmp_path / "users.csv"
-    csv_file.write_text("username,email,groups,load_balance\nalice,a@x.io,g,true\n")
-
-    with patch("src.cmd.stage_users_for_add") as mock_stage:
-        result = runner.invoke(dtaas, ["admin", "user", "add", "--file", str(csv_file)])
-
-    assert result.exit_code == 0
-    mock_stage.assert_called_once_with(None, str(csv_file), None, (), True)
-    mock_user_pkg["add"].assert_called_once()
-
-
-def test_add_single_user(runner, mock_user_pkg):
-    """add USERNAME --email stages one user then provisions."""
-    mock_user_pkg["add"].return_value = None
-
-    with patch("src.cmd.stage_users_for_add") as mock_stage:
-        result = runner.invoke(
-            dtaas, ["admin", "user", "add", "alice", "--email", "a@x.io"]
-        )
-
-    assert result.exit_code == 0
-    mock_stage.assert_called_once_with("alice", None, "a@x.io", (), True)
-    mock_user_pkg["add"].assert_called_once()
-
-
-def test_add_users_file_import_error(runner, tmp_path):
-    """A malformed users file surfaces as a ClickException."""
-    csv_file = tmp_path / "users.csv"
-    csv_file.write_text("no-username-column\n")
-
-    with patch(
-        "src.cmd_utils.registryPkg.read_csv_users", side_effect=KeyError("username")
-    ):
-        result = runner.invoke(dtaas, ["admin", "user", "add", "--file", str(csv_file)])
-
-    assert result.exit_code != 0
-    assert "Error importing users file" in result.output
 
 
 @pytest.fixture

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -17,12 +17,21 @@ def runner():
 
 
 def test_config_reconcile_invokes_run_reconcile(runner):
-    """config reconcile delegates to run_reconcile with the output dir."""
+    """config reconcile delegates to run_reconcile with the output dir and fix flag."""
     with patch("src.cmd.run_reconcile") as mock_reconcile:
         result = runner.invoke(dtaas, ["admin", "config", "reconcile"])
 
     assert result.exit_code == 0
-    mock_reconcile.assert_called_once_with(".")
+    mock_reconcile.assert_called_once_with(".", False)
+
+
+def test_config_reconcile_passes_fix_flag(runner):
+    """config reconcile --fix forwards fix=True to run_reconcile."""
+    with patch("src.cmd.run_reconcile") as mock_reconcile:
+        result = runner.invoke(dtaas, ["admin", "config", "reconcile", "--fix"])
+
+    assert result.exit_code == 0
+    mock_reconcile.assert_called_once_with(".", True)
 
 
 def test_config_reconcile_maps_errors(runner):

--- a/cli/tests/test_cmd.py
+++ b/cli/tests/test_cmd.py
@@ -153,29 +153,32 @@ def test_add_users_config_error(runner):
     assert "no config" in result.output
 
 
-def test_add_users_with_file_imports_registry(runner, mock_user_pkg, tmp_path):
-    """add --file imports the CSV into the registry before provisioning."""
+def test_add_users_with_file(runner, mock_user_pkg, tmp_path):
+    """add --file stages the CSV then provisions."""
     mock_user_pkg["add"].return_value = None
     csv_file = tmp_path / "users.csv"
     csv_file.write_text("username,email,groups,load_balance\nalice,a@x.io,g,true\n")
 
-    with patch("src.cmd.import_users_file") as mock_import:
+    with patch("src.cmd.stage_users_for_add") as mock_stage:
         result = runner.invoke(dtaas, ["admin", "user", "add", "--file", str(csv_file)])
 
     assert result.exit_code == 0
-    mock_import.assert_called_once_with(str(csv_file))
+    mock_stage.assert_called_once_with(None, str(csv_file), None, (), True)
     mock_user_pkg["add"].assert_called_once()
 
 
-def test_add_users_without_file_skips_import(runner, mock_user_pkg):
-    """add without --file provisions from the existing registry, no import."""
+def test_add_single_user(runner, mock_user_pkg):
+    """add USERNAME --email stages one user then provisions."""
     mock_user_pkg["add"].return_value = None
 
-    with patch("src.cmd.import_users_file") as mock_import:
-        result = runner.invoke(dtaas, ["admin", "user", "add"])
+    with patch("src.cmd.stage_users_for_add") as mock_stage:
+        result = runner.invoke(
+            dtaas, ["admin", "user", "add", "alice", "--email", "a@x.io"]
+        )
 
     assert result.exit_code == 0
-    mock_import.assert_not_called()
+    mock_stage.assert_called_once_with("alice", None, "a@x.io", (), True)
+    mock_user_pkg["add"].assert_called_once()
 
 
 def test_add_users_file_import_error(runner, tmp_path):

--- a/cli/tests/test_cmd_deploy_utils.py
+++ b/cli/tests/test_cmd_deploy_utils.py
@@ -45,7 +45,9 @@ def test_certs_src_handles_missing_section():
 def test_provision_user_files_creates_dirs_and_sets_permissions(tmp_path):
     """provision_user_files recreates per-user dirs from toml and fixes ownership."""
     (tmp_path / "dtaas.toml").write_text('[users]\nstarting = ["alice"]\n')
-    with patch("src.cmd_deploy_utils.projectPkg.create_user_dirs") as mock_create, patch(
+    with patch(
+        "src.cmd_deploy_utils.projectPkg.create_user_dirs"
+    ) as mock_create, patch(
         "src.cmd_deploy_utils.projectPkg.set_files_permissions"
     ) as mock_perms:
         provision_user_files(str(tmp_path))
@@ -57,7 +59,9 @@ def test_provision_user_files_creates_dirs_and_sets_permissions(tmp_path):
 def test_provision_user_files_noop_without_toml(tmp_path, monkeypatch):
     """provision_user_files does nothing when no dtaas.toml is present."""
     monkeypatch.chdir(tmp_path)  # no dtaas.toml in output dir or cwd
-    with patch("src.cmd_deploy_utils.projectPkg.create_user_dirs") as mock_create, patch(
+    with patch(
+        "src.cmd_deploy_utils.projectPkg.create_user_dirs"
+    ) as mock_create, patch(
         "src.cmd_deploy_utils.projectPkg.set_files_permissions"
     ) as mock_perms:
         provision_user_files(str(tmp_path))

--- a/cli/tests/test_cmd_deploy_utils.py
+++ b/cli/tests/test_cmd_deploy_utils.py
@@ -1,0 +1,66 @@
+"""Tests for the deployment-generation helpers in cmd_deploy_utils.py."""
+
+from unittest.mock import MagicMock, patch
+from src.cmd_deploy_utils import (
+    VerticalChoicesCommand,
+    _find_toml,
+    _certs_src,
+    provision_user_files,
+)
+
+
+def test_param_rows_skips_hidden_param():
+    """_param_rows returns no rows for a param with no help record (hidden)."""
+    param = MagicMock()
+    param.get_help_record.return_value = None
+
+    rows = VerticalChoicesCommand._param_rows(param, ctx=None)  # pylint: disable=protected-access
+    assert not rows
+
+
+def test_find_toml_prefers_output_dir(tmp_path):
+    """_find_toml returns the output_dir copy when present."""
+    toml = tmp_path / "dtaas.toml"
+    toml.write_text("x = 1")
+
+    assert _find_toml(str(tmp_path)) == toml
+
+
+def test_find_toml_returns_none_when_absent(tmp_path, monkeypatch):
+    """_find_toml returns None when no dtaas.toml exists in either location."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.chdir(empty)  # cwd has no dtaas.toml either
+
+    assert _find_toml(str(empty)) is None
+
+
+def test_certs_src_handles_missing_section():
+    """_certs_src returns '' when common.security is absent or malformed."""
+    assert _certs_src({}) == ""
+    assert _certs_src({"common": {"security": "oops"}}) == ""
+    assert _certs_src({"common": {"security": {"certs-src": " /x "}}}) == "/x"
+
+
+def test_provision_user_files_creates_dirs_and_sets_permissions(tmp_path):
+    """provision_user_files recreates per-user dirs from toml and fixes ownership."""
+    (tmp_path / "dtaas.toml").write_text('[users]\nstarting = ["alice"]\n')
+    with patch("src.cmd_deploy_utils.projectPkg.create_user_dirs") as mock_create, patch(
+        "src.cmd_deploy_utils.projectPkg.set_files_permissions"
+    ) as mock_perms:
+        provision_user_files(str(tmp_path))
+
+    mock_create.assert_called_once_with(str(tmp_path), ["alice"])
+    mock_perms.assert_called_once_with(str(tmp_path))
+
+
+def test_provision_user_files_noop_without_toml(tmp_path, monkeypatch):
+    """provision_user_files does nothing when no dtaas.toml is present."""
+    monkeypatch.chdir(tmp_path)  # no dtaas.toml in output dir or cwd
+    with patch("src.cmd_deploy_utils.projectPkg.create_user_dirs") as mock_create, patch(
+        "src.cmd_deploy_utils.projectPkg.set_files_permissions"
+    ) as mock_perms:
+        provision_user_files(str(tmp_path))
+
+    mock_create.assert_not_called()
+    mock_perms.assert_not_called()

--- a/cli/tests/test_cmd_user.py
+++ b/cli/tests/test_cmd_user.py
@@ -80,9 +80,7 @@ def test_add_single_user(runner, mock_user_pkg):
         )
 
     assert result.exit_code == 0
-    mock_stage.assert_called_once_with(
-        UserAddInput("alice", None, "a@x.io", (), True)
-    )
+    mock_stage.assert_called_once_with(UserAddInput("alice", None, "a@x.io", (), True))
     mock_user_pkg["add"].assert_called_once()
 
 

--- a/cli/tests/test_cmd_user.py
+++ b/cli/tests/test_cmd_user.py
@@ -31,7 +31,7 @@ def test_delete_user_success(runner, mock_user_pkg):
     result = runner.invoke(dtaas, ["admin", "user", "delete", "alice", "bob"])
     assert result.exit_code == 0
     assert "Users deleted successfully" in result.output
-    mock_user_pkg["delete"].assert_called_once_with(("alice", "bob"), dry_run=False)
+    mock_user_pkg["delete"].assert_called_once_with(["alice", "bob"], dry_run=False)
 
 
 def test_delete_user_dry_run(runner, mock_user_pkg):
@@ -42,7 +42,44 @@ def test_delete_user_dry_run(runner, mock_user_pkg):
 
     assert result.exit_code == 0
     assert "Dry run complete" in result.output
-    mock_user_pkg["delete"].assert_called_once_with(("alice",), dry_run=True)
+    mock_user_pkg["delete"].assert_called_once_with(["alice"], dry_run=True)
+
+
+def test_delete_users_with_file(runner, mock_user_pkg, tmp_path):
+    """delete --file bulk-deletes the usernames listed in a CSV."""
+    mock_user_pkg["delete"].return_value = None
+    csv_file = tmp_path / "users.csv"
+    csv_file.write_text(
+        "username,email,groups,load_balance\n"
+        "alice,a@x.io,g,true\n"
+        "bob,b@x.io,g,false\n"
+    )
+
+    result = runner.invoke(dtaas, ["admin", "user", "delete", "--file", str(csv_file)])
+
+    assert result.exit_code == 0
+    mock_user_pkg["delete"].assert_called_once_with(["alice", "bob"], dry_run=False)
+
+
+def test_delete_users_rejects_names_and_file(runner, tmp_path):
+    """Passing both USERNAMES and --file is rejected."""
+    csv_file = tmp_path / "users.csv"
+    csv_file.write_text("username,email\nalice,a@x.io\n")
+
+    result = runner.invoke(
+        dtaas, ["admin", "user", "delete", "alice", "--file", str(csv_file)]
+    )
+
+    assert result.exit_code != 0
+    assert "either USERNAMES or --file" in result.output
+
+
+def test_delete_users_requires_names_or_file(runner):
+    """A bare delete with no USERNAMES and no --file is rejected."""
+    result = runner.invoke(dtaas, ["admin", "user", "delete"])
+
+    assert result.exit_code != 0
+    assert "Provide one or more USERNAMES" in result.output
 
 
 def test_add_users_config_error(runner):

--- a/cli/tests/test_cmd_user.py
+++ b/cli/tests/test_cmd_user.py
@@ -54,6 +54,24 @@ def test_add_users_config_error(runner):
     assert "no config" in result.output
 
 
+def test_add_users_config_error_does_not_stage_registry(runner):
+    """A failed Config() load must not write to the registry first.
+
+    stage_users_for_add runs inside the action passed to run_user_command, so
+    it only executes once Config() has already succeeded -- a bad dtaas.toml
+    never leaves a partially-updated registry behind.
+    """
+    with patch(
+        "src.cmd_utils.configPkg.Config", side_effect=RuntimeError("no config")
+    ), patch("src.cmd_user.stage_users_for_add") as mock_stage:
+        result = runner.invoke(
+            dtaas, ["admin", "user", "add", "alice", "--email", "a@x.io"]
+        )
+
+    assert result.exit_code != 0
+    mock_stage.assert_not_called()
+
+
 def test_add_users_with_file(runner, mock_user_pkg, tmp_path):
     """add --file stages the CSV then provisions."""
     mock_user_pkg["add"].return_value = None
@@ -84,7 +102,7 @@ def test_add_single_user(runner, mock_user_pkg):
     mock_user_pkg["add"].assert_called_once()
 
 
-def test_add_users_file_import_error(runner, tmp_path):
+def test_add_users_file_import_error(runner, mock_user_pkg, tmp_path):
     """A malformed users file surfaces as a ClickException."""
     csv_file = tmp_path / "users.csv"
     csv_file.write_text("no-username-column\n")

--- a/cli/tests/test_cmd_user.py
+++ b/cli/tests/test_cmd_user.py
@@ -1,0 +1,100 @@
+"""Tests for the 'user add'/'user delete' CLI commands (cmd_user.py)."""
+
+from unittest.mock import patch, MagicMock
+import pytest
+from click.testing import CliRunner
+from src.cmd import dtaas
+from src.cmd_utils import UserAddInput
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture
+def runner():
+    """CLI test runner"""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_user_pkg():
+    """Mock user package functions and Config to avoid filesystem dependency"""
+    with patch("src.cmd_user.userPkg.add_users") as mock_add, patch(
+        "src.cmd_user.userPkg.delete_users"
+    ) as mock_delete, patch("src.cmd_utils.configPkg.Config") as mock_cfg:
+        mock_cfg.return_value = MagicMock()
+        yield {"add": mock_add, "delete": mock_delete, "config": mock_cfg}
+
+
+def test_delete_user_success(runner, mock_user_pkg):
+    """Test successful user deletion"""
+    mock_user_pkg["delete"].return_value = None
+
+    result = runner.invoke(dtaas, ["admin", "user", "delete", "alice", "bob"])
+    assert result.exit_code == 0
+    assert "Users deleted successfully" in result.output
+    mock_user_pkg["delete"].assert_called_once_with(("alice", "bob"), dry_run=False)
+
+
+def test_delete_user_dry_run(runner, mock_user_pkg):
+    """delete --dry-run previews without deleting and prints the dry-run message."""
+    mock_user_pkg["delete"].return_value = None
+
+    result = runner.invoke(dtaas, ["admin", "user", "delete", "alice", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "Dry run complete" in result.output
+    mock_user_pkg["delete"].assert_called_once_with(("alice",), dry_run=True)
+
+
+def test_add_users_config_error(runner):
+    """add command raises ClickException when Config() fails"""
+    with patch("src.cmd_utils.configPkg.Config", side_effect=RuntimeError("no config")):
+        result = runner.invoke(dtaas, ["admin", "user", "add"])
+
+    assert result.exit_code != 0
+    assert "no config" in result.output
+
+
+def test_add_users_with_file(runner, mock_user_pkg, tmp_path):
+    """add --file stages the CSV then provisions."""
+    mock_user_pkg["add"].return_value = None
+    csv_file = tmp_path / "users.csv"
+    csv_file.write_text("username,email,groups,load_balance\nalice,a@x.io,g,true\n")
+
+    with patch("src.cmd_user.stage_users_for_add") as mock_stage:
+        result = runner.invoke(dtaas, ["admin", "user", "add", "--file", str(csv_file)])
+
+    assert result.exit_code == 0
+    mock_stage.assert_called_once_with(
+        UserAddInput(None, str(csv_file), None, (), True)
+    )
+    mock_user_pkg["add"].assert_called_once()
+
+
+def test_add_single_user(runner, mock_user_pkg):
+    """add USERNAME --email stages one user then provisions."""
+    mock_user_pkg["add"].return_value = None
+
+    with patch("src.cmd_user.stage_users_for_add") as mock_stage:
+        result = runner.invoke(
+            dtaas, ["admin", "user", "add", "alice", "--email", "a@x.io"]
+        )
+
+    assert result.exit_code == 0
+    mock_stage.assert_called_once_with(
+        UserAddInput("alice", None, "a@x.io", (), True)
+    )
+    mock_user_pkg["add"].assert_called_once()
+
+
+def test_add_users_file_import_error(runner, tmp_path):
+    """A malformed users file surfaces as a ClickException."""
+    csv_file = tmp_path / "users.csv"
+    csv_file.write_text("no-username-column\n")
+
+    with patch(
+        "src.cmd_utils.registryPkg.read_csv_users", side_effect=KeyError("username")
+    ):
+        result = runner.invoke(dtaas, ["admin", "user", "add", "--file", str(csv_file)])
+
+    assert result.exit_code != 0
+    assert "Error importing users file" in result.output

--- a/cli/tests/test_cmd_utils.py
+++ b/cli/tests/test_cmd_utils.py
@@ -1,12 +1,16 @@
 """Tests for the CLI helper functions in cmd_utils.py."""
 
 from unittest.mock import MagicMock, patch
+import click
+import pytest
 from src.cmd_utils import (
     VerticalChoicesCommand,
     _find_toml,
     _certs_src,
     provision_user_files,
+    stage_users_for_add,
 )
+from src.pkg.registry import load_registry
 
 
 def test_param_rows_skips_hidden_param():
@@ -64,3 +68,73 @@ def test_provision_user_files_noop_without_toml(tmp_path, monkeypatch):
 
     mock_create.assert_not_called()
     mock_perms.assert_not_called()
+
+
+def test_stage_users_rejects_username_and_file(tmp_path):
+    """Passing both a USERNAME and --file is rejected."""
+    csv = tmp_path / "u.csv"
+    csv.write_text("username,email\nalice,a@intocps.org\n")
+    with pytest.raises(click.ClickException, match="either a USERNAME or --file"):
+        stage_users_for_add("alice", str(csv), None, (), True)
+
+
+def test_stage_single_user_requires_email():
+    """A single-user add without --email is rejected."""
+    with pytest.raises(click.ClickException, match="--email"):
+        stage_users_for_add("alice", None, None, (), True)
+
+
+def test_stage_single_user_registers(tmp_path, monkeypatch):
+    """A valid single-user add writes the user into the registry."""
+    monkeypatch.chdir(tmp_path)
+    stage_users_for_add("alice", None, "a@intocps.org", ("team",), False)
+
+    store = load_registry()
+    assert store["alice"]["email"] == "a@intocps.org"
+    assert store["alice"]["groups"] == ["team"]
+    assert store["alice"]["load_balance"] is False
+
+
+def test_stage_single_user_defaults_group_to_dtaas(tmp_path, monkeypatch):
+    """With no --group, a single-user add defaults the group to 'dtaas'."""
+    monkeypatch.chdir(tmp_path)
+    stage_users_for_add("alice", None, "a@intocps.org", (), True)
+
+    assert load_registry()["alice"]["groups"] == ["dtaas"]
+
+
+def test_stage_skips_duplicate_registry_user(tmp_path, monkeypatch, capsys):
+    """A username already in the registry is skipped with a warning, not overwritten."""
+    monkeypatch.chdir(tmp_path)
+    stage_users_for_add("alice", None, "a@intocps.org", (), True)
+    stage_users_for_add("alice", None, "changed@intocps.org", (), True)
+
+    assert "'alice' already exists, skipping" in capsys.readouterr().out
+    assert load_registry()["alice"]["email"] == "a@intocps.org"
+
+
+def test_stage_skips_starting_user(tmp_path, monkeypatch, capsys):
+    """A username that is a starting user in dtaas.toml is skipped."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "dtaas.toml").write_text(
+        '[users]\nstarting=["alice"]\n[users.alice]\nemail="a@intocps.org"\n'
+    )
+    stage_users_for_add("alice", None, "other@intocps.org", (), True)
+
+    assert "'alice' already exists, skipping" in capsys.readouterr().out
+    assert load_registry() == {}
+
+
+def test_stage_rejects_invalid_username(tmp_path, monkeypatch):
+    """A shell-unsafe username is rejected before registration."""
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(click.ClickException, match="Invalid username"):
+        stage_users_for_add("bad;rm", None, "a@intocps.org", (), True)
+
+
+def test_stage_noop_without_username_or_file(tmp_path, monkeypatch):
+    """A bare add (no USERNAME, no --file) registers nothing."""
+    monkeypatch.chdir(tmp_path)
+    stage_users_for_add(None, None, None, (), True)
+
+    assert load_registry() == {}

--- a/cli/tests/test_cmd_utils.py
+++ b/cli/tests/test_cmd_utils.py
@@ -108,9 +108,10 @@ def test_resolve_delete_usernames_rejects_both(tmp_path):
     """Passing both positional usernames and --file is rejected."""
     csv = tmp_path / "u.csv"
     csv.write_text("username,email\nalice,a@x.io\n")
+    csv_file = str(csv)
 
     with pytest.raises(click.ClickException, match="either USERNAMES or --file"):
-        resolve_delete_usernames(("alice",), str(csv))
+        resolve_delete_usernames(("alice",), csv_file)
 
 
 def test_resolve_delete_usernames_rejects_neither():

--- a/cli/tests/test_cmd_utils.py
+++ b/cli/tests/test_cmd_utils.py
@@ -1,5 +1,6 @@
 """Tests for the CLI helper functions in cmd_utils.py."""
 
+import json
 from unittest.mock import MagicMock, patch
 import click
 import pytest
@@ -9,8 +10,10 @@ from src.cmd_utils import (
     _certs_src,
     provision_user_files,
     stage_users_for_add,
+    run_reconcile,
 )
 from src.pkg.registry import load_registry
+from src.pkg.state import config_hash
 
 
 def test_param_rows_skips_hidden_param():
@@ -96,12 +99,13 @@ def test_stage_single_user_registers(tmp_path, monkeypatch):
     assert store["alice"]["load_balance"] is False
 
 
-def test_stage_single_user_defaults_group_to_dtaas(tmp_path, monkeypatch):
-    """With no --group, a single-user add defaults the group to 'dtaas'."""
+def test_stage_single_user_defaults_group_to_additional(tmp_path, monkeypatch):
+    """With no --group, a single-user add defaults the group to 'additional',
+    matching the CSV import path."""
     monkeypatch.chdir(tmp_path)
     stage_users_for_add("alice", None, "a@intocps.org", (), True)
 
-    assert load_registry()["alice"]["groups"] == ["dtaas"]
+    assert load_registry()["alice"]["groups"] == ["additional"]
 
 
 def test_stage_skips_duplicate_registry_user(tmp_path, monkeypatch, capsys):
@@ -139,3 +143,33 @@ def test_stage_noop_without_username_or_file(tmp_path, monkeypatch):
     stage_users_for_add(None, None, None, (), True)
 
     assert load_registry() == {}
+
+
+def test_run_reconcile_reports_drift(tmp_path, capsys):
+    """run_reconcile flags a user whose compose config differs from the state cache."""
+    (tmp_path / ".dtaas.state.json").write_text(
+        json.dumps({"alice": {"config_hash": "sha256:old"}}), encoding="utf-8"
+    )
+    (tmp_path / "compose.users.yml").write_text(
+        "services:\n  alice:\n    image: v2\n", encoding="utf-8"
+    )
+
+    run_reconcile(str(tmp_path))
+
+    out = capsys.readouterr().out
+    assert "alice" in out and "config changed" in out
+
+
+def test_run_reconcile_in_sync(tmp_path, capsys):
+    """run_reconcile reports 'In sync' when hashes match."""
+    stored = config_hash({"image": "v1"})
+    (tmp_path / ".dtaas.state.json").write_text(
+        json.dumps({"alice": {"config_hash": stored}}), encoding="utf-8"
+    )
+    (tmp_path / "compose.users.yml").write_text(
+        "services:\n  alice:\n    image: v1\n", encoding="utf-8"
+    )
+
+    run_reconcile(str(tmp_path))
+
+    assert "In sync" in capsys.readouterr().out

--- a/cli/tests/test_cmd_utils.py
+++ b/cli/tests/test_cmd_utils.py
@@ -74,8 +74,9 @@ def test_stage_users_rejects_username_and_file(tmp_path):
     """Passing both a USERNAME and --file is rejected."""
     csv = tmp_path / "u.csv"
     csv.write_text("username,email\nalice,a@intocps.org\n")
+    csv_path = str(csv)
     with pytest.raises(click.ClickException, match="either a USERNAME or --file"):
-        stage_users_for_add("alice", str(csv), None, (), True)
+        stage_users_for_add("alice", csv_path, None, (), True)
 
 
 def test_stage_single_user_requires_email():

--- a/cli/tests/test_cmd_utils.py
+++ b/cli/tests/test_cmd_utils.py
@@ -44,7 +44,7 @@ def test_certs_src_handles_missing_section():
 
 def test_provision_user_files_creates_dirs_and_sets_permissions(tmp_path):
     """provision_user_files recreates per-user dirs from toml and fixes ownership."""
-    (tmp_path / "dtaas.toml").write_text('[users]\nadd = ["alice"]\n')
+    (tmp_path / "dtaas.toml").write_text('[users]\nstarting = ["alice"]\n')
     with patch("src.cmd_utils.projectPkg.create_user_dirs") as mock_create, patch(
         "src.cmd_utils.projectPkg.set_files_permissions"
     ) as mock_perms:

--- a/cli/tests/test_cmd_utils.py
+++ b/cli/tests/test_cmd_utils.py
@@ -1,76 +1,11 @@
 """Tests for the CLI helper functions in cmd_utils.py."""
 
 import json
-from unittest.mock import MagicMock, patch
 import click
 import pytest
-from src.cmd_utils import (
-    VerticalChoicesCommand,
-    _find_toml,
-    _certs_src,
-    provision_user_files,
-    stage_users_for_add,
-    run_reconcile,
-)
+from src.cmd_utils import UserAddInput, stage_users_for_add, run_reconcile
 from src.pkg.registry import load_registry
 from src.pkg.state import config_hash
-
-
-def test_param_rows_skips_hidden_param():
-    """_param_rows returns no rows for a param with no help record (hidden)."""
-    param = MagicMock()
-    param.get_help_record.return_value = None
-
-    rows = VerticalChoicesCommand._param_rows(param, ctx=None)  # pylint: disable=protected-access
-    assert not rows
-
-
-def test_find_toml_prefers_output_dir(tmp_path):
-    """_find_toml returns the output_dir copy when present."""
-    toml = tmp_path / "dtaas.toml"
-    toml.write_text("x = 1")
-
-    assert _find_toml(str(tmp_path)) == toml
-
-
-def test_find_toml_returns_none_when_absent(tmp_path, monkeypatch):
-    """_find_toml returns None when no dtaas.toml exists in either location."""
-    empty = tmp_path / "empty"
-    empty.mkdir()
-    monkeypatch.chdir(empty)  # cwd has no dtaas.toml either
-
-    assert _find_toml(str(empty)) is None
-
-
-def test_certs_src_handles_missing_section():
-    """_certs_src returns '' when common.security is absent or malformed."""
-    assert _certs_src({}) == ""
-    assert _certs_src({"common": {"security": "oops"}}) == ""
-    assert _certs_src({"common": {"security": {"certs-src": " /x "}}}) == "/x"
-
-
-def test_provision_user_files_creates_dirs_and_sets_permissions(tmp_path):
-    """provision_user_files recreates per-user dirs from toml and fixes ownership."""
-    (tmp_path / "dtaas.toml").write_text('[users]\nstarting = ["alice"]\n')
-    with patch("src.cmd_utils.projectPkg.create_user_dirs") as mock_create, patch(
-        "src.cmd_utils.projectPkg.set_files_permissions"
-    ) as mock_perms:
-        provision_user_files(str(tmp_path))
-
-    mock_create.assert_called_once_with(str(tmp_path), ["alice"])
-    mock_perms.assert_called_once_with(str(tmp_path))
-
-
-def test_provision_user_files_noop_without_toml(tmp_path, monkeypatch):
-    """provision_user_files does nothing when no dtaas.toml is present."""
-    monkeypatch.chdir(tmp_path)  # no dtaas.toml in output dir or cwd
-    with patch("src.cmd_utils.projectPkg.create_user_dirs") as mock_create, patch(
-        "src.cmd_utils.projectPkg.set_files_permissions"
-    ) as mock_perms:
-        provision_user_files(str(tmp_path))
-
-    mock_create.assert_not_called()
-    mock_perms.assert_not_called()
 
 
 def test_stage_users_rejects_username_and_file(tmp_path):
@@ -79,19 +14,19 @@ def test_stage_users_rejects_username_and_file(tmp_path):
     csv.write_text("username,email\nalice,a@intocps.org\n")
     csv_path = str(csv)
     with pytest.raises(click.ClickException, match="either a USERNAME or --file"):
-        stage_users_for_add("alice", csv_path, None, (), True)
+        stage_users_for_add(UserAddInput("alice", csv_path, None, (), True))
 
 
 def test_stage_single_user_requires_email():
     """A single-user add without --email is rejected."""
     with pytest.raises(click.ClickException, match="--email"):
-        stage_users_for_add("alice", None, None, (), True)
+        stage_users_for_add(UserAddInput("alice", None, None, (), True))
 
 
 def test_stage_single_user_registers(tmp_path, monkeypatch):
     """A valid single-user add writes the user into the registry."""
     monkeypatch.chdir(tmp_path)
-    stage_users_for_add("alice", None, "a@intocps.org", ("team",), False)
+    stage_users_for_add(UserAddInput("alice", None, "a@intocps.org", ("team",), False))
 
     store = load_registry()
     assert store["alice"]["email"] == "a@intocps.org"
@@ -103,7 +38,7 @@ def test_stage_single_user_defaults_group_to_additional(tmp_path, monkeypatch):
     """With no --group, a single-user add defaults the group to 'additional',
     matching the CSV import path."""
     monkeypatch.chdir(tmp_path)
-    stage_users_for_add("alice", None, "a@intocps.org", (), True)
+    stage_users_for_add(UserAddInput("alice", None, "a@intocps.org", (), True))
 
     assert load_registry()["alice"]["groups"] == ["additional"]
 
@@ -111,8 +46,8 @@ def test_stage_single_user_defaults_group_to_additional(tmp_path, monkeypatch):
 def test_stage_skips_duplicate_registry_user(tmp_path, monkeypatch, capsys):
     """A username already in the registry is skipped with a warning, not overwritten."""
     monkeypatch.chdir(tmp_path)
-    stage_users_for_add("alice", None, "a@intocps.org", (), True)
-    stage_users_for_add("alice", None, "changed@intocps.org", (), True)
+    stage_users_for_add(UserAddInput("alice", None, "a@intocps.org", (), True))
+    stage_users_for_add(UserAddInput("alice", None, "changed@intocps.org", (), True))
 
     assert "'alice' already exists, skipping" in capsys.readouterr().out
     assert load_registry()["alice"]["email"] == "a@intocps.org"
@@ -124,7 +59,7 @@ def test_stage_skips_starting_user(tmp_path, monkeypatch, capsys):
     (tmp_path / "dtaas.toml").write_text(
         '[users]\nstarting=["alice"]\n[users.alice]\nemail="a@intocps.org"\n'
     )
-    stage_users_for_add("alice", None, "other@intocps.org", (), True)
+    stage_users_for_add(UserAddInput("alice", None, "other@intocps.org", (), True))
 
     assert "'alice' already exists, skipping" in capsys.readouterr().out
     assert load_registry() == {}
@@ -134,13 +69,13 @@ def test_stage_rejects_invalid_username(tmp_path, monkeypatch):
     """A shell-unsafe username is rejected before registration."""
     monkeypatch.chdir(tmp_path)
     with pytest.raises(click.ClickException, match="Invalid username"):
-        stage_users_for_add("bad;rm", None, "a@intocps.org", (), True)
+        stage_users_for_add(UserAddInput("bad;rm", None, "a@intocps.org", (), True))
 
 
 def test_stage_noop_without_username_or_file(tmp_path, monkeypatch):
     """A bare add (no USERNAME, no --file) registers nothing."""
     monkeypatch.chdir(tmp_path)
-    stage_users_for_add(None, None, None, (), True)
+    stage_users_for_add(UserAddInput(None, None, None, (), True))
 
     assert load_registry() == {}
 

--- a/cli/tests/test_cmd_utils.py
+++ b/cli/tests/test_cmd_utils.py
@@ -13,14 +13,16 @@ def test_stage_users_rejects_username_and_file(tmp_path):
     csv = tmp_path / "u.csv"
     csv.write_text("username,email\nalice,a@intocps.org\n")
     csv_path = str(csv)
+    user_input = UserAddInput("alice", csv_path, None, (), True)
     with pytest.raises(click.ClickException, match="either a USERNAME or --file"):
-        stage_users_for_add(UserAddInput("alice", csv_path, None, (), True))
+        stage_users_for_add(user_input)
 
 
 def test_stage_single_user_requires_email():
     """A single-user add without --email is rejected."""
+    user_input = UserAddInput("alice", None, None, (), True)
     with pytest.raises(click.ClickException, match="--email"):
-        stage_users_for_add(UserAddInput("alice", None, None, (), True))
+        stage_users_for_add(user_input)
 
 
 def test_stage_single_user_registers(tmp_path, monkeypatch):
@@ -68,8 +70,9 @@ def test_stage_skips_starting_user(tmp_path, monkeypatch, capsys):
 def test_stage_rejects_invalid_username(tmp_path, monkeypatch):
     """A shell-unsafe username is rejected before registration."""
     monkeypatch.chdir(tmp_path)
+    user_input = UserAddInput("bad;rm", None, "a@intocps.org", (), True)
     with pytest.raises(click.ClickException, match="Invalid username"):
-        stage_users_for_add(UserAddInput("bad;rm", None, "a@intocps.org", (), True))
+        stage_users_for_add(user_input)
 
 
 def test_stage_noop_without_username_or_file(tmp_path, monkeypatch):
@@ -80,8 +83,17 @@ def test_stage_noop_without_username_or_file(tmp_path, monkeypatch):
     assert load_registry() == {}
 
 
+def _write_registry(tmp_path, users):
+    """Write a dtaas.users.registry.json with the given {name: details} users."""
+    (tmp_path / "dtaas.users.registry.json").write_text(
+        json.dumps({"users": users}), encoding="utf-8"
+    )
+
+
 def test_run_reconcile_reports_drift(tmp_path, capsys):
-    """run_reconcile flags a user whose compose config differs from the state cache."""
+    """run_reconcile flags a registered, provisioned user whose compose config
+    differs from what the state cache last recorded."""
+    _write_registry(tmp_path, {"alice": {"email": "a@x.io"}})
     (tmp_path / ".dtaas.state.json").write_text(
         json.dumps({"alice": {"config_hash": "sha256:old"}}), encoding="utf-8"
     )
@@ -95,8 +107,24 @@ def test_run_reconcile_reports_drift(tmp_path, capsys):
     assert "alice" in out and "config changed" in out
 
 
+def test_run_reconcile_reports_missing_and_unexpected(tmp_path, capsys):
+    """run_reconcile flags a registered-but-not-provisioned user (missing) and
+    a provisioned-but-unregistered service (unexpected)."""
+    _write_registry(tmp_path, {"alice": {"email": "a@x.io"}})
+    (tmp_path / "compose.users.yml").write_text(
+        "services:\n  carol:\n    image: v1\n", encoding="utf-8"
+    )
+
+    run_reconcile(str(tmp_path))
+
+    out = capsys.readouterr().out
+    assert "alice" in out and "not provisioned" in out
+    assert "carol" in out and "not in the registry" in out
+
+
 def test_run_reconcile_in_sync(tmp_path, capsys):
-    """run_reconcile reports 'In sync' when hashes match."""
+    """run_reconcile reports 'In sync' when the registry, state, and compose agree."""
+    _write_registry(tmp_path, {"alice": {"email": "a@x.io"}})
     stored = config_hash({"image": "v1"})
     (tmp_path / ".dtaas.state.json").write_text(
         json.dumps({"alice": {"config_hash": stored}}), encoding="utf-8"

--- a/cli/tests/test_cmd_utils.py
+++ b/cli/tests/test_cmd_utils.py
@@ -1,9 +1,15 @@
 """Tests for the CLI helper functions in cmd_utils.py."""
 
 import json
+from unittest.mock import MagicMock, patch
 import click
 import pytest
-from src.cmd_utils import UserAddInput, stage_users_for_add, run_reconcile
+from src.cmd_utils import (
+    UserAddInput,
+    resolve_delete_usernames,
+    stage_users_for_add,
+    run_reconcile,
+)
 from src.pkg.registry import load_registry
 from src.pkg.state import config_hash
 
@@ -75,12 +81,42 @@ def test_stage_rejects_invalid_username(tmp_path, monkeypatch):
         stage_users_for_add(user_input)
 
 
-def test_stage_noop_without_username_or_file(tmp_path, monkeypatch):
-    """A bare add (no USERNAME, no --file) registers nothing."""
+def test_stage_rejects_bare_add(tmp_path, monkeypatch):
+    """A bare add (no USERNAME, no --file) is rejected with a helpful message."""
     monkeypatch.chdir(tmp_path)
-    stage_users_for_add(UserAddInput(None, None, None, (), True))
+    user_input = UserAddInput(None, None, None, (), True)
+    with pytest.raises(click.ClickException, match="Provide a USERNAME"):
+        stage_users_for_add(user_input)
 
     assert load_registry() == {}
+
+
+def test_resolve_delete_usernames_from_positional_args():
+    """Positional usernames are returned as-is (as a list)."""
+    assert resolve_delete_usernames(("alice", "bob"), None) == ["alice", "bob"]
+
+
+def test_resolve_delete_usernames_from_csv(tmp_path):
+    """--file resolves to the usernames parsed from the CSV, ignoring other columns."""
+    csv = tmp_path / "u.csv"
+    csv.write_text("username,email\nalice,a@x.io\nbob,b@x.io\n")
+
+    assert resolve_delete_usernames((), str(csv)) == ["alice", "bob"]
+
+
+def test_resolve_delete_usernames_rejects_both(tmp_path):
+    """Passing both positional usernames and --file is rejected."""
+    csv = tmp_path / "u.csv"
+    csv.write_text("username,email\nalice,a@x.io\n")
+
+    with pytest.raises(click.ClickException, match="either USERNAMES or --file"):
+        resolve_delete_usernames(("alice",), str(csv))
+
+
+def test_resolve_delete_usernames_rejects_neither():
+    """Passing neither positional usernames nor --file is rejected."""
+    with pytest.raises(click.ClickException, match="Provide one or more USERNAMES"):
+        resolve_delete_usernames((), None)
 
 
 def _write_registry(tmp_path, users):
@@ -136,3 +172,45 @@ def test_run_reconcile_in_sync(tmp_path, capsys):
     run_reconcile(str(tmp_path))
 
     assert "In sync" in capsys.readouterr().out
+
+
+def test_run_reconcile_fix_reprovisions_missing(tmp_path, capsys):
+    """--fix reprovisions when there are missing/drifted users."""
+    _write_registry(tmp_path, {"alice": {"email": "a@x.io"}})
+
+    with patch("src.cmd_utils.configPkg.Config", return_value=MagicMock()), patch(
+        "src.cmd_utils.userPkg.add_users", return_value=None
+    ) as mock_add:
+        run_reconcile(str(tmp_path), fix=True)
+
+    mock_add.assert_called_once()
+    assert "Reprovisioned" in capsys.readouterr().out
+
+
+def test_run_reconcile_fix_skips_when_in_sync(tmp_path):
+    """--fix does not reprovision when there is nothing missing or drifted."""
+    _write_registry(tmp_path, {"alice": {"email": "a@x.io"}})
+    stored = config_hash({"image": "v1"})
+    (tmp_path / ".dtaas.state.json").write_text(
+        json.dumps({"alice": {"config_hash": stored}}), encoding="utf-8"
+    )
+    (tmp_path / "compose.users.yml").write_text(
+        "services:\n  alice:\n    image: v1\n", encoding="utf-8"
+    )
+
+    with patch("src.cmd_utils.userPkg.add_users") as mock_add:
+        run_reconcile(str(tmp_path), fix=True)
+
+    mock_add.assert_not_called()
+
+
+def test_run_reconcile_fix_never_touches_unexpected(tmp_path):
+    """--fix does not reprovision for an 'unexpected' (unregistered) service alone."""
+    (tmp_path / "compose.users.yml").write_text(
+        "services:\n  carol:\n    image: v1\n", encoding="utf-8"
+    )
+
+    with patch("src.cmd_utils.userPkg.add_users") as mock_add:
+        run_reconcile(str(tmp_path), fix=True)
+
+    mock_add.assert_not_called()

--- a/cli/tests/test_config_validate.py
+++ b/cli/tests/test_config_validate.py
@@ -24,9 +24,12 @@ def base(tmp_path):
             },
         },
         "users": {
-            "add": ["u1", "u2"],
-            "delete": ["u2"],
-            "u1": {"email": "u1@intocps.org"},
+            "starting": ["u1", "u2"],
+            "u1": {
+                "email": "u1@intocps.org",
+                "groups": ["default"],
+                "load_balance": True,
+            },
             "u2": {"email": "u2@intocps.org"},
         },
     }
@@ -162,15 +165,14 @@ def test_resources_required_when_set_limits_true(base):
     assert "common.resources.shm_size is missing" in errors
 
 
-def test_user_lists_validation(base):
-    """users.add/delete are optional but must be lists of strings when present."""
+def test_starting_validation(base):
+    """users.starting is optional but must be a list of strings when present."""
     data = copy.deepcopy(base)
-    data["users"] = {"add": "notalist", "delete": ["ok", 5]}
+    data["users"] = {"starting": ["ok", 5]}
     errors = collect_errors(data)
-    assert "users.add must be a list of strings" in errors
-    assert "users.delete must be a list of strings" in errors
+    assert "users.starting must be a list of strings" in errors
 
-    data["users"] = {}  # absent lists are allowed
+    data["users"] = {}  # absent list is allowed
     assert collect_errors(data) == []
 
 
@@ -178,7 +180,7 @@ def test_email_validation(base):
     """Each user sub-table must carry a valid email."""
     data = copy.deepcopy(base)
     data["users"] = {
-        "add": ["u1"],
+        "starting": ["u1"],
         "u1": {"email": "not-an-email"},
         "u2": {},  # missing email
     }
@@ -191,8 +193,21 @@ def test_email_validation_rejects_malformed_addresses(base):
     """email-validator catches cases a minimal regex would wrongly accept."""
     for bad in ("foo@@bar.com", "foo@bar", "foo@.com", 123):
         data = copy.deepcopy(base)
-        data["users"] = {"add": ["u1"], "u1": {"email": bad}}
+        data["users"] = {"starting": ["u1"], "u1": {"email": bad}}
         assert "users.u1.email is not a valid email address" in collect_errors(data)
+
+
+def test_groups_and_load_balance_validation(base):
+    """Per-user groups must be a string list and load_balance a boolean."""
+    data = copy.deepcopy(base)
+    data["users"]["u1"] = {
+        "email": "u1@intocps.org",
+        "groups": "notalist",
+        "load_balance": "yes",
+    }
+    errors = collect_errors(data)
+    assert "users.u1.groups must be a list of strings" in errors
+    assert "users.u1.load_balance must be true or false" in errors
 
 
 def test_deploy_sections_are_optional(base):

--- a/cli/tests/test_config_validate.py
+++ b/cli/tests/test_config_validate.py
@@ -260,15 +260,17 @@ def test_non_dict_sections_report_missing_keys():
 def test_validate_config_missing_file(tmp_path, monkeypatch):
     """validate_config raises FileNotFoundError when no dtaas.toml exists."""
     monkeypatch.chdir(tmp_path)  # neither output_dir nor cwd has the file
+    output_dir = str(tmp_path)
     with pytest.raises(FileNotFoundError, match="dtaas.toml not found"):
-        validate_config(str(tmp_path))
+        validate_config(output_dir)
 
 
 def test_validate_config_parse_error(tmp_path):
     """validate_config raises ValueError when the file cannot be parsed."""
     (tmp_path / "dtaas.toml").write_text("key = = =")
+    output_dir = str(tmp_path)
     with pytest.raises(ValueError):
-        validate_config(str(tmp_path))
+        validate_config(output_dir)
 
 
 def test_validate_config_returns_empty_for_valid_file(tmp_path):

--- a/cli/tests/test_deploy_config.py
+++ b/cli/tests/test_deploy_config.py
@@ -50,7 +50,7 @@ def test_build_file_specs_insecure_server():
     """insecure-server splits server and frontend OAuth apps per file"""
     toml = {
         "common": {"server-dns": "myserver.com"},
-        "users": {"add": ["alice"], "alice": {"email": "alice@example.com"}},
+        "users": {"starting": ["alice"], "alice": {"email": "alice@example.com"}},
         "insecure-server": {
             "oauth-client-id": "server_id",
             "oauth-client-secret": "server_secret",
@@ -92,7 +92,7 @@ def test_build_file_specs_secure_server_uses_https():
     """secure-server uses https:// for REACT_APP_URL and friends"""
     toml = {
         "common": {"server-dns": "myserver.com"},
-        "users": {"add": ["alice"]},
+        "users": {"starting": ["alice"]},
         "secure-server": {
             "oauth-client-id": "id",
             "oauth-client-secret": "secret",
@@ -197,8 +197,8 @@ def test_apply_config_skips_binary_file(tmp_path):
 
 
 def test_toml_lookup_user_collision_reserved_key():
-    """email lookup is safe when a username collides with the 'add' key"""
-    toml = {"users": {"add": ["add"]}}
+    """email lookup is safe when a username collides with the 'starting' key"""
+    toml = {"users": {"starting": ["starting"]}}
     assert _toml_lookup(toml, "users.email1") == ""
 
 

--- a/cli/tests/test_deploy_config.py
+++ b/cli/tests/test_deploy_config.py
@@ -141,9 +141,11 @@ def test_apply_config_raises_on_file_error(tmp_path):
     """write failures are collected and raised as OSError"""
     bad = tmp_path / ".env"
     bad.write_text("SERVER_DNS=localhost\n")
+    dest = str(tmp_path)
+    specs = [(".env", "env", {"SERVER_DNS": "x"})]
     with patch.object(Path, "write_text", side_effect=OSError("permission denied")):
         with pytest.raises(OSError):
-            apply_config(str(tmp_path), [(".env", "env", {"SERVER_DNS": "x"})])
+            apply_config(dest, specs)
 
 
 def test_validate_value_rejects_newline():

--- a/cli/tests/test_project.py
+++ b/cli/tests/test_project.py
@@ -60,9 +60,10 @@ def test_generate_config_skips_existing_without_force(tmp_path, capsys):
 
 def test_generate_config_raises_on_copy_failure(tmp_path):
     """OSError is raised when the dtaas.toml copy fails."""
+    dest = str(tmp_path)
     with patch("src.pkg.project.shutil.copy2", side_effect=OSError("disk full")):
         with pytest.raises(OSError, match="disk full"):
-            generate_config(str(tmp_path))
+            generate_config(dest)
 
 
 def test_generate_project_skips_existing_file(tmp_path, capsys):
@@ -85,9 +86,10 @@ def test_generate_project_copies_resources_overlay(tmp_path):
 
 def test_generate_project_raises_on_copy_failure(tmp_path):
     """OSError is raised when a file copy fails."""
+    dest = str(tmp_path)
     with patch("src.pkg.project.shutil.copy2", side_effect=OSError("disk full")):
         with pytest.raises(OSError, match="disk full"):
-            generate_project(str(tmp_path))
+            generate_project(dest)
 
 
 def test_copy_file_skips_existing(tmp_path, capsys):
@@ -242,9 +244,10 @@ def test_copy_example_files_skips_existing_without_force(tmp_path):
 
 def test_generate_project_raises_when_templates_dir_missing(tmp_path):
     """generate_project raises RuntimeError when the bundled templates are absent."""
+    out = str(tmp_path / "out")
     with patch("src.pkg.project.TEMPLATES_DIR", tmp_path / "no-templates"):
         with pytest.raises(RuntimeError, match="templates directory not found"):
-            generate_project(str(tmp_path / "out"))
+            generate_project(out)
 
 
 def test_copy_example_files_raises_on_copy_failure(tmp_path):

--- a/cli/tests/test_project.py
+++ b/cli/tests/test_project.py
@@ -9,6 +9,7 @@ from src.pkg.project import (
     generate_deploy_project,
     create_user_dirs,
     set_files_permissions,
+    _copy_config_file,
     _copy_example_files,
     _copy_file,
     _check_no_symlinks,
@@ -19,12 +20,32 @@ from src.pkg.project import (
 # pylint: disable=protected-access
 
 
-def test_generate_config_copies_only_toml(tmp_path):
-    """generate_config writes dtaas.toml (returning False) and no other templates."""
+def test_generate_config_copies_toml_and_users_csv(tmp_path):
+    """generate_config writes dtaas.toml (returning False) and the users.csv sample."""
     assert generate_config(str(tmp_path)) is False
 
     assert (tmp_path / "dtaas.toml").is_file()
+    assert (tmp_path / "users.csv").is_file()
     assert not (tmp_path / "users.server.yml").exists()
+
+
+def test_generate_config_skips_existing_users_csv(tmp_path, capsys):
+    """An existing users.csv is preserved and a skip message is printed."""
+    (tmp_path / "users.csv").write_text("existing")
+
+    generate_config(str(tmp_path))
+
+    assert (tmp_path / "users.csv").read_text() == "existing"
+    assert "'users.csv' already exists, skipping" in capsys.readouterr().out
+
+
+def test_copy_config_file_writes_and_reports_skip(tmp_path, capsys):
+    """_copy_config_file returns False when written, True (with a message) when skipped."""
+    assert _copy_config_file("dtaas.toml", str(tmp_path), force=False) is False
+    assert (tmp_path / "dtaas.toml").is_file()
+
+    assert _copy_config_file("dtaas.toml", str(tmp_path), force=False) is True
+    assert "'dtaas.toml' already exists, skipping" in capsys.readouterr().out
 
 
 def test_generate_config_skips_existing_without_force(tmp_path, capsys):

--- a/cli/tests/test_registry.py
+++ b/cli/tests/test_registry.py
@@ -1,0 +1,105 @@
+"""Tests for the CLI-owned user registry store."""
+
+import json
+from src.pkg.registry import (
+    load_registry,
+    add_to_registry,
+    remove_from_registry,
+    read_csv_users,
+    _parse_csv_row,
+)
+# pylint: disable=protected-access
+
+USERS_CSV = (
+    "username,email,groups,load_balance\n"
+    "alice,alice@intocps.org,additional,true\n"
+    "bob,bob@intocps.org,additional;beta-testers,false\n"
+)
+
+
+def test_load_registry_empty_when_absent(tmp_path):
+    """A missing registry reads as an empty store, not an error."""
+    assert load_registry(str(tmp_path / "nope.json")) == {}
+
+
+def test_load_registry_reads_user_store(tmp_path):
+    """load_registry returns the users mapping from the JSON file."""
+    path = tmp_path / "dtaas.users.registry.json"
+    path.write_text(
+        json.dumps({"users": {"alice": {"email": "alice@intocps.org"}}}),
+        encoding="utf-8",
+    )
+
+    assert load_registry(str(path))["alice"]["email"] == "alice@intocps.org"
+
+
+def test_add_to_registry_merges_and_persists(tmp_path):
+    """add_to_registry unions new users into the store and writes it atomically."""
+    path = str(tmp_path / "dtaas.users.registry.json")
+
+    add_to_registry({"alice": {"email": "a@x.io"}}, path)
+    store = add_to_registry({"bob": {"email": "b@x.io"}}, path)
+
+    assert set(store) == {"alice", "bob"}
+    assert load_registry(path) == store
+    assert not (tmp_path / "dtaas.users.registry.json.tmp").exists()
+
+
+def test_add_to_registry_updates_existing_user(tmp_path):
+    """Re-adding a username overwrites that user's details."""
+    path = str(tmp_path / "dtaas.users.registry.json")
+    add_to_registry({"alice": {"email": "old@x.io"}}, path)
+
+    store = add_to_registry({"alice": {"email": "new@x.io"}}, path)
+
+    assert store["alice"]["email"] == "new@x.io"
+
+
+def test_remove_from_registry_drops_named_users(tmp_path):
+    """remove_from_registry deletes the named users and reports what was removed."""
+    path = str(tmp_path / "dtaas.users.registry.json")
+    add_to_registry({"alice": {}, "bob": {}}, path)
+
+    removed = remove_from_registry(["alice", "ghost"], path)
+
+    assert removed == ["alice"]
+    assert set(load_registry(path)) == {"bob"}
+
+
+def test_parse_csv_row_splits_groups_and_reads_load_balance():
+    """_parse_csv_row splits ';' groups and parses the boolean load_balance."""
+    username, details = _parse_csv_row(
+        {
+            "username": " bob ",
+            "email": "bob@intocps.org",
+            "groups": "additional;beta-testers",
+            "load_balance": "false",
+        }
+    )
+
+    assert username == "bob"
+    assert details["groups"] == ["additional", "beta-testers"]
+    assert details["load_balance"] is False
+
+
+def test_read_csv_users_parses_all_rows(tmp_path):
+    """read_csv_users turns every CSV row into a {username: details} entry."""
+    csv_path = tmp_path / "users.csv"
+    csv_path.write_text(USERS_CSV, encoding="utf-8")
+
+    users = read_csv_users(str(csv_path))
+
+    assert set(users) == {"alice", "bob"}
+    assert users["alice"]["load_balance"] is True
+    assert users["bob"]["groups"] == ["additional", "beta-testers"]
+
+
+def test_csv_import_round_trips_through_registry(tmp_path):
+    """A CSV merged into the registry reads back as the same user store."""
+    csv_path = tmp_path / "users.csv"
+    csv_path.write_text(USERS_CSV, encoding="utf-8")
+    registry_path = str(tmp_path / "dtaas.users.registry.json")
+
+    add_to_registry(read_csv_users(str(csv_path)), registry_path)
+
+    assert set(load_registry(registry_path)) == {"alice", "bob"}

--- a/cli/tests/test_registry.py
+++ b/cli/tests/test_registry.py
@@ -152,6 +152,20 @@ def test_read_csv_users_parses_all_rows(tmp_path):
     assert users["bob"]["groups"] == ["additional", "beta-testers"]
 
 
+def test_read_csv_users_rejects_duplicate_username(tmp_path):
+    """A username repeated in the CSV is rejected rather than silently overwritten."""
+    csv_path = tmp_path / "users.csv"
+    csv_path.write_text(
+        "username,email,groups,load_balance\n"
+        "alice,alice@intocps.org,additional,true\n"
+        "alice,other@intocps.org,additional,false\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Duplicate username 'alice'"):
+        read_csv_users(str(csv_path))
+
+
 def test_csv_import_round_trips_through_registry(tmp_path):
     """A CSV merged into the registry reads back as the same user store."""
     csv_path = tmp_path / "users.csv"

--- a/cli/tests/test_registry.py
+++ b/cli/tests/test_registry.py
@@ -1,12 +1,15 @@
 """Tests for the CLI-owned user registry store."""
 
 import json
+from unittest.mock import patch
+import pytest
 from src.pkg.registry import (
     load_registry,
-    add_to_registry,
+    register_new_users,
     remove_from_registry,
     read_csv_users,
     _parse_csv_row,
+    _partition_new,
 )
 # pylint: disable=protected-access
 
@@ -33,32 +36,54 @@ def test_load_registry_reads_user_store(tmp_path):
     assert load_registry(str(path))["alice"]["email"] == "alice@intocps.org"
 
 
-def test_add_to_registry_merges_and_persists(tmp_path):
-    """add_to_registry unions new users into the store and writes it atomically."""
+def test_register_new_users_merges_and_persists(tmp_path):
+    """register_new_users unions new users into the store and writes atomically."""
     path = str(tmp_path / "dtaas.users.registry.json")
 
-    add_to_registry({"alice": {"email": "a@x.io"}}, path)
-    store = add_to_registry({"bob": {"email": "b@x.io"}}, path)
+    register_new_users({"alice": {"email": "a@x.io"}}, [], path)
+    added, skipped = register_new_users({"bob": {"email": "b@x.io"}}, [], path)
 
-    assert set(store) == {"alice", "bob"}
-    assert load_registry(path) == store
+    assert added == ["bob"] and skipped == []
+    assert set(load_registry(path)) == {"alice", "bob"}
     assert not (tmp_path / "dtaas.users.registry.json.tmp").exists()
 
 
-def test_add_to_registry_updates_existing_user(tmp_path):
-    """Re-adding a username overwrites that user's details."""
+def test_register_new_users_skips_existing_without_overwriting(tmp_path):
+    """A name already in the registry is skipped, keeping its original details."""
     path = str(tmp_path / "dtaas.users.registry.json")
-    add_to_registry({"alice": {"email": "old@x.io"}}, path)
+    register_new_users({"alice": {"email": "old@x.io"}}, [], path)
 
-    store = add_to_registry({"alice": {"email": "new@x.io"}}, path)
+    added, skipped = register_new_users(
+        {"alice": {"email": "new@x.io"}, "carol": {"email": "c@x.io"}}, [], path
+    )
 
-    assert store["alice"]["email"] == "new@x.io"
+    assert added == ["carol"]
+    assert skipped == ["alice"]
+    assert load_registry(path)["alice"]["email"] == "old@x.io"
+
+
+def test_register_new_users_skips_reserved_starting_user(tmp_path):
+    """A username that is a starting user (reserved) is never added."""
+    path = str(tmp_path / "dtaas.users.registry.json")
+
+    added, skipped = register_new_users({"bob": {"email": "b@x.io"}}, ["bob"], path)
+
+    assert added == [] and skipped == ["bob"]
+    assert load_registry(path) == {}
+
+
+def test_partition_new_splits_known_and_new():
+    """_partition_new separates already-known names from genuinely new ones."""
+    added, skipped = _partition_new({"alice": {"e": 1}, "bob": {"e": 2}}, {"alice"})
+
+    assert added == {"bob": {"e": 2}}
+    assert skipped == ["alice"]
 
 
 def test_remove_from_registry_drops_named_users(tmp_path):
     """remove_from_registry deletes the named users and reports what was removed."""
     path = str(tmp_path / "dtaas.users.registry.json")
-    add_to_registry({"alice": {}, "bob": {}}, path)
+    register_new_users({"alice": {}, "bob": {}}, [], path)
 
     removed = remove_from_registry(["alice", "ghost"], path)
 
@@ -82,6 +107,39 @@ def test_parse_csv_row_splits_groups_and_reads_load_balance():
     assert details["load_balance"] is False
 
 
+def test_parse_csv_row_strips_group_names():
+    """Whitespace around ';'-separated group tags is trimmed."""
+    _, details = _parse_csv_row(
+        {"username": "x", "email": "x@y.io", "groups": " a ; b ", "load_balance": ""}
+    )
+    assert details["groups"] == ["a", "b"]
+
+
+def test_parse_csv_row_defaults_empty_groups_to_additional():
+    """An empty groups cell defaults to ['additional']."""
+    _, details = _parse_csv_row(
+        {"username": "x", "email": "x@y.io", "groups": "", "load_balance": "true"}
+    )
+    assert details["groups"] == ["additional"]
+
+
+def test_parse_csv_row_rejects_invalid_load_balance():
+    """A load_balance value that is neither true nor false is rejected."""
+    with pytest.raises(ValueError, match="load_balance"):
+        _parse_csv_row(
+            {"username": "x", "email": "x@y.io", "groups": "", "load_balance": "yes"}
+        )
+
+
+def test_write_registry_fsyncs_before_replace(tmp_path):
+    """The registry temp file is fsync'd before the atomic rename."""
+    path = str(tmp_path / "dtaas.users.registry.json")
+    with patch("src.pkg.registry.os.fsync") as mock_fsync:
+        register_new_users({"alice": {}}, [], path)
+
+    mock_fsync.assert_called_once()
+
+
 def test_read_csv_users_parses_all_rows(tmp_path):
     """read_csv_users turns every CSV row into a {username: details} entry."""
     csv_path = tmp_path / "users.csv"
@@ -100,6 +158,6 @@ def test_csv_import_round_trips_through_registry(tmp_path):
     csv_path.write_text(USERS_CSV, encoding="utf-8")
     registry_path = str(tmp_path / "dtaas.users.registry.json")
 
-    add_to_registry(read_csv_users(str(csv_path)), registry_path)
+    register_new_users(read_csv_users(str(csv_path)), [], registry_path)
 
     assert set(load_registry(registry_path)) == {"alice", "bob"}

--- a/cli/tests/test_registry.py
+++ b/cli/tests/test_registry.py
@@ -161,9 +161,10 @@ def test_read_csv_users_rejects_duplicate_username(tmp_path):
         "alice,other@intocps.org,additional,false\n",
         encoding="utf-8",
     )
+    csv_file = str(csv_path)
 
     with pytest.raises(ValueError, match="Duplicate username 'alice'"):
-        read_csv_users(str(csv_path))
+        read_csv_users(csv_file)
 
 
 def test_csv_import_round_trips_through_registry(tmp_path):

--- a/cli/tests/test_state.py
+++ b/cli/tests/test_state.py
@@ -3,7 +3,14 @@
 import json
 from unittest.mock import patch, MagicMock
 from python_on_whales.exceptions import DockerException
-from src.pkg.state import config_hash, build_state, write_state, _service_facts
+from src.pkg.state import (
+    config_hash,
+    build_state,
+    write_state,
+    load_state,
+    find_drift,
+    _service_facts,
+)
 # pylint: disable=protected-access
 
 
@@ -66,3 +73,45 @@ def test_service_facts_returns_empty_on_docker_error():
         side_effect=DockerException(["docker", "compose", "ps"], 1),
     ):
         assert _service_facts() == {}
+
+
+def test_load_state_empty_when_absent(tmp_path):
+    """A missing state cache reads as an empty mapping."""
+    assert load_state(str(tmp_path / "nope.json")) == {}
+
+
+def test_load_state_reads_file(tmp_path):
+    """load_state returns the recorded per-user facts."""
+    path = tmp_path / ".dtaas.state.json"
+    path.write_text(
+        json.dumps({"alice": {"config_hash": "sha256:x"}}), encoding="utf-8"
+    )
+
+    assert load_state(str(path))["alice"]["config_hash"] == "sha256:x"
+
+
+def test_find_drift_detects_changed_untracked_orphaned():
+    """find_drift classifies drifted, untracked, and orphaned users."""
+    services = {"alice": {"image": "v2"}, "bob": {"image": "b"}}
+    state = {
+        "alice": {"config_hash": config_hash({"image": "v1"})},  # config changed
+        "carol": {"config_hash": "sha256:x"},  # no longer provisioned
+    }
+
+    report = find_drift(state, services)
+
+    assert report["drifted"] == ["alice"]
+    assert report["untracked"] == ["bob"]
+    assert report["orphaned"] == ["carol"]
+
+
+def test_find_drift_in_sync():
+    """A state cache matching the compose services reports no drift."""
+    services = {"alice": {"image": "v1"}}
+    state = {"alice": {"config_hash": config_hash({"image": "v1"})}}
+
+    assert find_drift(state, services) == {
+        "drifted": [],
+        "untracked": [],
+        "orphaned": [],
+    }

--- a/cli/tests/test_state.py
+++ b/cli/tests/test_state.py
@@ -1,0 +1,68 @@
+"""Tests for the .dtaas.state.json runtime state cache."""
+
+import json
+from unittest.mock import patch, MagicMock
+from python_on_whales.exceptions import DockerException
+from src.pkg.state import config_hash, build_state, write_state, _service_facts
+# pylint: disable=protected-access
+
+
+def test_config_hash_is_stable_and_order_independent():
+    """config_hash ignores key order and changes when the config changes."""
+    assert config_hash({"a": 1, "b": 2}) == config_hash({"b": 2, "a": 1})
+    assert config_hash({"a": 1}) != config_hash({"a": 2})
+    assert config_hash({}).startswith("sha256:")
+
+
+def test_build_state_merges_facts_and_hash():
+    """build_state records the container facts and config hash per user."""
+    state = build_state({"alice": {"image": "x"}}, {"alice": ("cid123", "running")})
+
+    entry = state["alice"]
+    assert entry["container_id"] == "cid123"
+    assert entry["status"] == "running"
+    assert entry["config_hash"] == config_hash({"image": "x"})
+    assert entry["provisioned_at"]
+
+
+def test_build_state_defaults_missing_facts_to_none():
+    """Users without a live container get null container facts, still hashed."""
+    state = build_state({"bob": {"image": "y"}}, {})
+
+    assert state["bob"]["container_id"] is None
+    assert state["bob"]["status"] is None
+    assert state["bob"]["config_hash"].startswith("sha256:")
+
+
+def test_write_state_writes_file(tmp_path):
+    """write_state serialises the state mapping to the given path."""
+    path = tmp_path / ".dtaas.state.json"
+    with patch("src.pkg.state._service_facts", return_value={}):
+        write_state({"alice": {"image": "x"}}, str(path))
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["alice"]["config_hash"].startswith("sha256:")
+
+
+def test_service_facts_maps_service_label_to_container(tmp_path):
+    """_service_facts keys facts by the compose service label."""
+    container = MagicMock()
+    container.id = "cid1"
+    container.state.status = "running"
+    container.config.labels = {"com.docker.compose.service": "alice"}
+    client = MagicMock()
+    client.compose.ps.return_value = [container]
+
+    with patch("src.pkg.state.DockerClient", return_value=client):
+        facts = _service_facts()
+
+    assert facts == {"alice": ("cid1", "running")}
+
+
+def test_service_facts_returns_empty_on_docker_error():
+    """A Docker failure degrades to an empty fact mapping (best-effort)."""
+    with patch(
+        "src.pkg.state.DockerClient",
+        side_effect=DockerException(["docker", "compose", "ps"], 1),
+    ):
+        assert _service_facts() == {}

--- a/cli/tests/test_state.py
+++ b/cli/tests/test_state.py
@@ -90,28 +90,44 @@ def test_load_state_reads_file(tmp_path):
     assert load_state(str(path))["alice"]["config_hash"] == "sha256:x"
 
 
-def test_find_drift_detects_changed_untracked_orphaned():
-    """find_drift classifies drifted, untracked, and orphaned users."""
-    services = {"alice": {"image": "v2"}, "bob": {"image": "b"}}
-    state = {
-        "alice": {"config_hash": config_hash({"image": "v1"})},  # config changed
-        "carol": {"config_hash": "sha256:x"},  # no longer provisioned
-    }
+def test_find_drift_detects_missing_unexpected_drifted():
+    """find_drift classifies missing, unexpected, and drifted users.
 
-    report = find_drift(state, services)
+    'alice' is registered and provisioned but her live config no longer
+    matches what was recorded (drifted). 'bob' is registered but not
+    provisioned at all (missing). 'carol' is provisioned but not registered
+    (unexpected).
+    """
+    registry_users = {"alice": {}, "bob": {}}
+    services = {"alice": {"image": "v2"}, "carol": {"image": "c"}}
+    state = {"alice": {"config_hash": config_hash({"image": "v1"})}}
 
+    report = find_drift(registry_users, state, services)
+
+    assert report["missing"] == ["bob"]
+    assert report["unexpected"] == ["carol"]
     assert report["drifted"] == ["alice"]
-    assert report["untracked"] == ["bob"]
-    assert report["orphaned"] == ["carol"]
 
 
 def test_find_drift_in_sync():
-    """A state cache matching the compose services reports no drift."""
+    """A registry matching the live compose services reports no drift."""
+    registry_users = {"alice": {}}
     services = {"alice": {"image": "v1"}}
     state = {"alice": {"config_hash": config_hash({"image": "v1"})}}
 
-    assert find_drift(state, services) == {
+    assert find_drift(registry_users, state, services) == {
+        "missing": [],
+        "unexpected": [],
         "drifted": [],
-        "untracked": [],
-        "orphaned": [],
     }
+
+
+def test_find_drift_skips_unrecorded_config_hash():
+    """A registered, provisioned user with no entry in the state cache is not
+    flagged as drifted -- there is nothing to compare against."""
+    registry_users = {"alice": {}}
+    services = {"alice": {"image": "v1"}}
+
+    report = find_drift(registry_users, {}, services)
+
+    assert report == {"missing": [], "unexpected": [], "drifted": []}

--- a/cli/tests/test_users.py
+++ b/cli/tests/test_users.py
@@ -8,15 +8,13 @@ from src.pkg import users
 from src.pkg import users_utils
 from src.pkg.project import generate_project
 from tests.conftest import CONF_SERVER_CONTENT
-# pylint: disable=redefined-outer-name,unused-argument
+# pylint: disable=redefined-outer-name,unused-argument,protected-access
 
 
 @pytest.fixture
 def mock_config():
-    """Mock config object"""
+    """Mock config object providing deployment settings from dtaas.toml."""
     mock = MagicMock()
-    mock.get_add_users_list.return_value = (["user1"], None)
-    mock.get_delete_users_list.return_value = (["user1"], None)
     mock.get_server_dns.return_value = ("foo.example.com", None)
     mock.get_path.return_value = ("/test/path", None)
     mock.get_resource_limits.return_value = (
@@ -25,8 +23,17 @@ def mock_config():
     )
     mock.get_tls.return_value = (False, None)
     mock.get_set_limits.return_value = (True, None)
-    mock.get_users.return_value = ({"add": ["user1"], "user1": {}}, None)
     return mock
+
+
+@pytest.fixture
+def mock_registry():
+    """Patch the registry store functions add_users/delete_users use."""
+    with patch("src.pkg.users.load_registry") as mock_load, patch(
+        "src.pkg.users.remove_from_registry"
+    ) as mock_remove:
+        mock_load.return_value = {"user1": {"email": "user1@x.io"}}
+        yield {"load": mock_load, "remove": mock_remove}
 
 
 @pytest.fixture
@@ -48,9 +55,10 @@ def mock_user_operations():
         "src.pkg.users.add_users_to_compose"
     ) as ma, patch("src.pkg.users.start_user_containers") as ms, patch(
         "src.pkg.users.stop_user_containers"
-    ) as mst:
+    ) as mst, patch("src.pkg.users.write_state") as mw:
         mc.return_value = ma.return_value = ms.return_value = mst.return_value = None
-        yield {"create": mc, "add": ma, "start": ms, "stop": mst}
+        mw.return_value = {}
+        yield {"create": mc, "add": ma, "start": ms, "stop": mst, "state": mw}
 
 
 @pytest.fixture
@@ -200,27 +208,37 @@ def test_run_command_for_containers(mock_run, returncode, has_error):
     "compose,field", [({"services": {}}, "version"), ({"version": "3"}, "services")]
 )
 def test_add_users_missing_fields(
-    mock_config, mock_utils, mock_user_operations, compose, field
+    mock_config, mock_registry, mock_utils, mock_user_operations, compose, field
 ):
     """Test add_users adds missing fields to compose"""
     mock_utils["import"].return_value = (compose, None)
     assert users.add_users(mock_config) is None and field in compose
 
 
-def test_add_users_returns_config_error(mock_config, mock_utils):
-    """add_users returns the exception when config retrieval fails."""
-    mock_config.get_add_users_list.return_value = (None, Exception("missing add list"))
+def test_add_users_returns_registry_error(mock_config, mock_registry, mock_utils):
+    """add_users returns the exception when the registry cannot be read."""
+    mock_registry["load"].side_effect = ValueError("bad registry")
 
     err = users.add_users(mock_config)
 
-    assert err is not None and "missing add list" in str(err)
+    assert err is not None and "bad registry" in str(err)
+
+
+def test_get_registry_users_returns_list_and_details(mock_registry):
+    """_get_registry_users pairs the registry usernames with the details store."""
+    mock_registry["load"].return_value = {"alice": {"email": "a@x.io"}}
+
+    user_list, users_section = users._get_registry_users()
+
+    assert user_list == ["alice"]
+    assert users_section["alice"]["email"] == "a@x.io"
 
 
 def test_add_users_rejects_newline_in_email(
-    mock_config, mock_utils, mock_user_operations
+    mock_config, mock_registry, mock_utils, mock_user_operations
 ):
     """A newline in a user's email aborts add_users without writing the rule."""
-    mock_config.get_users.return_value = ({"user1": {"email": "bad\n@x.com"}}, None)
+    mock_registry["load"].return_value = {"user1": {"email": "bad\n@x.com"}}
 
     err = users.add_users(mock_config)
 
@@ -228,23 +246,23 @@ def test_add_users_rejects_newline_in_email(
 
 
 @pytest.mark.parametrize("export_error", [False, True])
-def test_delete_user(mock_config, mock_utils, mock_user_operations, export_error):
-    """Test delete_user removes users from compose"""
+def test_delete_users(mock_registry, mock_utils, mock_user_operations, export_error):
+    """delete_users removes users from compose and, on success, the registry."""
     compose = {"version": "3", "services": {"user1": {}, "user2": {}}}
-    mock_config.get_delete_users_list.return_value = (["user1"], None)
     mock_utils["import"].return_value = (compose, None)
     mock_utils["export"].return_value = Exception("Failed") if export_error else None
 
-    err = users.delete_user(mock_config)
+    err = users.delete_users(["user1"])
+
     assert (err is not None) if export_error else err is None
+    if not export_error:
+        mock_registry["remove"].assert_called_once_with(["user1"])
 
 
-def test_delete_user_handles_none_compose(
-    mock_config, mock_utils, mock_user_operations
-):
-    """delete_user returns an error when the compose file loads as None."""
+def test_delete_users_handles_none_compose(mock_registry, mock_utils):
+    """delete_users returns an error when the compose file loads as None."""
     mock_utils["import"].return_value = (None, None)
 
-    err = users.delete_user(mock_config)
+    err = users.delete_users(["user1"])
 
     assert err is not None and "Failed to load compose" in str(err)

--- a/cli/tests/test_users.py
+++ b/cli/tests/test_users.py
@@ -1,13 +1,8 @@
-"""Tests for users module."""
+"""Tests for the 'user add'/'user delete' orchestration in users.py."""
 
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest.mock import patch, MagicMock
 import pytest
 from src.pkg import users
-from src.pkg import users_utils
-from src.pkg.project import generate_project
-from tests.conftest import CONF_SERVER_CONTENT
 # pylint: disable=redefined-outer-name,unused-argument,protected-access
 
 
@@ -38,195 +33,27 @@ def mock_registry():
 
 @pytest.fixture
 def mock_utils():
-    """Mock all utils functions"""
+    """Mock the utils functions add_users/delete_users call directly."""
     with patch("src.pkg.users.utils.import_yaml") as mi, patch(
         "src.pkg.users.utils.export_yaml"
-    ) as me, patch("src.pkg.users.utils.replace_all") as mr:
+    ) as me:
         mi.return_value = ({"version": "3", "services": {}}, None)
         me.return_value = None
-        mr.return_value = ({"image": "test"}, None)
-        yield {"import": mi, "export": me, "replace": mr}
+        yield {"import": mi, "export": me}
 
 
 @pytest.fixture
 def mock_user_operations():
-    """Mock user operation functions"""
+    """Mock the users_compose functions imported into users.py"""
     with patch("src.pkg.users.create_user_files") as mc, patch(
         "src.pkg.users.add_users_to_compose"
-    ) as ma, patch("src.pkg.users.start_user_containers") as ms, patch(
+    ) as ma, patch("src.pkg.users.finalize_compose") as mf, patch(
         "src.pkg.users.stop_user_containers"
     ) as mst, patch("src.pkg.users.write_state") as mw:
-        mc.return_value = ma.return_value = ms.return_value = mst.return_value = None
+        mc.return_value = ma.return_value = mf.return_value = None
+        mst.return_value = None
         mw.return_value = {}
-        yield {"create": mc, "add": ma, "start": ms, "stop": mst, "state": mw}
-
-
-@pytest.fixture
-def temp_dir_with_template():
-    """Temporary directory with template folder"""
-    with TemporaryDirectory() as tmpdir:
-        (Path(tmpdir) / "template").mkdir(parents=True, exist_ok=True)
-        (Path(tmpdir) / "template" / "test.txt").write_text("test")
-        yield tmpdir
-
-
-@pytest.mark.parametrize("usernames", [["testuser"], ["user1", "user2", "user3"], []])
-def test_create_user_files(temp_dir_with_template, usernames):
-    """Test create_user_files creates user directories"""
-    assert users.create_user_files(usernames, temp_dir_with_template) is None
-    assert all(Path(temp_dir_with_template, u).exists() for u in usernames)
-
-
-def test_create_user_files_chowns_nested_items(temp_dir_with_template):
-    """When chown succeeds, ownership is applied to the dir and every nested item."""
-    with patch("src.pkg.users.shutil.chown") as mock_chown:
-        assert users.create_user_files(["alice"], temp_dir_with_template) is None
-
-    chowned = [call.args[0] for call in mock_chown.call_args_list]
-    assert Path(temp_dir_with_template, "alice") in chowned
-    assert Path(temp_dir_with_template, "alice", "test.txt") in chowned
-
-
-def test_add_users_to_compose(mock_utils):
-    """Test addUsersToCompose with resources"""
-    resources = {"cpus": 4, "mem_limit": "4G", "pids_limit": 4960, "shm_size": "512m"}
-    config = {
-        "server": "intocps.org",
-        "path": "/test",
-        "resources": resources,
-        "tls": False,
-        "set_limits": False,
-    }
-
-    users.add_users_to_compose(["user1", "user2", "user3"], {"services": {}}, config)
-    assert mock_utils["replace"].call_count == 3
-
-
-def test_add_users_to_compose_config_error():
-    """Test addUsersToCompose with config error"""
-    resources = {"cpus": 4, "mem_limit": "4G", "pids_limit": 4960, "shm_size": "512m"}
-    config = {"server": "localhost", "path": "/test", "resources": resources}
-    with patch(
-        "src.pkg.users.get_compose_config", return_value=(None, Exception("Error"))
-    ):
-        assert (
-            users.add_users_to_compose(["user1"], {"services": {}}, config) is not None
-        )
-
-
-@pytest.mark.parametrize(
-    "server,tls,file",
-    [
-        ("intocps.org", False, "users.server.yml"),
-        ("intocps.org", True, "users.server.secure.yml"),
-    ],
-)
-def test_get_compose_config(mock_utils, server, tls, file):
-    """Test getComposeConfig selects the template by server type and TLS flag"""
-    resources = {"cpus": 4, "mem_limit": "4G", "pids_limit": 4960, "shm_size": "512m"}
-    config = {
-        "server": server,
-        "path": "/test",
-        "resources": resources,
-        "tls": tls,
-        "set_limits": False,
-    }
-    _, _ = users.get_compose_config("testuser", config)
-    assert mock_utils["import"].called
-    mock_utils["import"].assert_called_with(file)
-
-
-def test_get_compose_config_error():
-    """Test getComposeConfig with error"""
-    resources = {"cpus": 4, "mem_limit": "4", "pids_limit": 4960, "shm_size": "512m"}
-    config = {"server": "localhost", "path": "/test", "resources": resources}
-    with patch(
-        "src.pkg.users.utils.import_yaml", return_value=(None, Exception("Error"))
-    ):
-        result, err = users.get_compose_config("testuser", config)
-        assert (result, isinstance(err, Exception)) == (None, True)
-
-
-@pytest.fixture
-def project_templates(tmp_path, monkeypatch):
-    """Generate the real CLI templates into a temp dir and run the CLI from there."""
-    generate_project(str(tmp_path))
-    monkeypatch.chdir(tmp_path)
-    return tmp_path
-
-
-def _limits_config(set_limits):
-    """A non-localhost user config with the given set_limits flag."""
-    return {
-        "server": "example.com",
-        "path": "/opt/dtaas",
-        "resources": {
-            "cpus": 4,
-            "mem_limit": "4G",
-            "pids_limit": 4960,
-            "shm_size": "512m",
-        },
-        "tls": False,
-        "set_limits": set_limits,
-    }
-
-
-def test_get_compose_config_includes_limits_when_enabled(project_templates):
-    """With set_limits true the generated service carries all four limit keys."""
-    result, err = users.get_compose_config("alice", _limits_config(True))
-
-    assert err is None
-    assert result is not None
-    assert result["cpus"] == "4"
-    assert result["mem_limit"] == "4G"
-    assert result["pids_limit"] == "4960"
-    assert result["shm_size"] == "512m"
-
-
-def test_get_compose_config_missing_template(tmp_path, monkeypatch):
-    """A missing user-workspace template yields a clear, actionable error."""
-    monkeypatch.chdir(tmp_path)  # no users.server.yml in this directory
-
-    result, err = users.get_compose_config("alice", _limits_config(False))
-
-    assert result is None
-    assert err is not None and "generate-project" in str(err)
-
-
-@pytest.mark.parametrize(
-    "func", [users.start_user_containers, users.stop_user_containers]
-)
-@patch("src.pkg.users.subprocess.run", return_value=MagicMock(returncode=0))
-def test_container_operations(mock_run, func):
-    """Test start and stop container operations"""
-    func(["user1", "user2"])
-    assert mock_run.called
-
-
-@pytest.mark.parametrize("returncode,has_error", [(0, False), (1, True)])
-@patch("src.pkg.users.subprocess.run")
-def test_run_command_for_containers(mock_run, returncode, has_error):
-    """Test run_command_for_containers with different return codes"""
-    mock_run.return_value = MagicMock(
-        returncode=returncode, stderr="Error" if has_error else ""
-    )
-    result = users.run_command_for_containers(["docker", "compose", "up"], ["user1"])
-    assert (result is not None) == has_error
-
-
-@patch("src.pkg.users.subprocess.run", return_value=MagicMock(returncode=0))
-def test_stop_user_containers_targets_named_services(mock_run):
-    """stop_user_containers uses 'rm --stop --force <services>', not 'down'.
-
-    'docker compose down' takes no SERVICE arguments and tears down the whole
-    project; 'rm --stop --force' stops and removes only the named services.
-    """
-    users.stop_user_containers(["alice", "bob"])
-
-    argv = mock_run.call_args.args[0]
-    assert "down" not in argv
-    assert "rm" in argv and "--stop" in argv and "--force" in argv
-    assert argv[-2:] == ["alice", "bob"]
+        yield {"create": mc, "add": ma, "finalize": mf, "stop": mst, "state": mw}
 
 
 # addUsers tests
@@ -296,8 +123,7 @@ def test_add_users_empty_registry_is_noop(
     err = users.add_users(mock_config)
 
     assert err is None
-    mock_user_operations["start"].assert_not_called()
-    mock_user_operations["state"].assert_not_called()
+    mock_user_operations["finalize"].assert_not_called()
 
 
 @pytest.mark.parametrize("export_error", [False, True])

--- a/cli/tests/test_users.py
+++ b/cli/tests/test_users.py
@@ -214,6 +214,21 @@ def test_run_command_for_containers(mock_run, returncode, has_error):
     assert (result is not None) == has_error
 
 
+@patch("src.pkg.users.subprocess.run", return_value=MagicMock(returncode=0))
+def test_stop_user_containers_targets_named_services(mock_run):
+    """stop_user_containers uses 'rm --stop --force <services>', not 'down'.
+
+    'docker compose down' takes no SERVICE arguments and tears down the whole
+    project; 'rm --stop --force' stops and removes only the named services.
+    """
+    users.stop_user_containers(["alice", "bob"])
+
+    argv = mock_run.call_args.args[0]
+    assert "down" not in argv
+    assert "rm" in argv and "--stop" in argv and "--force" in argv
+    assert argv[-2:] == ["alice", "bob"]
+
+
 # addUsers tests
 @pytest.mark.parametrize(
     "compose,field", [({"services": {}}, "version"), ({"version": "3"}, "services")]
@@ -332,3 +347,20 @@ def test_delete_users_handles_compose_without_services(
 
     assert err is None
     mock_registry["remove"].assert_called_once_with(["user1"])
+
+
+def test_delete_users_dry_run_makes_no_changes(
+    mock_registry, mock_utils, mock_user_operations, capsys
+):
+    """A dry-run previews the plan and calls no mutating operation."""
+    mock_utils["import"].return_value = ({"services": {"user1": {}}}, None)
+
+    err = users.delete_users(["user1", "ghost"], dry_run=True)
+
+    assert err is None
+    mock_user_operations["stop"].assert_not_called()
+    mock_registry["remove"].assert_not_called()
+    mock_utils["export"].assert_not_called()
+    out = capsys.readouterr().out
+    assert "Would deprovision and stop: user1" in out
+    assert "Would remove from registry: user1, ghost" in out

--- a/cli/tests/test_users.py
+++ b/cli/tests/test_users.py
@@ -183,6 +183,16 @@ def test_get_compose_config_includes_limits_when_enabled(project_templates):
     assert result["shm_size"] == "512m"
 
 
+def test_get_compose_config_missing_template(tmp_path, monkeypatch):
+    """A missing user-workspace template yields a clear, actionable error."""
+    monkeypatch.chdir(tmp_path)  # no users.server.yml in this directory
+
+    result, err = users.get_compose_config("alice", _limits_config(False))
+
+    assert result is None
+    assert err is not None and "generate-project" in str(err)
+
+
 @pytest.mark.parametrize(
     "func", [users.start_user_containers, users.stop_user_containers]
 )
@@ -200,7 +210,8 @@ def test_run_command_for_containers(mock_run, returncode, has_error):
     mock_run.return_value = MagicMock(
         returncode=returncode, stderr="Error" if has_error else ""
     )
-    assert (users.run_command_for_containers("up", ["user1"]) is not None) == has_error
+    result = users.run_command_for_containers(["docker", "compose", "up"], ["user1"])
+    assert (result is not None) == has_error
 
 
 # addUsers tests
@@ -245,6 +256,35 @@ def test_add_users_rejects_newline_in_email(
     assert err is not None and "newlines" in str(err)
 
 
+def test_add_users_rejects_invalid_username(mock_config, mock_registry, mock_utils):
+    """A registry username carrying shell metacharacters aborts add_users."""
+    mock_registry["load"].return_value = {"bad;rm -rf": {"email": "x@y.io"}}
+
+    err = users.add_users(mock_config)
+
+    assert err is not None and "Invalid username" in str(err)
+
+
+def test_delete_users_rejects_invalid_username():
+    """delete_users rejects a non-shell-safe username before touching docker."""
+    err = users.delete_users(["bad name"])
+
+    assert err is not None and "Invalid username" in str(err)
+
+
+def test_add_users_empty_registry_is_noop(
+    mock_config, mock_registry, mock_utils, mock_user_operations
+):
+    """An empty registry provisions nothing and starts no containers."""
+    mock_registry["load"].return_value = {}
+
+    err = users.add_users(mock_config)
+
+    assert err is None
+    mock_user_operations["start"].assert_not_called()
+    mock_user_operations["state"].assert_not_called()
+
+
 @pytest.mark.parametrize("export_error", [False, True])
 def test_delete_users(mock_registry, mock_utils, mock_user_operations, export_error):
     """delete_users removes users from compose and, on success, the registry."""
@@ -266,3 +306,29 @@ def test_delete_users_handles_none_compose(mock_registry, mock_utils):
     err = users.delete_users(["user1"])
 
     assert err is not None and "Failed to load compose" in str(err)
+
+
+def test_delete_users_removes_conf_for_every_requested_name(
+    mock_registry, mock_utils, mock_user_operations
+):
+    """conf.server rules are removed for every requested user, not just existing ones."""
+    mock_utils["import"].return_value = ({"services": {"user1": {}}}, None)
+
+    with patch("src.pkg.users.remove_conf_server_entry") as mock_remove:
+        err = users.delete_users(["user1", "ghost"])
+
+    assert err is None
+    removed = {call.args[0] for call in mock_remove.call_args_list}
+    assert removed == {"user1", "ghost"}
+
+
+def test_delete_users_handles_compose_without_services(
+    mock_registry, mock_utils, mock_user_operations
+):
+    """delete_users tolerates a compose file that has no 'services' key."""
+    mock_utils["import"].return_value = ({"version": "3"}, None)
+
+    err = users.delete_users(["user1"])
+
+    assert err is None
+    mock_registry["remove"].assert_called_once_with(["user1"])

--- a/cli/tests/test_users.py
+++ b/cli/tests/test_users.py
@@ -163,6 +163,18 @@ def test_delete_users_removes_conf_for_every_requested_name(
     assert removed == {"user1", "ghost"}
 
 
+def test_delete_users_handles_non_dict_services(
+    mock_registry, mock_utils, mock_user_operations
+):
+    """delete_users tolerates malformed YAML where 'services' is not a dict."""
+    mock_utils["import"].return_value = ({"services": None}, None)
+
+    err = users.delete_users(["user1"])
+
+    assert err is None
+    mock_registry["remove"].assert_called_once_with(["user1"])
+
+
 def test_delete_users_handles_compose_without_services(
     mock_registry, mock_utils, mock_user_operations
 ):

--- a/cli/tests/test_users_compose.py
+++ b/cli/tests/test_users_compose.py
@@ -1,0 +1,196 @@
+"""Tests for the compose/container plumbing in users_compose.py."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch, MagicMock
+import pytest
+from src.pkg import users_compose
+from src.pkg.project import generate_project
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture
+def mock_utils():
+    """Mock all utils functions"""
+    with patch("src.pkg.users_compose.utils.import_yaml") as mi, patch(
+        "src.pkg.users_compose.utils.export_yaml"
+    ) as me, patch("src.pkg.users_compose.utils.replace_all") as mr:
+        mi.return_value = ({"version": "3", "services": {}}, None)
+        me.return_value = None
+        mr.return_value = ({"image": "test"}, None)
+        yield {"import": mi, "export": me, "replace": mr}
+
+
+@pytest.fixture
+def temp_dir_with_template():
+    """Temporary directory with template folder"""
+    with TemporaryDirectory() as tmpdir:
+        (Path(tmpdir) / "template").mkdir(parents=True, exist_ok=True)
+        (Path(tmpdir) / "template" / "test.txt").write_text("test")
+        yield tmpdir
+
+
+@pytest.mark.parametrize("usernames", [["testuser"], ["user1", "user2", "user3"], []])
+def test_create_user_files(temp_dir_with_template, usernames):
+    """Test create_user_files creates user directories"""
+    assert users_compose.create_user_files(usernames, temp_dir_with_template) is None
+    assert all(Path(temp_dir_with_template, u).exists() for u in usernames)
+
+
+def test_create_user_files_chowns_nested_items(temp_dir_with_template):
+    """When chown succeeds, ownership is applied to the dir and every nested item."""
+    with patch("src.pkg.users_compose.shutil.chown") as mock_chown:
+        assert (
+            users_compose.create_user_files(["alice"], temp_dir_with_template) is None
+        )
+
+    chowned = [call.args[0] for call in mock_chown.call_args_list]
+    assert Path(temp_dir_with_template, "alice") in chowned
+    assert Path(temp_dir_with_template, "alice", "test.txt") in chowned
+
+
+def test_add_users_to_compose(mock_utils):
+    """Test addUsersToCompose with resources"""
+    resources = {"cpus": 4, "mem_limit": "4G", "pids_limit": 4960, "shm_size": "512m"}
+    config = {
+        "server": "intocps.org",
+        "path": "/test",
+        "resources": resources,
+        "tls": False,
+        "set_limits": False,
+    }
+
+    users_compose.add_users_to_compose(
+        ["user1", "user2", "user3"], {"services": {}}, config
+    )
+    assert mock_utils["replace"].call_count == 3
+
+
+def test_add_users_to_compose_config_error():
+    """Test addUsersToCompose with config error"""
+    resources = {"cpus": 4, "mem_limit": "4G", "pids_limit": 4960, "shm_size": "512m"}
+    config = {"server": "localhost", "path": "/test", "resources": resources}
+    with patch(
+        "src.pkg.users_compose.get_compose_config",
+        return_value=(None, Exception("Error")),
+    ):
+        result = users_compose.add_users_to_compose(["user1"], {"services": {}}, config)
+        assert result is not None
+
+
+@pytest.mark.parametrize(
+    "server,tls,file",
+    [
+        ("intocps.org", False, "users.server.yml"),
+        ("intocps.org", True, "users.server.secure.yml"),
+    ],
+)
+def test_get_compose_config(mock_utils, server, tls, file):
+    """Test getComposeConfig selects the template by server type and TLS flag"""
+    resources = {"cpus": 4, "mem_limit": "4G", "pids_limit": 4960, "shm_size": "512m"}
+    config = {
+        "server": server,
+        "path": "/test",
+        "resources": resources,
+        "tls": tls,
+        "set_limits": False,
+    }
+    _, _ = users_compose.get_compose_config("testuser", config)
+    assert mock_utils["import"].called
+    mock_utils["import"].assert_called_with(file)
+
+
+def test_get_compose_config_error():
+    """Test getComposeConfig with error"""
+    resources = {"cpus": 4, "mem_limit": "4", "pids_limit": 4960, "shm_size": "512m"}
+    config = {"server": "localhost", "path": "/test", "resources": resources}
+    with patch(
+        "src.pkg.users_compose.utils.import_yaml",
+        return_value=(None, Exception("Error")),
+    ):
+        result, err = users_compose.get_compose_config("testuser", config)
+        assert (result, isinstance(err, Exception)) == (None, True)
+
+
+@pytest.fixture
+def project_templates(tmp_path, monkeypatch):
+    """Generate the real CLI templates into a temp dir and run the CLI from there."""
+    generate_project(str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _limits_config(set_limits):
+    """A non-localhost user config with the given set_limits flag."""
+    return {
+        "server": "example.com",
+        "path": "/opt/dtaas",
+        "resources": {
+            "cpus": 4,
+            "mem_limit": "4G",
+            "pids_limit": 4960,
+            "shm_size": "512m",
+        },
+        "tls": False,
+        "set_limits": set_limits,
+    }
+
+
+def test_get_compose_config_includes_limits_when_enabled(project_templates):
+    """With set_limits true the generated service carries all four limit keys."""
+    result, err = users_compose.get_compose_config("alice", _limits_config(True))
+
+    assert err is None
+    assert result is not None
+    assert result["cpus"] == "4"
+    assert result["mem_limit"] == "4G"
+    assert result["pids_limit"] == "4960"
+    assert result["shm_size"] == "512m"
+
+
+def test_get_compose_config_missing_template(tmp_path, monkeypatch):
+    """A missing user-workspace template yields a clear, actionable error."""
+    monkeypatch.chdir(tmp_path)  # no users.server.yml in this directory
+
+    result, err = users_compose.get_compose_config("alice", _limits_config(False))
+
+    assert result is None
+    assert err is not None and "generate-project" in str(err)
+
+
+@pytest.mark.parametrize(
+    "func", [users_compose.start_user_containers, users_compose.stop_user_containers]
+)
+@patch("src.pkg.users_compose.subprocess.run", return_value=MagicMock(returncode=0))
+def test_container_operations(mock_run, func):
+    """Test start and stop container operations"""
+    func(["user1", "user2"])
+    assert mock_run.called
+
+
+@pytest.mark.parametrize("returncode,has_error", [(0, False), (1, True)])
+@patch("src.pkg.users_compose.subprocess.run")
+def test_run_command_for_containers(mock_run, returncode, has_error):
+    """Test run_command_for_containers with different return codes"""
+    mock_run.return_value = MagicMock(
+        returncode=returncode, stderr="Error" if has_error else ""
+    )
+    result = users_compose.run_command_for_containers(
+        ["docker", "compose", "up"], ["user1"]
+    )
+    assert (result is not None) == has_error
+
+
+@patch("src.pkg.users_compose.subprocess.run", return_value=MagicMock(returncode=0))
+def test_stop_user_containers_targets_named_services(mock_run):
+    """stop_user_containers uses 'rm --stop --force <services>', not 'down'.
+
+    'docker compose down' takes no SERVICE arguments and tears down the whole
+    project; 'rm --stop --force' stops and removes only the named services.
+    """
+    users_compose.stop_user_containers(["alice", "bob"])
+
+    argv = mock_run.call_args.args[0]
+    assert "down" not in argv
+    assert "rm" in argv and "--stop" in argv and "--force" in argv
+    assert argv[-2:] == ["alice", "bob"]

--- a/cli/tests/test_users_utils.py
+++ b/cli/tests/test_users_utils.py
@@ -11,6 +11,7 @@ from src.pkg.users_utils import (
     resource_mapping,
     is_valid_username,
     validate_usernames,
+    report_delete_preview,
 )
 from tests.conftest import CONF_SERVER_CONTENT
 
@@ -42,6 +43,24 @@ def test_validate_usernames_raises_on_first_bad_name():
 def test_validate_usernames_passes_for_all_valid():
     """A list of valid usernames validates without raising."""
     validate_usernames(["alice", "bob-1"])  # must not raise
+
+
+def test_report_delete_preview_lists_actions(capsys):
+    """The dry-run preview names both the deprovision and registry removals."""
+    report_delete_preview(["alice"], ["alice", "bob"])
+
+    out = capsys.readouterr().out
+    assert "Would deprovision and stop: alice" in out
+    assert "Would remove from registry: alice, bob" in out
+
+
+def test_report_delete_preview_no_provisioned_users(capsys):
+    """With nothing provisioned, only the registry-removal line is printed."""
+    report_delete_preview([], ["bob"])
+
+    out = capsys.readouterr().out
+    assert "Would deprovision" not in out
+    assert "Would remove from registry: bob" in out
 
 
 def test_build_base_mapping_includes_server_dns_for_remote():

--- a/cli/tests/test_users_utils.py
+++ b/cli/tests/test_users_utils.py
@@ -1,5 +1,6 @@
 """Tests for users_utils module."""
 
+import pytest
 from src.pkg import users_utils
 from src.pkg.users_utils import (
     _next_rule_num,
@@ -8,8 +9,39 @@ from src.pkg.users_utils import (
     remove_conf_server_entry,
     build_base_mapping,
     resource_mapping,
+    is_valid_username,
+    validate_usernames,
 )
 from tests.conftest import CONF_SERVER_CONTENT
+
+
+@pytest.mark.parametrize(
+    "name,valid",
+    [
+        ("alice", True),
+        ("user.name-1_2", True),
+        ("bad;rm -rf", False),
+        ("bad name", False),
+        ("$(whoami)", False),
+        ("-leading-dash", False),
+        ("", False),
+        (5, False),
+    ],
+)
+def test_is_valid_username(name, valid):
+    """Only alphanumeric-plus-._- names (no shell metacharacters) are valid."""
+    assert is_valid_username(name) is valid
+
+
+def test_validate_usernames_raises_on_first_bad_name():
+    """validate_usernames names the offending username in the error."""
+    with pytest.raises(ValueError, match="bad;name"):
+        validate_usernames(["alice", "bad;name"])
+
+
+def test_validate_usernames_passes_for_all_valid():
+    """A list of valid usernames validates without raising."""
+    validate_usernames(["alice", "bob-1"])  # must not raise
 
 
 def test_build_base_mapping_includes_server_dns_for_remote():

--- a/cli/tests/test_utils.py
+++ b/cli/tests/test_utils.py
@@ -27,7 +27,7 @@ def test_import_toml():
 
     expected = {
         "name": "Digital Twin as a Service (DTaaS)",
-        "version": "0.10.0",
+        "version": "0.11.0",
         "owner": "The INTO-CPS-Association",
         "git-repo": "https://github.com/into-cps-association/DTaaS.git",
         "common": {


### PR DESCRIPTION
# Separate starting users from additional users to prevent duplicate containers

## Type of Change

- [X] New feature
- [X] Bug fix
- [X] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description
#1690 This makes a 3-file split that separates hand-edited config, CLI-owned user
data, and disposable runtime facts, replacing a single overloaded `dtaas.toml`
list.

Before this change, `dtaas.toml` had one `[users]` table with `add`/`delete`
lists that were expected to be hand-edited and silently consumed and never
rewritten by the CLI.

Now there are 3 files, each with exactly one owner:

1. **`dtaas.toml`**  a human writes this once at install time, listing the `starting` users. The CLI never touches it again.
2. **`dtaas.users.registry.json`**  the CLI owns this. Every `user add`/`user delete` reads and rewrites it directly (atomically, so a crash mid-write can't corrupt it). The user never hand-edits it; they feed it via a CSV instead.
3. **`.dtaas.state.json`**  a disposable cache the CLI writes after every add/delete, recording what's actually running (container id, status, a hash of its config). It's gitignored; deleting it is harmless.

## What changed, from the user's point of view
- `dtaas.toml`'s `[users]` table now has a `starting` list (was `add`/ `delete`), with per-user `email`, `groups`, `load_balance`. It's set once at install and never rewritten.
- `dtaas admin config generate` now also drops a sample `users.csv` next to `dtaas.toml`.
- `dtaas admin user add` no longer reads `dtaas.toml`. It provisions from `dtaas.users.registry.json` instead:
- `dtaas admin user add alice --email alice@x.org [--group g] [--load-balance]` adds one user.
- `dtaas admin user add --file users.csv` bulk-adds from a CSV.
 - Plain `dtaas admin user add` re-runs setup for whatever is already registered.
- A username that's already a `starting` user or already registered is skipped with a warning, never duplicated or silently overwritten.
- `dtaas admin user delete alice bob` now takes usernames directly as arguments (was a `dtaas.toml` list). Add `--dry-run` to preview a removal without changing anything.
- New `dtaas admin config reconcile` (read-only) compares `.dtaas.state.json` against the running containers and reports drifted, untracked, or orphaned users.