### PR TITLE
Adds docs and fixes client package version

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -160,7 +160,7 @@ The `[common.resources]` limit fields (`cpus`, `pids_limit`, `mem_limit`,
 `set_limits = false` they are optional and ignored; any value still present is
 validated.
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 |---|---|---|
@@ -179,7 +179,7 @@ directory ready to be customised.
 dtaas generate-deployment --type <name>
 ```
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 |---|---|---|
@@ -204,7 +204,7 @@ dtaas generate-deployment --type <name>
 > manual hardening steps documented in the `README.md` and `CONFIGURATION.md`
 > shipped with each generated project.
 
-**Examples**
+**Examples:**
 
 ```bash
 # Localhost demo in the current directory
@@ -259,7 +259,7 @@ the installation directory. Before starting, it ensures per-user workspace
 directories for every `[[users]]` record exist, recreating each from
 `files/template/` if missing and sets ownership to `1000:100`.
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 |---|---|---|
@@ -304,7 +304,7 @@ in non-interactive scripts with `--yes`:
 dtaas admin uninstall --remove-user-files --yes
 ```
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 |---|---|---|
@@ -335,7 +335,7 @@ succeeded, there is no rollback, re-run the same command: each project's
 compose command is idempotent, so retrying repeats a harmless no-op against
 whichever project already changed and retries the one that failed.
 
-**Lifecycle command matrix**
+**Lifecycle command matrix:**
 
 | Command | `docker compose` verb | Effect | Containers kept? | Reverse with |
 |---|---|---|:---:|---|
@@ -389,7 +389,7 @@ dtaas admin status --json
 ]
 ```
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 |---|---|---|
@@ -411,7 +411,7 @@ Both report `no existing DTaaS / Workspace installation` and exit `0` when
 nothing is installed (no containers in any state), so they are safe to call
 repeatedly.
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 |---|---|---|
@@ -431,7 +431,7 @@ dtaas admin resume
 Both report the absent-installation case and exit `0` when nothing is
 installed (no containers in any state).
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 |---|---|---|
@@ -461,7 +461,7 @@ The command reads `[common.security].certs-src` from `dtaas.toml`, then:
 If validation fails, live certificates are left untouched. The command is safe
 to run repeatedly.
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 |---|---|---|
@@ -499,7 +499,7 @@ dtaas admin update --config --output-dir ./my-server
 apply if problems are found. It is **idempotent** a second run with no
 `dtaas.toml` changes reports `No configuration changes` and restarts nothing.
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 |---|---|---|
@@ -520,14 +520,14 @@ Scaffolds `dtaas.toml`, Docker Compose user-workspace templates, and the
 dtaas generate-project
 ```
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 |---|---|---|
 | `--output-dir PATH` | `.` | Target directory (must already exist) |
 | `--force` | off | Overwrite files that already exist |
 
-**Generated files**
+**Generated files:**
 
 | Item | Purpose |
 |---|---|
@@ -551,7 +551,7 @@ Provisions users on a running DTaaS instance. Additional users are recorded in
 the CLI-owned `dtaas.users.registry.json`
 (see [User files](#-user-files)), not in `dtaas.toml`.
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 |---|---|---|
@@ -605,7 +605,7 @@ registry. To (re)provision **every** registry user at once (e.g. after
 `compose.users.yml` was lost), use `dtaas admin config reconcile --fix`
 instead.
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 |---|---|---|
@@ -670,7 +670,7 @@ and unconstrained users by toggling `set_limits` between runs.
 
 Removes one or more users from a running DTaaS instance, like `userdel`.
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 |---|---|---|
@@ -759,7 +759,7 @@ aborting the whole batch:
 alice, bob paused successfully
 ```
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 |---|---|---|
@@ -804,7 +804,7 @@ dtaas admin config reconcile --fix
 that's actually running is a deliberate action use
 `dtaas admin user delete` for those.
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 |---|---|---|

--- a/cli/README.md
+++ b/cli/README.md
@@ -721,7 +721,7 @@ docker compose --env-file config/.env up -d --force-recreate traefik-forward-aut
 
 Suspend or resume **specific additional (registry) users** without touching
 the rest of the installation, targeting one or more `USERNAMES` or a
-`--file`/`-f users.csv` (only the `username` column is read) the same way
+`--file`/`-f users.csv` (only the `username` column is read), the same way
 `admin user delete` does.
 
 ```bash
@@ -770,8 +770,8 @@ alice, bob paused successfully
 
 ### 🔍 `admin config reconcile`
 
-Reports drift between `dtaas.users.registry.json` (who **should** be
-provisioned) and the live `compose.users.yml` services (who **is**
+Reports drift between `dtaas.users.registry.json` (which **should** be
+provisioned) and the live `compose.users.yml` services (which **are**
 provisioned).
 
 ```bash
@@ -789,9 +789,9 @@ It lists:
   match the user's registry `desired_status` (e.g. `desired 'paused' but
   container is 'running'`).
 
-When everything matches it prints `In sync: no drift detected.`
+When everything matches, it prints `In sync: no drift detected.`
 
-Without `--fix` this is read-only. Pass `--fix` to reprovision **missing** and
+Without `--fix`, this is read-only. Pass `--fix` to reprovision **missing** and
 **drifted** users and to pause/stop/start every provisioned user to match its
 `desired_status` (equivalent to running `dtaas admin user add`, so it acts on
 the current directory, not `--output-dir`):

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@into-cps-association/dtaas-web",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Web client for Digital Twin as a Service (DTaaS)",
   "main": "index.tsx",
   "author": "prasadtalasila <prasad.talasila@gmail.com> (http://prasad.talasila.in/)",

--- a/docs/admin/cli-config.md
+++ b/docs/admin/cli-config.md
@@ -7,11 +7,11 @@ valid with `dtaas admin config validate` before running any other
 command. The installation workflow itself is covered in
 [Install with DTaaS CLI](cli.md).
 
-## Which Sections Does My Deployment Need?
+## 🧭 Which Sections Does My Deployment Need?
 
 Required ✅ &nbsp; Optional ○ &nbsp; Not-Used —
 
-### Server Deployments
+### 🖥️ Server Deployments
 
 | Section | `localhost` | `insecure-server` | `secure-server` | `secure-server-gitlab` |
 | --- | :---: | :---: | :---: | :---: |
@@ -25,7 +25,7 @@ Required ✅ &nbsp; Optional ○ &nbsp; Not-Used —
 | `[secure-server]` | — | — | ✅ | — |
 | `[secure-server-gitlab]` | — | — | — | ✅ |
 
-### Workspace Deployments
+### 🧑‍💻 Workspace Deployments
 
 | Section | `workspace-localhost` | `workspace-secure-server` |
 | --- | :---: | :---: |
@@ -36,7 +36,7 @@ Required ✅ &nbsp; Optional ○ &nbsp; Not-Used —
 | `[workspace-localhost]` | ✅ | — |
 | `[workspace-secure-server]` | — | ✅ |
 
-## Annotated `dtaas.toml`
+## 📄 Annotated `dtaas.toml`
 
 The full file below shows every possible key with inline comments.
 Copy it as a starting point and delete sections that do not apply to
@@ -155,7 +155,7 @@ client-id               = "dtaas-frontend"
 auth-authority          = "https://keycloak.example.com/realms/dtaas"
 ```
 
-## Validation Rules
+## ✅ Validation Rules
 
 `dtaas admin config validate` reads `dtaas.toml` (from `--output-dir`
 first, then the current directory) and reports all problems at once:
@@ -193,7 +193,7 @@ The `[common.resources]` limit fields (`cpus`, `pids_limit`,
 `true` (the default). With `set_limits = false` they are optional and
 ignored; any value still present is validated.
 
-## Configuration Substitution
+## 🔀 Configuration Substitution
 
 When `dtaas.toml` is present, `generate-deployment` reads
 deployment-specific values from it and substitutes them into the
@@ -211,7 +211,7 @@ and `[[users]]` sections are substituted across all types.
 If `dtaas.toml` is not found, a note is printed and generated files
 keep their default placeholder values.
 
-### TLS Certificate Placement
+### 🔐 TLS Certificate Placement
 
 For the TLS types (`secure-server`, `secure-server-gitlab`,
 `workspace-secure-server`), `generate-deployment` also populates the
@@ -219,7 +219,7 @@ For the TLS types (`secure-server`, `secure-server-gitlab`,
 `[common.security].certs-src` from `dtaas.toml` and copies the latest
 `fullchain.pem` and `privkey.pem` there.
 
-## User Files
+## 👥 User Files
 
 User management spans three files, each with a single owner, modelled
 on the config/state split Terraform uses for `.tf` vs
@@ -247,11 +247,11 @@ on the config/state split Terraform uses for `.tf` vs
   running, refreshed on every add/delete. It is git-ignored and safe
   to delete.
 
-### Checking for Drift
+### 🔍 Checking for Drift
 
 `dtaas admin config reconcile` reports drift between
-`dtaas.users.registry.json` (who **should** be provisioned) and the
-live `compose.users.yml` services (who **is** provisioned). It lists:
+`dtaas.users.registry.json` (which **should** be provisioned) and the
+live `compose.users.yml` services (which **are** provisioned). It lists:
 
 - **missing** — registered but not currently provisioned;
 - **unexpected** — provisioned but not in the registry (investigate:
@@ -262,8 +262,8 @@ live `compose.users.yml` services (who **is** provisioned). It lists:
   state does not match the user's registry `desired_status` (e.g.
   `desired 'paused' but container is 'running'`).
 
-When everything matches it prints `In sync: no drift detected.`
-Without `--fix` this is read-only. Pass `--fix` to reprovision
+When everything matches, it prints `In sync: no drift detected.`
+Without `--fix`, this is read-only. Pass `--fix` to reprovision
 **missing** and **drifted** users, and to pause/stop/start every
 provisioned user to match its `desired_status`; **unexpected**
 services are never touched by `--fix` — use `dtaas admin user delete`

--- a/docs/admin/cli-config.md
+++ b/docs/admin/cli-config.md
@@ -228,7 +228,7 @@ on the config/state split Terraform uses for `.tf` vs
 | File | Owner | Contents | Git |
 | --- | --- | --- | --- |
 | `dtaas.toml` `[[users]]` | Human, at install time | **Starting** users: one self-contained record per user (`username`, `email`, `groups`, `load_balance`) | Tracked, hand-edited |
-| `dtaas.users.registry.json` | CLI (`user add` / `user delete`) | **Additional** users, same fields | Tracked, CLI-written, never hand-edited |
+| `dtaas.users.registry.json` | CLI (`user add` / `delete` / `pause` / `stop` / `resume`) | **Additional** users: the same fields, plus `desired_status` (`running`/`paused`/`stopped`) | Tracked, CLI-written, never hand-edited |
 | `.dtaas.state.json` | CLI, at provisioning time | Observed runtime facts: container id, status, provisioned-at, config hash | Ignored, runtime cache |
 
 - **`dtaas.toml`** is written once by a human and never rewritten by
@@ -236,10 +236,13 @@ on the config/state split Terraform uses for `.tf` vs
   mutated.
 - **`dtaas.users.registry.json`** is a database the CLI owns and
   mutates atomically (the way `useradd` owns `/etc/passwd`). Edit its
-  users through `dtaas admin user add --file users.csv` /
-  `dtaas admin user delete`, not by hand. The `users.csv` copied by
+  users through `dtaas admin user add --file users.csv` / `delete` /
+  `pause` / `stop` / `resume`, not by hand. `users.csv` copied by
   `dtaas admin config generate` is the human-editable bulk input that
-  feeds it.
+  feeds `add`/`delete`. `desired_status` defaults to `running` for a
+  user who has never been paused or stopped, and `user add` /
+  `config reconcile --fix` skip starting any user whose
+  `desired_status` is not `running`.
 - **`.dtaas.state.json`** is a disposable cache of what is actually
   running, refreshed on every add/delete. It is git-ignored and safe
   to delete.
@@ -254,10 +257,19 @@ live `compose.users.yml` services (who **is** provisioned). It lists:
 - **unexpected** — provisioned but not in the registry (investigate:
   may be a manual edit or a partial delete);
 - **drifted** — provisioned, but the live config no longer matches
-  what `.dtaas.state.json` recorded when it was last provisioned.
+  what `.dtaas.state.json` recorded when it was last provisioned;
+- **desired-status drift** — provisioned, but the live container
+  state does not match the user's registry `desired_status` (e.g.
+  `desired 'paused' but container is 'running'`).
 
 When everything matches it prints `In sync: no drift detected.`
 Without `--fix` this is read-only. Pass `--fix` to reprovision
-**missing** and **drifted** users afterward; **unexpected** services
-are never touched by `--fix` — use `dtaas admin user delete` for
-those.
+**missing** and **drifted** users, and to pause/stop/start every
+provisioned user to match its `desired_status`; **unexpected**
+services are never touched by `--fix` — use `dtaas admin user delete`
+for those.
+
+Suspending a user with `dtaas admin user pause`/`stop` is intentional
+and durable: it is reflected as that user's `desired_status`, so a
+later `reconcile` treats the suspension as the desired state instead
+of reporting it as drift.

--- a/docs/admin/cli.md
+++ b/docs/admin/cli.md
@@ -6,10 +6,10 @@ generates deployment projects, validates configuration, brings
 deployments up and down, manages users, and rotates certificates for
 all supported scenarios.
 
-This page covers the standard installation workflow. The complete command
-reference, including all options and generated-file layouts, is in
-the
-[Config Reference](cli-config.md).
+This page covers the standard installation workflow and every `dtaas`
+command. The complete `dtaas.toml` field reference — validation
+rules, the annotated example file, and the user-file model — is in
+the [Config Reference](cli-config.md).
 
 ## Installation
 
@@ -46,18 +46,26 @@ dtaas admin install
 
 Tear it down again with `dtaas admin uninstall` (add
 `--remove-user-files` to also delete per-user workspace directories;
-this prompts for confirmation).
+this prompts for confirmation, or pass `--yes` to skip the prompt).
 
 ### Deployment Types
 
-| `--type` | When to use |
-| :------- | :---------- |
-| `localhost` | Local development or demo, single user |
-| `insecure-server` | Multi-user HTTP demo — **not internet-facing** |
-| `secure-server` | Multi-user HTTPS — production-ready |
-| `secure-server-gitlab` | HTTPS with bundled GitLab — production-ready |
-| `workspace-localhost` | Workspace with Dex on localhost |
-| `workspace-secure-server` | Workspace with Keycloak — production-ready |
+| `--type` | When to use | Support level |
+| :------- | :---------- | :------------- |
+| `localhost` | Local development or demo, single user | dev/demo only |
+| `insecure-server` | Multi-user HTTP demo | insecure/demo only |
+| `secure-server` | Multi-user HTTPS | **production-supported** |
+| `secure-server-gitlab` | HTTPS with bundled GitLab | **production-supported** |
+| `workspace-localhost` | Workspace with Dex on localhost | dev/demo only |
+| `workspace-secure-server` | Workspace with Keycloak | **production-supported** |
+
+!!! warning
+    Types marked *dev/demo only* or *insecure/demo only* run over
+    plain HTTP with default or static credentials. **Do not expose
+    them to the internet or shared networks.** Production-supported
+    types still require the manual hardening steps documented in the
+    `README.md` and `CONFIGURATION.md` shipped with each generated
+    project.
 
 The generated packages match the
 [manual installation scenarios](overview.md#manual-installation-scenarios-advanced);
@@ -83,35 +91,8 @@ Key sections:
   source directory for TLS certificates.
 
 Always run `dtaas admin config validate` after editing; it reports
-all problems at once.
-
-### TLS Certificates
-
-For the HTTPS scenarios, point `[common.security].certs-src` at the
-directory holding the certificate pair before running
-`generate-deployment`. To rotate certificates on a running
-deployment:
-
-```bash
-dtaas admin update --certs
-```
-
-The command validates the new pair, swaps it in with a backup of the
-live pair, and restarts only the gateway. If validation fails, the
-live certificates are left untouched.
-
-### Updating Configuration In Place
-
-To re-apply `dtaas.toml` changes to an installed deployment without
-regenerating the project:
-
-```bash
-dtaas admin update --config --dry-run   # preview
-dtaas admin update --config             # apply and restart services
-```
-
-The command is idempotent and refuses to apply an invalid
-configuration. `--certs` and `--config` may be combined.
+all problems at once — see
+[Validation Rules](cli-config.md#validation-rules) for the full list.
 
 ### Abridged Configuration
 
@@ -175,34 +156,446 @@ email = "username2@intocps.org"
   workspace via the CLI or by restarting the container in Docker Compose).
 - Use units (`M`, `G`) for memory and shared memory values.
 
-## User Management
+## Commands
 
-### Generate Templates
+This section documents every `dtaas` command not already covered
+above. Every command accepts `--output-dir` (default `.`), checked
+before falling back to the current working directory.
 
-The _cli_ uses YAML templates provided in this directory to create
-new user workspaces. The available templates are:
+### `admin config generate` / `admin config validate`
 
-1. _user.local.yml_: localhost installation
-1. _User.server.yml_: multi-user web application over HTTP
-1. _user.server.secure.yml_: multi-user web application over HTTPS
+```bash
+dtaas admin config generate    # writes dtaas.toml + a sample users.csv
+dtaas admin config validate    # checks an existing dtaas.toml
+```
 
-Generate the required user templates using
+`generate` writes `dtaas.toml` and a sample `users.csv` (bulk input
+for `admin user add --file`) into `--output-dir`; `--force` overwrites
+an existing `dtaas.toml`. `validate` reports every problem in the
+file at once — see [Validation Rules](cli-config.md#validation-rules).
+
+**Options**
+
+| Option | Default | Description |
+| :----- | :------ | :----------- |
+| `--output-dir PATH` | `.` | For `generate`: target directory (created if missing). For `validate`: search location |
+| `--force` | off | (`generate` only) Overwrite an existing `dtaas.toml` |
+
+### `admin config reconcile`
+
+Reports drift between `dtaas.users.registry.json` (who **should** be
+provisioned) and the live `compose.users.yml` services (who **is**
+provisioned):
+
+```bash
+dtaas admin config reconcile
+```
+
+It lists:
+
+- **missing** — registered but not currently provisioned;
+- **unexpected** — provisioned but not in the registry (investigate:
+  may be a manual edit or a partial delete);
+- **drifted** — provisioned, but the live config no longer matches
+  what `.dtaas.state.json` recorded when it was last provisioned;
+- **desired-status drift** — provisioned, but the live container
+  state does not match the user's registry `desired_status` (e.g.
+  `desired 'paused' but container is 'running'`).
+
+When everything matches it prints `In sync: no drift detected.`
+Without `--fix` this is read-only. Pass `--fix` to reprovision
+**missing** and **drifted** users, and to pause/stop/start every
+provisioned user to match its `desired_status`:
+
+```bash
+dtaas admin config reconcile --fix
+```
+
+**unexpected** services are never touched by `--fix` — removing
+something that's actually running is a deliberate action; use
+`dtaas admin user delete` for those.
+
+**Options**
+
+| Option | Default | Description |
+| :----- | :------ | :----------- |
+| `--output-dir PATH` | `.` | Installation directory to inspect |
+| `--fix` | off | Reprovision missing/drifted registry users, and enforce desired status, after reporting |
+
+### `generate-deployment`
+
+Copies the full project structure for a specific deployment scenario
+— `docker-compose.yml`, config examples, and supporting files — into
+a target directory ready to be customised.
+
+```bash
+dtaas generate-deployment --type <name>
+```
+
+**Options**
+
+| Option | Default | Description |
+| :----- | :------ | :----------- |
+| `--type NAME` | *(required)* | Deployment scenario (see [Deployment Types](#deployment-types)) |
+| `--output-dir PATH` | `.` | Target directory (must already exist) |
+| `--force` | off | Overwrite files that already exist |
+
+**Examples**
+
+```bash
+# Localhost demo in the current directory
+dtaas generate-deployment --type localhost
+
+# Production HTTPS server in a subdirectory
+dtaas generate-deployment --type secure-server --output-dir ./my-server
+
+# Regenerate, overwriting existing files
+dtaas generate-deployment --type insecure-server --output-dir ./demo --force
+```
+
+When `dtaas.toml` is present, values are substituted automatically
+into the generated files (dotenv files, `config/client.js`, and — for
+TLS types — the `certs/` directory). See
+[Configuration Substitution](cli-config.md#configuration-substitution)
+for the full details. If `dtaas.toml` is not found, a note is printed
+and generated files keep their default placeholder values.
+
+### `generate-project`
+
+Scaffolds `dtaas.toml`, Docker Compose user-workspace templates, and
+the `files/template/` directory into your working directory.
 
 ```bash
 dtaas generate-project
 ```
 
+**Options**
+
+| Option | Default | Description |
+| :----- | :------ | :----------- |
+| `--output-dir PATH` | `.` | Target directory (must already exist) |
+| `--force` | off | Overwrite files that already exist |
+
+**Generated files**
+
+| Item | Purpose |
+| :--- | :------ |
+| `dtaas.toml` | Main CLI configuration |
+| `users.server.yml` | Docker Compose template for HTTP deployments |
+| `users.server.secure.yml` | Docker Compose template for HTTPS/TLS deployments |
+| `users.resources.yml` | Per-user resource-limit overlay, merged in when `set_limits` is true |
+| `files/template/` | Skeleton copied into each new user workspace |
+
+!!! tip "Verify the Docker image tag"
+    `users.server.yml` and `users.server.secure.yml` contain a pinned
+    workspace image tag (e.g. `intocps/workspace:main-967bc10`). Check
+    [Docker Hub](https://hub.docker.com/r/intocps/workspace/tags) and
+    update the tag to a current, stable version before deploying.
+
+### `admin install`
+
+Brings a generated deployment up with a single command.
+
+```bash
+dtaas admin install
+```
+
+Internally runs `docker compose up -d` against the
+`docker-compose.yml` in the installation directory. Before starting,
+it ensures per-user workspace directories for every `[[users]]`
+record exist, recreating each from `files/template/` if missing, and
+sets ownership to `1000:100`.
+
+**Options**
+
+| Option | Default | Description |
+| :----- | :------ | :----------- |
+| `--output-dir PATH` | `.` | Installation directory containing the generated deployment |
+
+The CLI looks for `dtaas.toml` in `--output-dir` first, then the
+current working directory, so a single top-level `dtaas.toml` can
+serve a deployment generated into a subdirectory:
+
+```bash
+dtaas admin install --output-dir ./insecure
+```
+
+The command fails with a clear error if `docker-compose.yml` is
+missing, `dtaas.toml` cannot be found, or the Docker daemon is
+unreachable.
+
+### `admin uninstall`
+
+Tears the deployment down, stopping and removing containers and
+networks.
+
+```bash
+dtaas admin uninstall
+```
+
+User containers added with `admin user add` run as a separate Compose
+project; they are torn down first so they do not hold the shared
+network open. **Per-user workspace files are preserved by default.**
+
+To also delete the generated per-user workspace directories **and**
+the CLI-owned `dtaas.users.registry.json` / `.dtaas.state.json`:
+
+```bash
+dtaas admin uninstall --remove-user-files
+```
+
+This is destructive, so the command prompts for confirmation. Skip
+the prompt in non-interactive scripts with `--yes`:
+
+```bash
+dtaas admin uninstall --remove-user-files --yes
+```
+
+**Options**
+
+| Option | Default | Description |
+| :----- | :------ | :----------- |
+| `--output-dir PATH` | `.` | Installation directory |
+| `--remove-user-files` | off | Also delete per-user workspace dirs + registry/state files |
+| `--yes` / `-y` | off | Skip the confirmation prompt for `--remove-user-files` |
+
+!!! note
+    `--remove-user-files` removes only the per-user directories inside
+    `<output-dir>/files/`, preserving `files/common/` and
+    `files/template/` so a later `admin install` can recreate user
+    directories. It refuses to follow a symlinked `files/`.
+    Double-check `--output-dir` before using this flag.
+
+### Lifecycle operations
+
+Operational controls for an **already-installed** deployment: observe
+it with `status`, and suspend or resume it with `stop`/`start` and
+`pause`/`resume`. None of these remove containers or networks — that
+is `uninstall`'s job. Each command targets both the main deployment
+and any user-added workloads (`compose.users.yml`), and exits `0` on
+success (including the idempotent "nothing installed" case) and
+non-zero on failure, so they are safe to call from CI/ops scripts.
+
+`stop`/`start`/`pause`/`resume` act on the main deployment first, then
+user-added workloads. If the second project fails after the first
+already succeeded, there is no rollback — re-run the same command:
+each project's compose command is idempotent, so retrying repeats a
+harmless no-op against whichever project already changed and retries
+the one that failed.
+
+**Lifecycle command matrix**
+
+| Command | `docker compose` verb | Effect | Containers kept? | Reverse with |
+| :------ | :---------------------- | :----- | :----------------: | :----------- |
+| `admin install` | `up -d` | Create and start every service | n/a | `admin stop` / `admin uninstall` |
+| `admin status` | `ps` (read-only) | Report per-service state; no change | n/a | n/a |
+| `admin stop` | `stop` | Terminate the processes, keep the containers | yes | `admin start` |
+| `admin start` | `start` | Start previously stopped containers | yes | `admin stop` |
+| `admin pause` | `pause` | Freeze the processes (memory preserved) | yes | `admin resume` |
+| `admin resume` | `unpause` | Thaw previously paused processes | yes | n/a |
+| `admin uninstall` | `down` | Stop **and remove** containers and networks | no | `admin install` |
+
+!!! note "`stop` vs `pause`"
+    `stop` sends `SIGTERM`/`SIGKILL`: processes end, and a restart
+    re-runs them from scratch (reverse with `admin start`). `pause`
+    uses the kernel cgroup freezer: processes are suspended in place
+    with their memory intact and resume instantly (reverse with
+    `admin resume`), but a paused container still holds its resources.
+    Use `stop` to free CPU; use `pause` for a brief, instantly
+    reversible suspension. `pause` expects running containers and will
+    error if the deployment is already stopped.
+
+#### `admin status`
+
+Reports the state of every service, for both the deployment and user
+workloads.
+
+```bash
+dtaas admin status
+```
+
+```text
+PROJECT     SERVICE            STATE        HEALTH
+deployment  traefik            running      healthy
+deployment  client             running      -
+deployment  gitlab             not created  -
+users       user-alice         paused       -
+```
+
+State values are `running`, `paused`, `stopped` (a terminated
+container, what Docker calls `exited`), `restarting`, or
+`not created` (a service defined in `docker-compose.yml` that has no
+container yet). `HEALTH` shows the container healthcheck status, or
+`-` when the service has none.
+
+For automation, `--json` emits the same records as machine-readable
+JSON:
+
+```bash
+dtaas admin status --json
+```
+
+```json
+[
+  {"project": "deployment", "service": "traefik", "state": "running", "health": "healthy"}
+]
+```
+
+**Options**
+
+| Option | Default | Description |
+| :----- | :------ | :----------- |
+| `--output-dir PATH` | `.` | Installation directory |
+| `--json` | off | Emit machine-readable JSON instead of the table |
+
+#### `admin stop` / `admin start`
+
+`stop` stops all services with `docker compose stop`; `start` brings
+the stopped containers back with `docker compose start`. Containers
+and networks are **kept**, so `stop` is not an uninstall.
+
+```bash
+dtaas admin stop
+dtaas admin start
+```
+
+Both report `no existing DTaaS / Workspace installation` and exit `0`
+when nothing is installed (no containers in any state), so they are
+safe to call repeatedly.
+
+**Options**
+
+| Option | Default | Description |
+| :----- | :------ | :----------- |
+| `--output-dir PATH` | `.` | Installation directory |
+
+#### `admin pause` / `admin resume`
+
+`pause` freezes every running container in place with
+`docker compose pause`; `resume` thaws them with
+`docker compose unpause`. Memory is preserved and resume is
+near-instant.
+
+```bash
+dtaas admin pause
+dtaas admin resume
+```
+
+Both report the absent-installation case and exit `0` when nothing is
+installed (no containers in any state).
+
+**Options**
+
+| Option | Default | Description |
+| :----- | :------ | :----------- |
+| `--output-dir PATH` | `.` | Installation directory |
+
+### `admin update --certs`
+
+Rotates TLS certificates of a running deployment in place: no project
+regeneration or manual file copying required.
+
+```bash
+dtaas admin update --certs
+```
+
+The command reads `[common.security].certs-src` from `dtaas.toml`,
+then:
+
+1. **Validates** the new certificate pair (parseable, private key
+   matches cert, no expired intermediates).
+2. **Stops** the `traefik` service to release open file handles.
+3. **Swaps** the validated files into `<output-dir>/certs/`, backing
+   up the live pair and restoring it on any failure.
+4. **Restricts** the private key to `0600` (POSIX; prints a warning
+   on Windows).
+5. **Restarts** `traefik` and waits for it to come back up.
+
+If validation fails, live certificates are left untouched. The
+command is safe to run repeatedly.
+
+**Options**
+
+| Option | Default | Description |
+| :----- | :------ | :----------- |
+| `--certs` | *(required)* | Refresh the deployment's TLS certificates |
+| `--output-dir PATH` | `.` | Installation directory |
+
+### `admin update --config`
+
+Re-applies the values in `dtaas.toml` to an already-installed
+deployment's service config files without regenerating the project.
+
+```bash
+dtaas admin update --config
+```
+
+Treats `dtaas.toml` as the single source of truth, re-runs the same
+substitution as `generate-deployment`, and if anything changed,
+recreates all deployment services with
+`docker compose up -d --force-recreate`. The deployment type is
+auto-detected from `docker-compose.yml`.
+
+```bash
+# Preview changes without writing or restarting
+dtaas admin update --config --dry-run
+
+# Apply changes and restart
+dtaas admin update --config
+
+# Update a deployment in a subdirectory
+dtaas admin update --config --output-dir ./my-server
+```
+
+`--config` validates `dtaas.toml` before making any changes and
+refuses to apply if problems are found. It is **idempotent** — a
+second run with no `dtaas.toml` changes reports
+`No configuration changes` and restarts nothing.
+
+**Options**
+
+| Option | Default | Description |
+| :----- | :------ | :----------- |
+| `--config` | *(required)* | Re-apply `dtaas.toml` to installed service config files |
+| `--dry-run` | off | Report what would change without writing or restarting |
+| `--output-dir PATH` | `.` | Installation directory |
+
+`--certs` and `--config` may be combined in a single invocation.
+
+## User Management
+
+User management spans three files, each with a single owner — see
+[User Files](cli-config.md#user-files) for the full model.
+
+- **`dtaas.users.registry.json`** — the CLI-owned record of every
+  _additional_ user (added after install with `admin user add`),
+  including their `desired_status` (`running`/`paused`/`stopped`).
+  Mutated only by `admin user add`/`delete`/`pause`/`stop`/`resume`;
+  never hand-edited.
+- **`.dtaas.state.json`** — a git-ignored, disposable cache of what is
+  actually running: per-user container id, status, and a config hash,
+  refreshed on every add/delete. Safe to delete; the CLI rebuilds it
+  on the next provisioning run. `admin config reconcile` compares it
+  against the registry to detect drift.
+
 ### Add Users
 
 The initial, "starting" users an instance is installed with are declared in
-_dtaas.toml_ as `[[users]]` records (see above); they are hand-edited once,
-at install time, and never rewritten by the CLI.
+_dtaas.toml_ as `[[users]]` records (see [Abridged Configuration](#abridged-configuration));
+they are hand-edited once, at install time, and never rewritten by the CLI.
 
 Users added later at runtime are **not** added to _dtaas.toml_. Instead, run
-`dtaas admin user add` from the _cli_ directory, either for a single user:
+`dtaas admin user add`, either for a single user:
 
 ```bash
-dtaas admin user add alice --email alice@intocps.org
+dtaas admin user add --email alice@intocps.org --group dtaas --load-balance alice
+```
+
+`--group` is repeatable, not comma-separated — pass it once per group to add
+a user to multiple groups:
+
+```bash
+dtaas admin user add --email alice@intocps.org --group dtaas --group testers alice
 ```
 
 or in bulk from a CSV file (the sample `users.csv` is written alongside
@@ -212,12 +605,37 @@ or in bulk from a CSV file (the sample `users.csv` is written alongside
 dtaas admin user add --file users.csv
 ```
 
-`--group` (repeatable) and `--load-balance`/`--no-load-balance` set the
-optional per-user tags. Either form merges the user(s) into the CLI-owned
-`dtaas.users.registry.json` (never hand-edited), then provisions every
-registry user. A username already declared in `dtaas.toml`'s `[[users]]` or
-already in the registry is skipped with a warning, never added twice or
-overwritten.
+```csv
+username,email,groups,load_balance
+alice,alice@intocps.org,additional,true
+bob,bob@intocps.org,additional;beta-testers,false
+```
+
+`groups` is a `;`-separated list and `load_balance` is `true`/`false`. A
+`USERNAME` or `--file` is required (not both) — a bare `dtaas admin user add`
+with neither is rejected rather than silently reprovisioning the whole
+registry.
+
+Either form merges the user(s) into the CLI-owned
+`dtaas.users.registry.json` (never hand-edited) with `desired_status` set to
+`running`, then **only the newly-added users are started** — already-running
+users are left untouched, so adding one user never recreates the rest. A
+username already declared in `dtaas.toml`'s `[[users]]` or already in the
+registry is skipped with a warning, never added twice or overwritten.
+
+To (re)provision **every** registry user at once (e.g. after
+`compose.users.yml` was lost), use `dtaas admin config reconcile --fix`
+instead.
+
+**Options**
+
+| Option | Default | Description |
+| :----- | :------ | :----------- |
+| `USERNAME` | — | Add one user (requires `--email`) |
+| `--file PATH` / `-f` | — | Bulk-add users from a CSV |
+| `--email TEXT` | — | Email for `USERNAME` (enables forward-auth routing) |
+| `--group TEXT` | `additional` | Group tag for `USERNAME`; repeat the flag for multiple groups |
+| `--load-balance` / `--no-load-balance` | on | Mark `USERNAME` for load balancing |
 
 The command checks for the existence of `files/<username>` directory.
 If it does not exist, a new directory with correct file structure is created.
@@ -230,10 +648,39 @@ traefik-forward-auth routing rule to `config/conf.server`; no manual editing
 of `conf.server` is needed. Restart the container for the change to take
 effect:
 
+```bash
+docker compose --env-file config/.env up -d --force-recreate traefik-forward-auth
+```
+
+#### Resource limits (optional)
+
+By default each user container is created with the CPU, memory, process, and
+shared-memory caps from `[common.resources]`, merged in from the
+`users.resources.yml` overlay. To onboard users without any caps, set
+`set_limits = false` in that section:
+
+```toml
+# Constrained users (default): limits enforced
+[common.resources]
+set_limits = true
+cpus       = 4
+mem_limit  = "4G"
+pids_limit = 4960
+shm_size   = "512m"
+```
+
+```toml
+# Unconstrained users: no caps written, limit fields optional
+[common.resources]
+set_limits = false
+```
+
+The flag is read on every `user add`, so a deployment can host both
+constrained and unconstrained users by toggling `set_limits` between runs.
+
 ### Delete Users
 
-Pass one or more usernames to `dtaas admin user delete`, run from the _cli_
-directory:
+Pass one or more usernames to `dtaas admin user delete`:
 
 ```bash
 dtaas admin user delete alice bob
@@ -245,10 +692,83 @@ or bulk-delete from the same CSV format (only the `username` column is used):
 dtaas admin user delete --file users.csv
 ```
 
+`USERNAMES` and `--file` are mutually exclusive, and one of them is required.
 Add `--dry-run` to preview which users would be removed without deleting
-anything. Each deleted user is deprovisioned (container stopped, compose
-service and forward-auth rule removed) and dropped from
-`dtaas.users.registry.json`.
+anything:
+
+```bash
+dtaas admin user delete alice bob --dry-run
+```
+
+Each deleted user is deprovisioned (container stopped, compose service and
+forward-auth rule removed) and dropped from `dtaas.users.registry.json`.
+Users that are not currently provisioned are reported and skipped, but are
+still removed from the registry.
+
+The CLI automatically removes the traefik-forward-auth routing rules for
+deleted users from `config/conf.server`. Restart the container for the
+change to take effect:
+
+```bash
+docker compose --env-file config/.env up -d --force-recreate traefik-forward-auth
+```
+
+**Options**
+
+| Option | Default | Description |
+| :----- | :------ | :----------- |
+| `USERNAMES` | — | One or more usernames to remove |
+| `--file PATH` / `-f` | — | Bulk-delete users listed in a CSV (only the `username` column is used) |
+| `--dry-run` | off | Preview the removal without making any changes |
+
+### `admin user pause` / `stop` / `resume`
+
+Suspend or resume **specific additional (registry) users** without touching
+the rest of the installation, targeting one or more `USERNAMES` or a
+`--file`/`-f users.csv` (only the `username` column is read) the same way
+`admin user delete` does.
+
+```bash
+dtaas admin user pause alice bob
+dtaas admin user stop alice
+dtaas admin user resume alice bob
+dtaas admin user pause --file users.csv
+```
+
+| Command | `docker compose` verb | Effect | Reverse with |
+| :------ | :----------------------- | :----- | :----------- |
+| `admin user pause` | `pause` | Freeze the named users' containers (memory preserved) | `admin user resume` |
+| `admin user stop` | `stop` | Terminate the named users' containers, keep them | `admin user resume` |
+| `admin user resume` | `unpause` or `start`, as needed | Thaw a paused user, or restart a stopped one | — |
+
+Each command also writes a `desired_status` (`"paused"`/`"stopped"`/`"running"`)
+into `dtaas.users.registry.json` for the users it acted on. This is what makes
+the suspension durable: a later `dtaas admin user add` (which idempotently
+re-provisions every registry user on every run) or
+`dtaas admin config reconcile --fix` checks `desired_status` and will **not**
+silently restart a user you paused or stopped. Only `admin user resume` (or
+hand-editing the registry) clears it back to `"running"`.
+
+Only additional users can be targeted here. Naming a `dtaas.toml` starting
+user is rejected with an error: suspend or resume the whole installation
+(starting users included) with
+[`dtaas admin pause`/`stop`/`resume`](#lifecycle-operations) instead.
+
+A username not found in the registry, or found but not currently provisioned
+(e.g. `user add` was never run for them), is reported and skipped rather than
+aborting the whole batch:
+
+```text
+'carol' is not a registered user, skipping
+alice, bob paused successfully
+```
+
+**Options**
+
+| Option | Default | Description |
+| :----- | :------ | :----------- |
+| `USERNAMES` | — | One or more usernames to target |
+| `--file PATH` / `-f` | — | Bulk-target users listed in a CSV (only the `username` column is used) |
 
 ### Additional Points to Remember
 
@@ -256,12 +776,14 @@ service and forward-auth rule removed) and dropped from
   stopped. It reports a _Running_ status for containers already up, without
   restarting them.
 - Provisioning is idempotent: re-running `user add` reprovisions every
-  registry user without duplicating work.
-- Usernames may include `_` and `-` (must start with a letter or digit);
+  registry user without duplicating work. An empty registry is a no-op.
+- Usernames may include `.`, `_` and `-` (must start with a letter or digit);
   whitespace, path separators, and shell metacharacters are rejected.
+- This command does not enable AuthMS authentication.
 
 ### Known Limitations
 
-- Usernames containing `.` cannot currently be added through the
-  CLI. This is an active issue that will be resolved in a future
-  release.
+- Usernames containing `.` are accepted by validation, but `.` is a special
+  character for labels in Docker Compose, so containers for such users can
+  fail to provision correctly. This is an active issue, tracked for a future
+  release to internally replace `.` with `-` or `_` in generated labels.

--- a/docs/admin/cli.md
+++ b/docs/admin/cli.md
@@ -48,7 +48,7 @@ Tear it down again with `dtaas admin uninstall` (add
 `--remove-user-files` to also delete per-user workspace directories;
 this prompts for confirmation, or pass `--yes` to skip the prompt).
 
-### 🗺️ Deployment Types
+### 🗺️ Deployment Types {#deployment-types}
 
 | `--type` | When to use | Support level |
 | :------- | :---------- | :------------- |
@@ -94,7 +94,7 @@ Always run `dtaas admin config validate` after editing; it reports
 all problems at once — see
 [Validation Rules](cli-config.md#validation-rules) for the full list.
 
-### 📄 Abridged Configuration
+### 📄 Abridged Configuration {#abridged-configuration}
 
 The CLI uses *dtaas.toml* as its configuration file. An abridged
 configuration file is given here.
@@ -366,7 +366,7 @@ dtaas admin uninstall --remove-user-files --yes
     directories. It refuses to follow a symlinked `files/`.
     Double-check `--output-dir` before using this flag.
 
-### 🔄 Lifecycle operations
+### 🔄 Lifecycle operations {#lifecycle-operations}
 
 Operational controls for an **already-installed** deployment: observe
 it with `status`, and suspend or resume it with `stop`/`start` and

--- a/docs/admin/cli.md
+++ b/docs/admin/cli.md
@@ -11,7 +11,7 @@ command. The complete `dtaas.toml` field reference — validation
 rules, the annotated example file, and the user-file model — is in
 the [Config Reference](cli-config.md).
 
-## Installation
+## 📦 Installation
 
 Installation inside a virtual environment is strongly recommended.
 
@@ -24,7 +24,7 @@ pip install dtaas
 dtaas --help                  # verify
 ```
 
-## Quick Start
+## ⚡ Quick Start
 
 From a clean machine to a running deployment:
 
@@ -48,7 +48,7 @@ Tear it down again with `dtaas admin uninstall` (add
 `--remove-user-files` to also delete per-user workspace directories;
 this prompts for confirmation, or pass `--yes` to skip the prompt).
 
-### Deployment Types
+### 🗺️ Deployment Types
 
 | `--type` | When to use | Support level |
 | :------- | :---------- | :------------- |
@@ -72,7 +72,7 @@ The generated packages match the
 the CLI fills in the configuration and file structure that the manual
 path asks you to prepare by hand.
 
-## Configuration
+## ⚙️ Configuration
 
 The CLI treats `dtaas.toml` as the single source of truth. It looks
 for the file in `--output-dir` first, then in the current working
@@ -94,9 +94,9 @@ Always run `dtaas admin config validate` after editing; it reports
 all problems at once — see
 [Validation Rules](cli-config.md#validation-rules) for the full list.
 
-### Abridged Configuration
+### 📄 Abridged Configuration
 
-The CLI uses _dtaas.toml_ as configuration file. An abridged
+The CLI uses _dtaas.toml_ as its configuration file. An abridged
 configuration file is given here.
 
 ```toml
@@ -156,13 +156,13 @@ email = "username2@intocps.org"
   workspace via the CLI or by restarting the container in Docker Compose).
 - Use units (`M`, `G`) for memory and shared memory values.
 
-## Commands
+## 🛠 Commands
 
 This section documents every `dtaas` command not already covered
 above. Every command accepts `--output-dir` (default `.`), checked
 before falling back to the current working directory.
 
-### `admin config generate` / `admin config validate`
+### 🗒️ `admin config generate` / `admin config validate`
 
 ```bash
 dtaas admin config generate    # writes dtaas.toml + a sample users.csv
@@ -181,10 +181,10 @@ file at once — see [Validation Rules](cli-config.md#validation-rules).
 | `--output-dir PATH` | `.` | For `generate`: target directory (created if missing). For `validate`: search location |
 | `--force` | off | (`generate` only) Overwrite an existing `dtaas.toml` |
 
-### `admin config reconcile`
+### 🔍 `admin config reconcile`
 
-Reports drift between `dtaas.users.registry.json` (who **should** be
-provisioned) and the live `compose.users.yml` services (who **is**
+Reports drift between `dtaas.users.registry.json` (which **should** be
+provisioned) and the live `compose.users.yml` services (which **are**
 provisioned):
 
 ```bash
@@ -202,8 +202,8 @@ It lists:
   state does not match the user's registry `desired_status` (e.g.
   `desired 'paused' but container is 'running'`).
 
-When everything matches it prints `In sync: no drift detected.`
-Without `--fix` this is read-only. Pass `--fix` to reprovision
+When everything matches, it prints `In sync: no drift detected.`
+Without `--fix`, this is read-only. Pass `--fix` to reprovision
 **missing** and **drifted** users, and to pause/stop/start every
 provisioned user to match its `desired_status`:
 
@@ -222,7 +222,7 @@ something that's actually running is a deliberate action; use
 | `--output-dir PATH` | `.` | Installation directory to inspect |
 | `--fix` | off | Reprovision missing/drifted registry users, and enforce desired status, after reporting |
 
-### `generate-deployment`
+### 🏗️ `generate-deployment`
 
 Copies the full project structure for a specific deployment scenario
 — `docker-compose.yml`, config examples, and supporting files — into
@@ -260,7 +260,7 @@ TLS types — the `certs/` directory). See
 for the full details. If `dtaas.toml` is not found, a note is printed
 and generated files keep their default placeholder values.
 
-### `generate-project`
+### 🧰 `generate-project`
 
 Scaffolds `dtaas.toml`, Docker Compose user-workspace templates, and
 the `files/template/` directory into your working directory.
@@ -292,7 +292,7 @@ dtaas generate-project
     [Docker Hub](https://hub.docker.com/r/intocps/workspace/tags) and
     update the tag to a current, stable version before deploying.
 
-### `admin install`
+### 🚀 `admin install`
 
 Brings a generated deployment up with a single command.
 
@@ -324,7 +324,7 @@ The command fails with a clear error if `docker-compose.yml` is
 missing, `dtaas.toml` cannot be found, or the Docker daemon is
 unreachable.
 
-### `admin uninstall`
+### 🧹 `admin uninstall`
 
 Tears the deployment down, stopping and removing containers and
 networks.
@@ -366,7 +366,7 @@ dtaas admin uninstall --remove-user-files --yes
     directories. It refuses to follow a symlinked `files/`.
     Double-check `--output-dir` before using this flag.
 
-### Lifecycle operations
+### 🔄 Lifecycle operations
 
 Operational controls for an **already-installed** deployment: observe
 it with `status`, and suspend or resume it with `stop`/`start` and
@@ -405,7 +405,7 @@ the one that failed.
     reversible suspension. `pause` expects running containers and will
     error if the deployment is already stopped.
 
-#### `admin status`
+#### 📊 `admin status`
 
 Reports the state of every service, for both the deployment and user
 workloads.
@@ -448,7 +448,7 @@ dtaas admin status --json
 | `--output-dir PATH` | `.` | Installation directory |
 | `--json` | off | Emit machine-readable JSON instead of the table |
 
-#### `admin stop` / `admin start`
+#### ⏹️ `admin stop` / ▶️ `admin start`
 
 `stop` stops all services with `docker compose stop`; `start` brings
 the stopped containers back with `docker compose start`. Containers
@@ -469,7 +469,7 @@ safe to call repeatedly.
 | :----- | :------ | :----------- |
 | `--output-dir PATH` | `.` | Installation directory |
 
-#### `admin pause` / `admin resume`
+#### ⏸️ `admin pause` / ▶️ `admin resume`
 
 `pause` freezes every running container in place with
 `docker compose pause`; `resume` thaws them with
@@ -490,7 +490,7 @@ installed (no containers in any state).
 | :----- | :------ | :----------- |
 | `--output-dir PATH` | `.` | Installation directory |
 
-### `admin update --certs`
+### 🔁 `admin update --certs`
 
 Rotates TLS certificates of a running deployment in place: no project
 regeneration or manual file copying required.
@@ -521,7 +521,7 @@ command is safe to run repeatedly.
 | `--certs` | *(required)* | Refresh the deployment's TLS certificates |
 | `--output-dir PATH` | `.` | Installation directory |
 
-### `admin update --config`
+### 🧩 `admin update --config`
 
 Re-applies the values in `dtaas.toml` to an already-installed
 deployment's service config files without regenerating the project.
@@ -562,7 +562,7 @@ second run with no `dtaas.toml` changes reports
 
 `--certs` and `--config` may be combined in a single invocation.
 
-## User Management
+## 👥 User Management
 
 User management spans three files, each with a single owner — see
 [User Files](cli-config.md#user-files) for the full model.
@@ -578,7 +578,7 @@ User management spans three files, each with a single owner — see
   on the next provisioning run. `admin config reconcile` compares it
   against the registry to detect drift.
 
-### Add Users
+### ➕ Add Users
 
 The initial, "starting" users an instance is installed with are declared in
 _dtaas.toml_ as `[[users]]` records (see [Abridged Configuration](#abridged-configuration));
@@ -637,10 +637,10 @@ instead.
 | `--group TEXT` | `additional` | Group tag for `USERNAME`; repeat the flag for multiple groups |
 | `--load-balance` / `--no-load-balance` | on | Mark `USERNAME` for load balancing |
 
-The command checks for the existence of `files/<username>` directory.
-If it does not exist, a new directory with correct file structure is created.
-The directory, if it exists, must be owned by the user executing
-**dtaas** command on the host operating system. If the files do not
+The command checks for the existence of the `files/<username>` directory.
+If it does not exist, a new directory with the correct file structure is
+created. The directory, if it exists, must be owned by the user executing
+the **dtaas** command on the host operating system. If the files do not
 have the expected ownership rights, the command fails.
 
 When an _email_ is given for a user, the CLI automatically adds the matching
@@ -652,7 +652,7 @@ effect:
 docker compose --env-file config/.env up -d --force-recreate traefik-forward-auth
 ```
 
-#### Resource limits (optional)
+#### ⚖️ Resource limits (optional)
 
 By default each user container is created with the CPU, memory, process, and
 shared-memory caps from `[common.resources]`, merged in from the
@@ -678,7 +678,7 @@ set_limits = false
 The flag is read on every `user add`, so a deployment can host both
 constrained and unconstrained users by toggling `set_limits` between runs.
 
-### Delete Users
+### ➖ Delete Users
 
 Pass one or more usernames to `dtaas admin user delete`:
 
@@ -721,11 +721,11 @@ docker compose --env-file config/.env up -d --force-recreate traefik-forward-aut
 | `--file PATH` / `-f` | — | Bulk-delete users listed in a CSV (only the `username` column is used) |
 | `--dry-run` | off | Preview the removal without making any changes |
 
-### `admin user pause` / `stop` / `resume`
+### ⏯️ `admin user pause` / `stop` / `resume`
 
 Suspend or resume **specific additional (registry) users** without touching
 the rest of the installation, targeting one or more `USERNAMES` or a
-`--file`/`-f users.csv` (only the `username` column is read) the same way
+`--file`/`-f users.csv` (only the `username` column is read), the same way
 `admin user delete` does.
 
 ```bash
@@ -770,7 +770,7 @@ alice, bob paused successfully
 | `USERNAMES` | — | One or more usernames to target |
 | `--file PATH` / `-f` | — | Bulk-target users listed in a CSV (only the `username` column is used) |
 
-### Additional Points to Remember
+### 📌 Additional Points to Remember
 
 - `user add` starts a container for a new user, or restarts one that was
   stopped. It reports a _Running_ status for containers already up, without
@@ -781,7 +781,7 @@ alice, bob paused successfully
   whitespace, path separators, and shell metacharacters are rejected.
 - This command does not enable AuthMS authentication.
 
-### Known Limitations
+### ⚠️ Known Limitations
 
 - Usernames containing `.` are accepted by validation, but `.` is a special
   character for labels in Docker Compose, so containers for such users can

--- a/docs/admin/cli.md
+++ b/docs/admin/cli.md
@@ -96,7 +96,7 @@ all problems at once — see
 
 ### 📄 Abridged Configuration
 
-The CLI uses _dtaas.toml_ as its configuration file. An abridged
+The CLI uses *dtaas.toml* as its configuration file. An abridged
 configuration file is given here.
 
 ```toml
@@ -174,7 +174,7 @@ for `admin user add --file`) into `--output-dir`; `--force` overwrites
 an existing `dtaas.toml`. `validate` reports every problem in the
 file at once — see [Validation Rules](cli-config.md#validation-rules).
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 | :----- | :------ | :----------- |
@@ -215,7 +215,7 @@ dtaas admin config reconcile --fix
 something that's actually running is a deliberate action; use
 `dtaas admin user delete` for those.
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 | :----- | :------ | :----------- |
@@ -232,7 +232,7 @@ a target directory ready to be customised.
 dtaas generate-deployment --type <name>
 ```
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 | :----- | :------ | :----------- |
@@ -240,7 +240,7 @@ dtaas generate-deployment --type <name>
 | `--output-dir PATH` | `.` | Target directory (must already exist) |
 | `--force` | off | Overwrite files that already exist |
 
-**Examples**
+**Examples:**
 
 ```bash
 # Localhost demo in the current directory
@@ -269,14 +269,14 @@ the `files/template/` directory into your working directory.
 dtaas generate-project
 ```
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 | :----- | :------ | :----------- |
 | `--output-dir PATH` | `.` | Target directory (must already exist) |
 | `--force` | off | Overwrite files that already exist |
 
-**Generated files**
+**Generated files:**
 
 | Item | Purpose |
 | :--- | :------ |
@@ -306,7 +306,7 @@ it ensures per-user workspace directories for every `[[users]]`
 record exist, recreating each from `files/template/` if missing, and
 sets ownership to `1000:100`.
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 | :----- | :------ | :----------- |
@@ -351,7 +351,7 @@ the prompt in non-interactive scripts with `--yes`:
 dtaas admin uninstall --remove-user-files --yes
 ```
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 | :----- | :------ | :----------- |
@@ -383,7 +383,7 @@ each project's compose command is idempotent, so retrying repeats a
 harmless no-op against whichever project already changed and retries
 the one that failed.
 
-**Lifecycle command matrix**
+**Lifecycle command matrix:**
 
 | Command | `docker compose` verb | Effect | Containers kept? | Reverse with |
 | :------ | :---------------------- | :----- | :----------------: | :----------- |
@@ -441,7 +441,7 @@ dtaas admin status --json
 ]
 ```
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 | :----- | :------ | :----------- |
@@ -463,7 +463,7 @@ Both report `no existing DTaaS / Workspace installation` and exit `0`
 when nothing is installed (no containers in any state), so they are
 safe to call repeatedly.
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 | :----- | :------ | :----------- |
@@ -484,7 +484,7 @@ dtaas admin resume
 Both report the absent-installation case and exit `0` when nothing is
 installed (no containers in any state).
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 | :----- | :------ | :----------- |
@@ -514,7 +514,7 @@ then:
 If validation fails, live certificates are left untouched. The
 command is safe to run repeatedly.
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 | :----- | :------ | :----------- |
@@ -552,7 +552,7 @@ refuses to apply if problems are found. It is **idempotent** — a
 second run with no `dtaas.toml` changes reports
 `No configuration changes` and restarts nothing.
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 | :----- | :------ | :----------- |
@@ -568,7 +568,7 @@ User management spans three files, each with a single owner — see
 [User Files](cli-config.md#user-files) for the full model.
 
 - **`dtaas.users.registry.json`** — the CLI-owned record of every
-  _additional_ user (added after install with `admin user add`),
+  *additional* user (added after install with `admin user add`),
   including their `desired_status` (`running`/`paused`/`stopped`).
   Mutated only by `admin user add`/`delete`/`pause`/`stop`/`resume`;
   never hand-edited.
@@ -581,10 +581,10 @@ User management spans three files, each with a single owner — see
 ### ➕ Add Users
 
 The initial, "starting" users an instance is installed with are declared in
-_dtaas.toml_ as `[[users]]` records (see [Abridged Configuration](#abridged-configuration));
+*dtaas.toml* as `[[users]]` records (see [Abridged Configuration](#abridged-configuration));
 they are hand-edited once, at install time, and never rewritten by the CLI.
 
-Users added later at runtime are **not** added to _dtaas.toml_. Instead, run
+Users added later at runtime are **not** added to *dtaas.toml*. Instead, run
 `dtaas admin user add`, either for a single user:
 
 ```bash
@@ -627,7 +627,7 @@ To (re)provision **every** registry user at once (e.g. after
 `compose.users.yml` was lost), use `dtaas admin config reconcile --fix`
 instead.
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 | :----- | :------ | :----------- |
@@ -643,7 +643,7 @@ created. The directory, if it exists, must be owned by the user executing
 the **dtaas** command on the host operating system. If the files do not
 have the expected ownership rights, the command fails.
 
-When an _email_ is given for a user, the CLI automatically adds the matching
+When an *email* is given for a user, the CLI automatically adds the matching
 traefik-forward-auth routing rule to `config/conf.server`; no manual editing
 of `conf.server` is needed. Restart the container for the change to take
 effect:
@@ -713,7 +713,7 @@ change to take effect:
 docker compose --env-file config/.env up -d --force-recreate traefik-forward-auth
 ```
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 | :----- | :------ | :----------- |
@@ -763,7 +763,7 @@ aborting the whole batch:
 alice, bob paused successfully
 ```
 
-**Options**
+**Options:**
 
 | Option | Default | Description |
 | :----- | :------ | :----------- |
@@ -773,7 +773,7 @@ alice, bob paused successfully
 ### 📌 Additional Points to Remember
 
 - `user add` starts a container for a new user, or restarts one that was
-  stopped. It reports a _Running_ status for containers already up, without
+  stopped. It reports a *Running* status for containers already up, without
   restarting them.
 - Provisioning is idempotent: re-running `user add` reprovisions every
   registry user without duplicating work. An empty registry is a no-op.

--- a/docs/user/digital-twins/devops/measurement.md
+++ b/docs/user/digital-twins/devops/measurement.md
@@ -7,7 +7,7 @@ future optimization.
 
 ## Accessing the Measurement Page
 
-Navigate to `http://localhost:4000/insight/measure` or `https://intocps.org/insight/measure`
+Navigate to `http://localhost:4000/insights/measure` or `https://intocps.org/insights/measure`
 to access the measurement page. This page is only accessible to authenticated users.
 
 ![Measurement page](./images/measurement-page.png)

--- a/docs/user/website/images/logs-all.png
+++ b/docs/user/website/images/logs-all.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3f74423c015b518839f98d402707c4adb9219a974a341764e0e7ba47bf02598
+size 71320

--- a/docs/user/website/images/logs-filter.png
+++ b/docs/user/website/images/logs-filter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d65879c3710c0541c32d5ca11400607ffb051066eef2e69ab8716bba7fa4bdbc
+size 48869

--- a/docs/user/website/images/settings-overview.png
+++ b/docs/user/website/images/settings-overview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f081a506005f4c1799c751cbf1497166c3087a23349ca91d878d8628aa56ab5f
-size 75684
+oid sha256:ce97a71bfdafd07eccf442756d327d3b48e2bc0b6c9c92aee8942cb45c135207
+size 71426

--- a/docs/user/website/logs.md
+++ b/docs/user/website/logs.md
@@ -52,7 +52,7 @@ Each entry is shown as a card with:
 - Any additional context recorded for the event, shown as small chips
   (for example a link's target URL, or a form field's changed value).
 
-## 🔍 Filtering Logs
+## 🔍 Filtering Logs {#filtering-logs}
 
 Typing into the **Filter logs** box narrows the entries to those whose event
 type, label, element, page, or context text contains the search text. The

--- a/docs/user/website/logs.md
+++ b/docs/user/website/logs.md
@@ -5,9 +5,9 @@ users interact with the workbench: page navigation, button and link clicks,
 form changes, and notifications. These events are captured entirely in the
 browser and can be reviewed on the **Workflow Logs** page.
 
-## Enabling Logging
+## 🔓 Enabling Logging
 
-Logging is disabled by default. It can be enabled from the
+Logging is disabled by default. It can be enabled using the
 **Enable Logging** checkbox in the **Logging Settings** section of the
 [Settings](settings.md) page (**Account** > **Settings**). No events are
 captured, and none of the pages described below record anything, until this
@@ -18,7 +18,7 @@ server, a notice is shown on the Settings page. Remote logging should only be
 kept enabled with the consent of the person whose workbench activity is
 being recorded.
 
-## Viewing the Logs
+## 👁️ Viewing the Logs
 
 > **URL**: `https://intocps.org/insights/log` or
 > `http://localhost:4000/insights/log`
@@ -40,7 +40,7 @@ The toolbar above the log list provides the following controls:
 | Download                    | Exports the currently displayed entries as a `.jsonl` file.                             |
 | Live update                 | Streams new events into the view as they are recorded.                                  |
 
-## Log Entries (Card View)
+## 🗂️ Log Entries (Card View)
 
 Each entry is shown as a card with:
 
@@ -52,10 +52,10 @@ Each entry is shown as a card with:
 - Any additional context recorded for the event, shown as small chips
   (for example a link's target URL, or a form field's changed value).
 
-## Filtering Logs
+## 🔍 Filtering Logs
 
 Typing into the **Filter logs** box narrows the entries to those whose event
-type, label, element, page, or context text contain the search text. The
+type, label, element, page, or context text contains the search text. The
 entry count above the log list updates to show how many of the total
 entries match, for example *3 of 10 log entries*.
 
@@ -64,7 +64,7 @@ entries match, for example *3 of 10 log entries*.
 The **Download** button label changes to **Download Filtered JSONL** while a
 filter is active, so only the entries currently shown are exported.
 
-## Raw View
+## 🧾 Raw View
 
 Toggling **Raw view** displays the same entries as pretty-printed JSON
 Lines instead of cards, and adds a **Copy to clipboard** button. To keep the
@@ -74,7 +74,7 @@ entries; a note is shown when more entries exist. **Download** and
 entry currently displayed (i.e. respecting the filter, if any).
 
 Each line is a single JSON object. For example, a click on a link followed
-by the resulting page navigation appear as:
+by the resulting page navigation appears as:
 
 ```json
 {
@@ -118,7 +118,7 @@ by the resulting page navigation appear as:
 | `sessionId`        | A random identifier generated for the current browser session.                       |
 | `userHash`         | A SHA-256 hash of the username, used to link events without recording it in plain text. |
 
-## Live Updates
+## 🔴 Live Updates
 
 Turning on **Live update** subscribes the page to new log events as they are
 recorded elsewhere in the browser (including other open tabs), and reloads
@@ -126,14 +126,14 @@ the list automatically. It is turned off by default because continuously
 reloading a large log store is unnecessary while just reviewing past
 entries.
 
-## Clearing Logs
+## 🗑️ Clearing Logs
 
 The :material-delete-outline: icon opens a confirmation dialog before
 permanently deleting all stored log entries. This action cannot be undone,
 and only clears entries stored locally in the browser; it has no effect on
 any copies already streamed to a remote logging server.
 
-## Privacy and Storage
+## 🔒 Privacy and Storage
 
 - Log entries are stored locally in the browser (IndexedDB) and never leave
   the device, unless the DTaaS installation is configured with a remote
@@ -146,7 +146,7 @@ any copies already streamed to a remote logging server.
 - The `sessionId` field is a random value generated per browser session and
   is not linked to user identity.
 
-## Summary
+## 💭 Summary
 
 This page has described the client-side logging feature of the DTaaS
 website: enabling it from Settings, viewing and filtering recorded events

--- a/docs/user/website/logs.md
+++ b/docs/user/website/logs.md
@@ -1,0 +1,155 @@
+# Logs
+
+The DTaaS website includes a client-side logging feature that records how
+users interact with the workbench: page navigation, button and link clicks,
+form changes, and notifications. These events are captured entirely in the
+browser and can be reviewed on the **Workflow Logs** page.
+
+## Enabling Logging
+
+Logging is disabled by default. It can be enabled from the
+**Enable Logging** checkbox in the **Logging Settings** section of the
+[Settings](settings.md) page (**Account** > **Settings**). No events are
+captured, and none of the pages described below record anything, until this
+checkbox is turned on.
+
+If the DTaaS installation is configured to stream events to a remote logging
+server, a notice is shown on the Settings page. Remote logging should only be
+kept enabled with the consent of the person whose workbench activity is
+being recorded.
+
+## Viewing the Logs
+
+> **URL**: `https://intocps.org/insights/log` or
+> `http://localhost:4000/insights/log`
+
+The logs are viewed by navigating directly to `/insights/log` on the DTaaS
+installation. The page is titled **Workflow Logs**, and the :fontawesome-solid-circle-info:
+icon next to the title expands a short description of the page.
+
+![Workflow Logs](images/logs-all.png)
+
+The toolbar above the log list provides the following controls:
+
+| Control                     | Description                                                                             |
+| :--------------------------- | :---------------------------------------------------------------------------------------- |
+| Filter logs                 | Narrows the entries shown to those matching the search text (see [Filtering](#filtering-logs)). |
+| :material-refresh: Refresh  | Reloads the log entries from local storage.                                             |
+| Raw view :material-code-braces: | Switches between the card view and the raw JSON Lines view.                        |
+| :material-delete-outline: Clear logs | Permanently deletes all stored log entries, after confirmation.                |
+| Download                    | Exports the currently displayed entries as a `.jsonl` file.                             |
+| Live update                 | Streams new events into the view as they are recorded.                                  |
+
+## Log Entries (Card View)
+
+Each entry is shown as a card with:
+
+- A coloured chip identifying the event type: `click`, `change`, `navigation`,
+  `notification`, or `dismiss`.
+- The label of the element that triggered the event.
+- The timestamp of the event.
+- The element type and the page path on which the event occurred.
+- Any additional context recorded for the event, shown as small chips
+  (for example a link's target URL, or a form field's changed value).
+
+## Filtering Logs
+
+Typing into the **Filter logs** box narrows the entries to those whose event
+type, label, element, page, or context text contain the search text. The
+entry count above the log list updates to show how many of the total
+entries match, for example *3 of 10 log entries*.
+
+![Filtered Workflow Logs](images/logs-filter.png)
+
+The **Download** button label changes to **Download Filtered JSONL** while a
+filter is active, so only the entries currently shown are exported.
+
+## Raw View
+
+Toggling **Raw view** displays the same entries as pretty-printed JSON
+Lines instead of cards, and adds a **Copy to clipboard** button. To keep the
+page responsive, both the card view and the raw view render at most 500
+entries; a note is shown when more entries exist. **Download** and
+**Copy to clipboard** are not affected by this limit and always cover every
+entry currently displayed (i.e. respecting the filter, if any).
+
+Each line is a single JSON object. For example, a click on a link followed
+by the resulting page navigation appear as:
+
+```json
+{
+  "timestamp": "2026-07-22T20:19:02.736Z",
+  "event": "navigation",
+  "label": "/preview/digitaltwins",
+  "element": "page",
+  "page": "/preview/digitaltwins",
+  "context": {},
+  "sessionId": "eaba3642-324e-4f3b-bd21-4204ddd10ebe",
+  "userHash": "dee55bf8057abd8211bf80d6513577ff260e739d627c20762d9d617a393a89db"
+}
+
+{
+  "timestamp": "2026-07-22T20:19:01.245Z",
+  "event": "click",
+  "label": "Digital Twins page preview",
+  "element": "link",
+  "page": "/workbench",
+  "context": {
+    "link": {
+      "url": "/preview/digitaltwins"
+    }
+  },
+  "sessionId": "eaba3642-324e-4f3b-bd21-4204ddd10ebe",
+  "userHash": "dee55bf8057abd8211bf80d6513577ff260e739d627c20762d9d617a393a89db"
+}
+```
+
+### Log Event Fields
+
+| Field             | Description                                                                          |
+| :----------------- | :------------------------------------------------------------------------------------- |
+| `timestamp`        | UTC time the event was recorded, in ISO 8601 format.                                 |
+| `event`            | The event type: `click`, `change`, `navigation`, `notification`, or `dismiss`.       |
+| `label`            | A human-readable label for the element involved.                                     |
+| `element`          | The type of UI element involved, e.g. `link`, `button`, `tab`, `page`.               |
+| `page`             | The URL path of the page on which the event occurred.                                |
+| `page_transition`  | Present on some `navigation` events; records the source and target page.             |
+| `context`          | Additional metadata specific to the event, e.g. a link's target URL.                 |
+| `sessionId`        | A random identifier generated for the current browser session.                       |
+| `userHash`         | A SHA-256 hash of the username, used to link events without recording it in plain text. |
+
+## Live Updates
+
+Turning on **Live update** subscribes the page to new log events as they are
+recorded elsewhere in the browser (including other open tabs), and reloads
+the list automatically. It is turned off by default because continuously
+reloading a large log store is unnecessary while just reviewing past
+entries.
+
+## Clearing Logs
+
+The :material-delete-outline: icon opens a confirmation dialog before
+permanently deleting all stored log entries. This action cannot be undone,
+and only clears entries stored locally in the browser; it has no effect on
+any copies already streamed to a remote logging server.
+
+## Privacy and Storage
+
+- Log entries are stored locally in the browser (IndexedDB) and never leave
+  the device, unless the DTaaS installation is configured with a remote
+  logging server, in which case entries are also streamed to that server.
+- The local log store is capped in size; the oldest entries are pruned
+  automatically once the cap is reached.
+- The `userHash` field is a hash of the username, not the username itself.
+  This pseudonymizes the user while still allowing their events to be
+  linked together.
+- The `sessionId` field is a random value generated per browser session and
+  is not linked to user identity.
+
+## Summary
+
+This page has described the client-side logging feature of the DTaaS
+website: enabling it from Settings, viewing and filtering recorded events
+on the Workflow Logs page, switching between card and raw JSON Lines views,
+downloading and clearing logs, and the privacy properties of the stored
+data.

--- a/docs/user/website/logs.md
+++ b/docs/user/website/logs.md
@@ -73,8 +73,8 @@ entries; a note is shown when more entries exist. **Download** and
 **Copy to clipboard** are not affected by this limit and always cover every
 entry currently displayed (i.e. respecting the filter, if any).
 
-Each line is a single JSON object. For example, a click on a link followed
-by the resulting page navigation appears as:
+Each line is a single JSON object. Entries are shown newest-first,
+so a click on a link followed by the resulting page navigation appears as:
 
 ```json
 {

--- a/docs/user/website/settings.md
+++ b/docs/user/website/settings.md
@@ -98,6 +98,13 @@ the second digital twin is to be selected.
 
 **Default**: `second digital twin in alphabetical order`
 
+## Logging Settings
+
+### Enable Logging
+
+The setting to permit logging of user activity which is only stored in
+the local browser. The logs can be downloaded by visiting `https://<server-url>/insights/log`.
+
 ## 💾 Saving and Resetting Changes
 
 When satisfied with the changes, **SAVE SETTINGS** must be pressed for them to

--- a/docs/user/website/settings.md
+++ b/docs/user/website/settings.md
@@ -1,7 +1,7 @@
 # Settings
 
 Settings are important both during initial DTaaS setup and during use when
-working with different configurations. All the most important
+working with different configurations. The most important
 settings have been consolidated on one page for both of these scenarios.
 
 ## ⚙️ Changing Settings
@@ -9,26 +9,26 @@ settings have been consolidated on one page for both of these scenarios.
 The parameters used for sending and receiving information
 to the storage and execution services (e.g., GitLab) may need adjustment
 to match the infrastructure.
-Navigation to **Account** using the top-right purple 🅰️ icon
-followed by selection of the **Settings** tab displays the following
-adjustable parameters:
+Navigating to **Account** using the top-right purple 🅰️ icon, then
+selecting the **Settings** tab, displays the following adjustable
+parameters:
 
 ![Settings Overview](images/settings-overview.png)
 
-There are two categories of settings - **Application Settings**,
-and **Measurement Settings**. Application settings are used for DevOps features
+There are two categories of settings: **Application Settings** and
+**Measurement Settings**. Application settings are used for DevOps features,
 while measurement settings are used for benchmarking the DevOps features.
 
-Following is a description of what each parameter does.
+The following is a description of what each parameter does.
 
 ### Application Settings
 
 #### Group Name
 
 The Group Name denotes the highest level of organizational abstraction
-concerned with on the storage service, namely Groups. A
+on the storage service, namely Groups. A
 GitLab group is required to use the DTaaS. Within the group, projects
-reside, which must match the usernames of system users. More information about
+reside that must match the usernames of system users. More information about
 the [file organisation](../digital-twins/devops/file-structure.md) is available.
 This parameter must be set to the case-insensitive name of the group.
 
@@ -39,7 +39,7 @@ This parameter must be set to the case-insensitive name of the group.
 One project within the group serves as the Digital Twins *Library*.
 Through the DTaaS, the files inside the Library are accessible to all users and
 can be copied to individual user projects as needed. This parameter specifies
-the project name of the Library, and must match that name.
+the project name of the Library and must match that name.
 
 **Default**: common
 
@@ -79,7 +79,7 @@ The number of times a test is run during benchmark runs.
 #### Measurement Secondary Runner Tag
 
 Some benchmark runs require two GitLab runners.
-The *Runner Tag* in **Application Settings** points to first runner,
+The *Runner Tag* in **Application Settings** points to the first runner,
 while *Measurement Secondary Runner Tag* points to the second runner.
 
 **Default**: windows
@@ -98,33 +98,35 @@ the second digital twin is to be selected.
 
 **Default**: `second digital twin in alphabetical order`
 
-## Logging Settings
+## 📋 Logging Settings
 
-### Enable Logging
+### 🔓 Enable Logging
 
-The setting to permit logging of user activity which is only stored in
-the local browser. The logs can be downloaded by visiting `https://<server-url>/insights/log`.
+Logging controls whether DTaaS records workflow events in your browser
+(stored locally in IndexedDB). If the deployment is configured with
+a remote logger, events may also be streamed to that server. View and download
+logs at `/insights/log`.
 
 ## 💾 Saving and Resetting Changes
 
-When satisfied with the changes, **SAVE SETTINGS** must be pressed for them to
+Once satisfied with the changes, press **SAVE SETTINGS** for them to
 persist after leaving the Settings page.
 If a mistake was made, the settings can be reset
 to their default values by pressing the **RESET TO DEFAULTS** button. The reset
 values are saved automatically, so additional saving is not required. The
-Saving and Resetting buttons on the page:
+Saving and Resetting buttons on the page are shown below:
 
 ![Saving and Resetting Settings buttons](images/saving-settings.png)
 
 The default values can be found and modified in the code if needed.
 
-Return to the DevOps pages (i.e., Digital Twin Preview) is now possible. **Refreshing
-ensures fresh data from the remote repository is fetched**, and the
-Digital Twins should be visible, ready to be executed, edited, and shared.
+It is now possible to return to the DevOps pages (i.e., Digital Twin Preview).
+**Refreshing ensures fresh data from the remote repository is fetched**, and
+the Digital Twins should be visible, ready to be executed, edited, and shared.
 
 ## 💭 Summary
 
 This document has described how to edit the settings for initializing the DTaaS
-to a project and for continuous use (i.e., modifying Runner Tag and Branch).
+for a project and for continuous use (i.e., modifying Runner Tag and Branch).
 The need to save changes and how to return to default
 values if a mistake is made have been discussed.

--- a/docs/user/website/settings.md
+++ b/docs/user/website/settings.md
@@ -104,8 +104,8 @@ the second digital twin is to be selected.
 
 Logging controls whether DTaaS records workflow events in your browser
 (stored locally in IndexedDB). If the deployment is configured with
-a remote logger, events may also be streamed to that server. View and download
-logs at `/insights/log`.
+a remote logger,  a remote logger, events may also be streamed to that server. See
+ [Logs](logs.md) for viewing and downloading logs at `/insights/log`.
 
 ## 💾 Saving and Resetting Changes
 

--- a/mkdocs-github.yml
+++ b/mkdocs-github.yml
@@ -24,6 +24,7 @@ nav:
           - Overview: user/website/dtaas.md
           - Workspace: user/website/workspace.md
           - Settings: user/website/settings.md
+          - Logs: user/website/logs.md
       - Reusable Assets:
           - Concept: user/servers/lib/assets.md
           - Microservice: user/servers/lib/LIB-MS.md

--- a/mkdocs-github.yml
+++ b/mkdocs-github.yml
@@ -137,7 +137,7 @@ nav:
           - Architecture: developer/system/architecture.md
           - Current Status: developer/system/current-status.md
           - Research Overview: developer/system/research-overview.md
-          - Review:
+          - Code Review:
               - Overview: developer/system/review/index.md
               - Architecture Review:
                   developer/system/review/architecture-review.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
           - Overview: user/website/dtaas.md
           - Workspace: user/website/workspace.md
           - Settings: user/website/settings.md
+          - Logs: user/website/logs.md
       - Reusable Assets:
           - Concept: user/servers/lib/assets.md
           - Microservice: user/servers/lib/LIB-MS.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,7 +137,7 @@ nav:
           - Architecture: developer/system/architecture.md
           - Current Status: developer/system/current-status.md
           - Research Overview: developer/system/research-overview.md
-          - Review:
+          - Code Review:
               - Overview: developer/system/review/index.md
               - Architecture Review:
                   developer/system/review/architecture-review.md


### PR DESCRIPTION
# Pull Request Template

## Title

Fix client package version and document the Logger feature

## Type of Change

- [ ] New feature
- [x] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [ ] Security patch
- [ ] UI/UX improvement

## Description

`client/package.json` was left at `1.3.0` when the client-side Logger
feature (#1703, "Adds Logger to React Client") was merged, so the
package version no longer reflected the shipped feature set. This PR
bumps it to `1.4.0`.

Alongside the version fix, this PR adds and updates the user- and
admin-facing documentation that was missing for recently merged
features:

- **New page** `docs/user/website/logs.md` documents the client-side
  Workflow Logs page (`/insights/log`): enabling logging from account
  settings, the card and raw JSON Lines views, filtering, live
  updates, clearing/downloading logs, and the local/remote privacy
  model. Registered in the nav of both `mkdocs.yml` and
  `mkdocs-github.yml`, alongside two new screenshots
  (`logs-all.png`, `logs-filter.png`).
- `docs/user/website/settings.md` gains a short "Logging Settings"
  section describing the "Enable Logging" checkbox, plus an updated
  `settings-overview.png` screenshot.
- `docs/admin/cli.md` and `docs/admin/cli-config.md` are brought up to
  date with the CLI's current command surface, based on
  `cli/README.md` and `cli/DEVELOPER.md`. Previously undocumented
  commands are now covered: `admin config reconcile`, the lifecycle
  operations (`admin status`/`stop`/`start`/`pause`/`resume`),
  per-user `admin user pause`/`stop`/`resume`, and fuller detail for
  `admin install`, `admin uninstall`, `admin update --certs`/`--config`,
  and `generate-project`. The user-registry file model
  (`dtaas.users.registry.json`, `.dtaas.state.json`) is also now
  described, including the `desired_status` field and how
  `admin config reconcile` treats it.

## Testing

- `mkdocs build -f mkdocs-github.yml --strict` completes with no
  broken links, anchors, or missing images across the new/updated
  pages.
- Verified the new/updated internal cross-links between `cli.md` and
  `cli-config.md` resolve (`#validation-rules`,
  `#configuration-substitution`, `#user-files`, `#deployment-types`,
  `#lifecycle-operations`).
- No client code changes beyond the `package.json` version bump, so no
  client test suite changes are needed.

## Impact

- Documentation-only changes plus a metadata (version) bump in
  `client/package.json` — no runtime or behavioural changes to the
  application.
- Brings published docs in line with CLI and client capabilities that
  were already shipped but undocumented.

## Additional Information

This PR intentionally does not touch `cli/DTaaS-CLI-Design.md`, since
that document describes a proposed future command-grammar redesign
that has not been implemented.

## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have added tests for all the new code and any changes made to
      existing code.
- [x] I have made corresponding changes to the documentation.
